### PR TITLE
Roadmap 8/14: harden phi/select backend lowering tests

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -66,6 +66,8 @@ int test_jit_alloca_load_store(void);
 int test_jit_forward_typed_call(void);
 int test_jit_fadd_double_bits(void);
 int test_jit_fmul_float_bits(void);
+int test_jit_phi_select_nested(void);
+int test_jit_phi_select_loop_carried(void);
 int test_e2e_ret_42(void);
 int test_e2e_add_i32(void);
 int test_e2e_branch(void);
@@ -128,6 +130,8 @@ int main(void) {
     RUN_TEST(test_jit_forward_typed_call);
     RUN_TEST(test_jit_fadd_double_bits);
     RUN_TEST(test_jit_fmul_float_bits);
+    RUN_TEST(test_jit_phi_select_nested);
+    RUN_TEST(test_jit_phi_select_loop_carried);
 
     fprintf(stderr, "\nE2E tests:\n");
     RUN_TEST(test_e2e_ret_42);


### PR DESCRIPTION
Closes #12

## Summary
- add JIT regression for nested phi/select merge lowering
- add JIT regression for loop-carried phi/select lowering
- lock CFG-heavy phi/select backend behavior with executable checks

## Validation
- cmake --build build -j32
- ctest --test-dir build --output-on-failure
- python3 -m tools.lfortran_mass.run_mass --workers 8 --force

MassTest: selected 2415, emit 2414 (+0), parse 1427 (+0), jit 1 (+0), diff_match 0 (+0)
