### PR TITLE
Roadmap 11/14: validate external and varargs call ABI paths

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -71,6 +71,8 @@ int test_jit_phi_select_nested(void);
 int test_jit_phi_select_loop_carried(void);
 int test_jit_internal_global_load_store(void);
 int test_jit_internal_global_address_relocation(void);
+int test_jit_external_call_abs(void);
+int test_jit_varargs_printf_call(void);
 int test_e2e_ret_42(void);
 int test_e2e_add_i32(void);
 int test_e2e_branch(void);
@@ -138,6 +140,8 @@ int main(void) {
     RUN_TEST(test_jit_phi_select_loop_carried);
     RUN_TEST(test_jit_internal_global_load_store);
     RUN_TEST(test_jit_internal_global_address_relocation);
+    RUN_TEST(test_jit_external_call_abs);
+    RUN_TEST(test_jit_varargs_printf_call);
 
     fprintf(stderr, "\nE2E tests:\n");
     RUN_TEST(test_e2e_ret_42);


### PR DESCRIPTION
Closes #15

## Summary
- add executable JIT regression for external call ABI (`abs`)
- add executable JIT regression for varargs-style runtime call ABI (`printf`)
- validate symbol binding path for external/runtime call sites

## Validation
- cmake --build build -j32
- ctest --test-dir build --output-on-failure
- python3 -m tools.lfortran_mass.run_mass --workers 8 --force

MassTest: selected 2415, emit 2414 (+0), parse 1427 (+0), jit 1 (+0), diff_match 0 (+0)
