### PR TITLE
Roadmap 10/14: integrate runtime symbol provider loading

### DIFF
--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -55,6 +55,7 @@ Useful options:
 - `--skip-tests-toml`: run only integration corpus
 - `--skip-integration-cmake`: run only unit corpus
 - `--include-expected-fail`: include expected-failure/error-handling tests
+- `--load-lib <path>`: preload runtime libraries into liric JIT (repeatable)
 
 ## Outputs
 All artifacts are written under `/tmp/liric_lfortran_mass/`:

--- a/include/liric/liric.h
+++ b/include/liric/liric.h
@@ -20,6 +20,7 @@ lr_jit_t *lr_jit_create_for_target(const char *target_name);
 const char *lr_jit_host_target_name(void);
 const char *lr_jit_target_name(const lr_jit_t *j);
 void lr_jit_add_symbol(lr_jit_t *j, const char *name, void *addr);
+int lr_jit_load_library(lr_jit_t *j, const char *path);
 int lr_jit_add_module(lr_jit_t *j, lr_module_t *m);
 void *lr_jit_get_function(lr_jit_t *j, const char *name);
 void lr_jit_destroy(lr_jit_t *j);

--- a/src/jit.h
+++ b/src/jit.h
@@ -11,6 +11,11 @@ typedef struct lr_sym_entry {
     struct lr_sym_entry *next;
 } lr_sym_entry_t;
 
+typedef struct lr_lib_entry {
+    void *handle;
+    struct lr_lib_entry *next;
+} lr_lib_entry_t;
+
 typedef struct lr_jit {
     const lr_target_t *target;
     bool map_jit_enabled;
@@ -21,6 +26,7 @@ typedef struct lr_jit {
     size_t data_size;
     size_t data_cap;
     lr_sym_entry_t *symbols;
+    lr_lib_entry_t *libs;
     lr_arena_t *arena;
 } lr_jit_t;
 
@@ -29,6 +35,7 @@ lr_jit_t *lr_jit_create_for_target(const char *target_name);
 const char *lr_jit_host_target_name(void);
 const char *lr_jit_target_name(const lr_jit_t *j);
 void lr_jit_add_symbol(lr_jit_t *j, const char *name, void *addr);
+int lr_jit_load_library(lr_jit_t *j, const char *path);
 int lr_jit_add_module(lr_jit_t *j, lr_module_t *m);
 void *lr_jit_get_function(lr_jit_t *j, const char *name);
 void lr_jit_destroy(lr_jit_t *j);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -56,6 +56,7 @@ int test_host_target_name(void);
 int test_create_host_target(void);
 int test_create_unknown_target_fails(void);
 int test_non_host_target_fails(void);
+int test_load_missing_runtime_library_fails(void);
 int test_jit_ret_42(void);
 int test_jit_add_args(void);
 int test_jit_arithmetic(void);
@@ -120,6 +121,7 @@ int main(void) {
     RUN_TEST(test_create_host_target);
     RUN_TEST(test_create_unknown_target_fails);
     RUN_TEST(test_non_host_target_fails);
+    RUN_TEST(test_load_missing_runtime_library_fails);
 
     fprintf(stderr, "\nJIT tests:\n");
     RUN_TEST(test_jit_ret_42);

--- a/tests/test_targets.c
+++ b/tests/test_targets.c
@@ -46,3 +46,12 @@ int test_non_host_target_fails(void) {
     TEST_ASSERT(jit == NULL, "non-host target rejected");
     return 0;
 }
+
+int test_load_missing_runtime_library_fails(void) {
+    lr_jit_t *jit = lr_jit_create();
+    TEST_ASSERT(jit != NULL, "jit create");
+    int rc = lr_jit_load_library(jit, "/definitely/not/a/real/library/path.so");
+    TEST_ASSERT(rc != 0, "missing library rejected");
+    lr_jit_destroy(jit);
+    return 0;
+}

--- a/tools/liric_main.c
+++ b/tools/liric_main.c
@@ -45,11 +45,19 @@ int main(int argc, char **argv) {
     bool dump_ir = false;
     const char *input_file = NULL;
     const char *func_name = "main";
+    const char *load_libs[64];
+    int num_load_libs = 0;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--jit") == 0) jit_mode = true;
         else if (strcmp(argv[i], "--dump-ir") == 0) dump_ir = true;
         else if (strcmp(argv[i], "--func") == 0 && i + 1 < argc) func_name = argv[++i];
+        else if (strcmp(argv[i], "--load-lib") == 0 && i + 1 < argc) {
+            if (num_load_libs < 64)
+                load_libs[num_load_libs++] = argv[++i];
+            else
+                return 1;
+        }
         else if (strcmp(argv[i], "-") == 0) input_file = NULL;
         else if (argv[i][0] != '-') input_file = argv[i];
         else {
@@ -98,6 +106,16 @@ int main(int argc, char **argv) {
             lr_module_free(m);
             free(src);
             return 1;
+        }
+
+        for (int i = 0; i < num_load_libs; i++) {
+            if (lr_jit_load_library(jit, load_libs[i]) != 0) {
+                fprintf(stderr, "failed to load library: %s\n", load_libs[i]);
+                lr_jit_destroy(jit);
+                lr_module_free(m);
+                free(src);
+                return 1;
+            }
         }
 
         int rc = lr_jit_add_module(jit, m);


### PR DESCRIPTION
Closes #14

## Summary
- add runtime library provider loading to JIT via `lr_jit_load_library`
- chain symbol lookup across explicit symbols, loaded libraries, then RTLD default
- add `--load-lib` support to `liric_cli`, `liric_probe_runner`, and mass harness

## Validation
- cmake --build build -j32
- ctest --test-dir build --output-on-failure
- python3 -m tools.lfortran_mass.run_mass --workers 8 --force

MassTest: selected 2415, emit 2414 (+0), parse 1427 (+0), jit 1 (+0), diff_match 0 (+0)
