### PR TITLE
Roadmap 6/14: lock canonical phi/select parser support

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -48,6 +48,8 @@ int test_parser_store_with_const_gep_operand(void);
 int test_parser_call_arg_with_align_attr(void);
 int test_parser_store_with_struct_constant(void);
 int test_parser_urem_instruction(void);
+int test_parser_canonical_phi_pairs(void);
+int test_parser_select_with_ptr_operands(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
 int test_host_target_name(void);
@@ -100,6 +102,8 @@ int main(void) {
     RUN_TEST(test_parser_call_arg_with_align_attr);
     RUN_TEST(test_parser_store_with_struct_constant);
     RUN_TEST(test_parser_urem_instruction);
+    RUN_TEST(test_parser_canonical_phi_pairs);
+    RUN_TEST(test_parser_select_with_ptr_operands);
 
     fprintf(stderr, "\nCodegen tests:\n");
     RUN_TEST(test_codegen_ret_42);


### PR DESCRIPTION
Closes #10

## Summary
- add parser/IR regression tests for canonical phi incoming-pair forms
- add parser/IR regression tests for select over pointer global operands
- lock current phi/select acceptance against future regressions

## Validation
- cmake --build build -j32
- ctest --test-dir build --output-on-failure
- python3 -m tools.lfortran_mass.run_mass --workers 8 --force

MassTest: selected 2415, emit 2414 (+0), parse 1427 (+0), jit 1 (+0), diff_match 0 (+0)
