### PR TITLE
Fix select lowering regression that breaks CI

### DIFF
--- a/src/target_x86_64.c
+++ b/src/target_x86_64.c
@@ -667,13 +667,7 @@ static int x86_64_encode_func(lr_mfunc_t *mf, uint8_t *buf, size_t buflen, size_
             case LR_X86_MOV_IMM: {
                 uint8_t dst = mi->dst.reg;
                 int64_t imm = mi->src.imm;
-                if (imm == 0) {
-                    /* xor eax, eax is shorter */
-                    if (dst >= 8)
-                        emit_byte(buf, &pos, buflen, rex(false, dst >= 8, false, dst >= 8));
-                    emit_byte(buf, &pos, buflen, 0x31);
-                    emit_byte(buf, &pos, buflen, modrm(3, dst, dst));
-                } else if (imm >= INT32_MIN && imm <= INT32_MAX) {
+                if (imm >= INT32_MIN && imm <= INT32_MAX) {
                     /* mov reg, imm32 (sign-extended) */
                     emit_byte(buf, &pos, buflen, rex(true, false, false, dst >= 8));
                     emit_byte(buf, &pos, buflen, 0xC7);


### PR DESCRIPTION
## Summary
- fix x86_64 `LR_X86_MOV_IMM` encoding to preserve flags when materializing zero
- remove `xor reg, reg` fast path because it clobbers flags used by `test` + `cmov` select lowering

## Root cause
`select` lowering relies on condition flags set by `test`. Loading the true/false values emitted `mov imm 0` as `xor reg, reg`, which overwrote flags and forced `cmovne` to behave incorrectly.

## Validation
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure` (55/55 passing locally)

This addresses the current CI failure in `test_jit_phi_select_loop_carried` (`clamp_sum(4)` expected `0`, got `-10`).
