### PR TITLE
Roadmap 7/14: add scalar FP arithmetic lowering

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -64,6 +64,8 @@ int test_jit_branch(void);
 int test_jit_loop(void);
 int test_jit_alloca_load_store(void);
 int test_jit_forward_typed_call(void);
+int test_jit_fadd_double_bits(void);
+int test_jit_fmul_float_bits(void);
 int test_e2e_ret_42(void);
 int test_e2e_add_i32(void);
 int test_e2e_branch(void);
@@ -124,6 +126,8 @@ int main(void) {
     RUN_TEST(test_jit_loop);
     RUN_TEST(test_jit_alloca_load_store);
     RUN_TEST(test_jit_forward_typed_call);
+    RUN_TEST(test_jit_fadd_double_bits);
+    RUN_TEST(test_jit_fmul_float_bits);
 
     fprintf(stderr, "\nE2E tests:\n");
     RUN_TEST(test_e2e_ret_42);

--- a/tools/lfortran_mass/classify.py
+++ b/tools/lfortran_mass/classify.py
@@ -16,12 +16,12 @@ UNSUPPORTED_ABI = "unsupported_abi"
 INFRA_FAIL = "infra_fail"
 
 UNSUPPORTED_FEATURE_PATTERNS = [
-    r"\bfadd\b",
-    r"\bfsub\b",
-    r"\bfmul\b",
-    r"\bfdiv\b",
-    r"\bfloat\b",
-    r"\bdouble\b",
+    r"\bfcmp\b",
+    r"\bsitofp\b",
+    r"\bfptosi\b",
+    r"\bfpext\b",
+    r"\bfptrunc\b",
+    r"\bfneg\b",
     r"<\s*\d+\s*x\s*",
     r"\bx86_amx\b",
     r"\btarget-features\b",
@@ -54,7 +54,12 @@ def classify_parse_failure(stderr: str, ir_text: str) -> str:
     msg = stderr.lower()
     if detect_unsupported_feature(ir_text):
         return UNSUPPORTED_FEATURE
-    if "expected type" in msg or "unexpected token" in msg:
+    if (
+        "expected type" in msg
+        or "unexpected token" in msg
+        or "expected operand" in msg
+        or "unknown instruction" in msg
+    ):
         return UNSUPPORTED_FEATURE
     return LIRIC_PARSE_FAIL
 


### PR DESCRIPTION
Closes #11

## Summary
- add scalar floating-point arithmetic lowering for fadd/fsub/fmul/fdiv using helper-call lowering
- support float immediates in machine operand loading
- add JIT regression coverage for double fadd and float fmul paths

## Validation
- cmake --build build -j32
- ctest --test-dir build --output-on-failure
- python3 -m tools.lfortran_mass.run_mass --workers 8 --force

MassTest: selected 2415, emit 2414 (+0), parse 1427 (+0), jit 1 (+0), diff_match 0 (+0)
