### PR TITLE
Roadmap 9/14: materialize globals and relocations in JIT

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -68,6 +68,8 @@ int test_jit_fadd_double_bits(void);
 int test_jit_fmul_float_bits(void);
 int test_jit_phi_select_nested(void);
 int test_jit_phi_select_loop_carried(void);
+int test_jit_internal_global_load_store(void);
+int test_jit_internal_global_address_relocation(void);
 int test_e2e_ret_42(void);
 int test_e2e_add_i32(void);
 int test_e2e_branch(void);
@@ -132,6 +134,8 @@ int main(void) {
     RUN_TEST(test_jit_fmul_float_bits);
     RUN_TEST(test_jit_phi_select_nested);
     RUN_TEST(test_jit_phi_select_loop_carried);
+    RUN_TEST(test_jit_internal_global_load_store);
+    RUN_TEST(test_jit_internal_global_address_relocation);
 
     fprintf(stderr, "\nE2E tests:\n");
     RUN_TEST(test_e2e_ret_42);


### PR DESCRIPTION
Closes #13

## Summary
- materialize internal module globals in JIT data memory and bind them as symbols
- resolve internal global references before machine-code generation
- add JIT regressions for internal global load/store and address relocation

## Validation
- cmake --build build -j32
- ctest --test-dir build --output-on-failure
- python3 -m tools.lfortran_mass.run_mass --workers 8 --force

MassTest: selected 2415, emit 2414 (+0), parse 1427 (+0), jit 1 (+0), diff_match 0 (+0)
