### PR TITLE
Add deterministic selection and skip accounting to mass harness

### DIFF
--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -58,6 +58,7 @@ Useful options:
 All artifacts are written under `/tmp/liric_lfortran_mass/`:
 - `manifest_tests_toml.jsonl`: canonical list from `tests.toml`
 - `manifest_tests_toml.jsonl` includes both selected corpora with a `corpus` field
+- `selection_decisions.jsonl`: per-case selection decision and skip reason
 - `results.jsonl`: per-case outcomes
 - `summary.md`: aggregate metrics
 - `failures.csv`: non-pass rows for triage
@@ -65,11 +66,13 @@ All artifacts are written under `/tmp/liric_lfortran_mass/`:
 
 ## Statistics in Summary
 `summary.md` reports:
-- Total tests in `tests.toml`
+- Total selected tests
 - LLVM emission attempted/succeeded
 - Liric parse attempted/passed
 - Liric JIT attempted/passed
 - Differential attempted/completed/exact-match counts
+- Selected/skipped counts per corpus
+- Skip reason histogram and skip reasons by corpus
 - Supported processed/passed counts
 - Unsupported histogram
 - Mismatch count

--- a/tools/lfortran_mass/test_report_selection.py
+++ b/tools/lfortran_mass/test_report_selection.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Unit tests for selection/skip accounting in report summary."""
+
+from __future__ import annotations
+
+import unittest
+
+from tools.lfortran_mass import report
+
+
+class ReportSelectionSummaryTests(unittest.TestCase):
+    def test_selection_skip_histograms(self) -> None:
+        processed = [
+            {"case_id": "a", "classification": "pass", "corpus": "tests_toml"},
+            {"case_id": "b", "classification": "unsupported_abi", "corpus": "integration_cmake"},
+        ]
+        selection_rows = [
+            {"corpus": "tests_toml", "decision": "selected", "reason": "included"},
+            {"corpus": "integration_cmake", "decision": "selected", "reason": "included"},
+            {"corpus": "tests_toml", "decision": "skipped", "reason": "not_llvm_intended"},
+            {"corpus": "tests_toml", "decision": "skipped", "reason": "expected_failure"},
+            {"corpus": "integration_cmake", "decision": "skipped", "reason": "duplicate_case"},
+        ]
+
+        summary = report.summarize(
+            manifest_total=2,
+            processed=processed,
+            baseline=[],
+            selection_rows=selection_rows,
+        )
+
+        self.assertEqual(summary["selected_by_corpus"]["tests_toml"], 1)
+        self.assertEqual(summary["selected_by_corpus"]["integration_cmake"], 1)
+        self.assertEqual(summary["skipped_by_corpus"]["tests_toml"], 2)
+        self.assertEqual(summary["skipped_by_corpus"]["integration_cmake"], 1)
+        self.assertEqual(summary["skipped_reason_counts"]["not_llvm_intended"], 1)
+        self.assertEqual(summary["skipped_reason_counts"]["expected_failure"], 1)
+        self.assertEqual(summary["skipped_reason_counts"]["duplicate_case"], 1)
+        self.assertEqual(summary["skipped_by_corpus_reason"]["tests_toml:expected_failure"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #7

## Summary
- add deterministic per-case selection decision records (`selection_decisions.jsonl`)
- record skip reasons for all excluded cases (`not_llvm_intended`, `expected_failure`, `duplicate_case`, `limit`)
- include selected/skipped counts by corpus in summary
- include skip reason histogram and skip reasons by corpus in summary
- keep selection ordering deterministic and auditable across reruns
- document new selection artifact and summary sections
- add unit tests for selection/skip summary accounting

## Validation
- `python3 -m py_compile tools/lfortran_mass/*.py`
- `python3 -m unittest tools.lfortran_mass.test_run_mass_helpers tools.lfortran_mass.test_report_selection`
- `ctest --test-dir build --output-on-failure`
- `python3 -m tools.lfortran_mass.run_mass --workers 8 --force`

## MassTest delta
MassTest: selected 2415, emit 2414 (+0), parse 1186 (+0), jit 1 (+0), diff_match 0 (+0)
