### PR TITLE
Roadmap 4/14: parser support for modern operand forms

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -43,6 +43,8 @@ int test_parser_function_decl(void);
 int test_parser_add(void);
 int test_parser_typed_call_and_dot_label(void);
 int test_parser_named_type_operand(void);
+int test_parser_decl_with_modern_param_attrs(void);
+int test_parser_store_with_const_gep_operand(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
 int test_host_target_name(void);
@@ -90,6 +92,8 @@ int main(void) {
     RUN_TEST(test_parser_add);
     RUN_TEST(test_parser_typed_call_and_dot_label);
     RUN_TEST(test_parser_named_type_operand);
+    RUN_TEST(test_parser_decl_with_modern_param_attrs);
+    RUN_TEST(test_parser_store_with_const_gep_operand);
 
     fprintf(stderr, "\nCodegen tests:\n");
     RUN_TEST(test_codegen_ret_42);


### PR DESCRIPTION
Closes #8

## Summary
- parse modern attribute forms like captures(none) and similar bare-identifier attrs
- allow constant getelementptr expressions in operand positions used by LFortran IR
- add parser regression tests for attr-heavy declare signatures and const-gep store operands

## Validation
- cmake --build build -j32
- ctest --test-dir build --output-on-failure
- python3 -m tools.lfortran_mass.run_mass --workers 8 --force

MassTest: selected 2415, emit 2414 (+0), parse 1354 (+168), jit 1 (+0), diff_match 0 (+0)
