### PR TITLE
Fix extrafile compilation by source language in mass harness

### DIFF
--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -12,6 +12,9 @@ evaluate compatibility in liric parse/JIT/runtime lanes.
 - Do not duplicate test lists or copy LFortran config files into this repository.
 - Feed liric raw `--show-llvm` output from LFortran without preprocessing.
 - Exclude expected-failure tests by default.
+- Compile extrafiles by language:
+  - Fortran extrafiles with LFortran (including `--cpp`/fixed-form handling)
+  - C/C++ extrafiles with host C/C++ compiler (`CC`/`CXX`)
 - Treat unsupported features/ABI as tracked non-fatal buckets.
 - Fail only on mismatches and new supported regressions.
 

--- a/tools/lfortran_mass/test_run_mass_helpers.py
+++ b/tools/lfortran_mass/test_run_mass_helpers.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Unit tests for mass harness extrafile compile helpers."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from tools.lfortran_mass import run_mass
+
+
+class RunMassHelperTests(unittest.TestCase):
+    def test_extract_c_compile_options_include_define(self) -> None:
+        opts = [
+            "--cpp",
+            "--realloc-lhs-arrays",
+            "-I",
+            "/tmp/inc",
+            "-DMODE=1",
+            "-U",
+            "X",
+            "-O3",
+            "-isystem",
+            "/tmp/sys",
+        ]
+        got = run_mass.extract_c_compile_options(opts)
+        self.assertEqual(
+            got,
+            ["-I", "/tmp/inc", "-DMODE=1", "-U", "X", "-isystem", "/tmp/sys"],
+        )
+
+    def test_needs_fortran_cpp_from_suffix(self) -> None:
+        path = Path("/tmp/example.F90")
+        self.assertTrue(run_mass.needs_fortran_cpp(path, []))
+
+    def test_needs_fortran_cpp_from_option(self) -> None:
+        path = Path("/tmp/example.f90")
+        self.assertTrue(run_mass.needs_fortran_cpp(path, ["--cpp"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #6

## Summary
- compile extrafiles by language in mass harness:
  - Fortran extrafiles with LFortran (`--fixed-form` and `--cpp` handling)
  - C extrafiles with `CC`/`cc`
  - C++ extrafiles with `CXX`/`c++`
- ignore header-only extrafiles during compile stage
- make subprocess execution robust when compiler executable is missing
- add helper unit tests for compile option filtering and preprocess detection
- document extrafile language strategy in mass-testing docs

## Validation
- `python3 -m py_compile tools/lfortran_mass/*.py`
- `python3 -m unittest tools.lfortran_mass.test_run_mass_helpers`
- `ctest --test-dir build --output-on-failure`
- `python3 -m tools.lfortran_mass.run_mass --workers 8 --force`

## MassTest delta
MassTest: selected 2415, emit 2414 (+14), parse 1186 (+9), jit 1 (+0), diff_match 0 (+0)
