### PR TITLE
Mass harness: auto-load LFortran runtime library by default

### DIFF
--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -31,6 +31,9 @@ Defaults are:
 - LFortran binary: auto-detected:
   - `../lfortran/build/src/bin/lfortran` (preferred)
   - `../lfortran/build_clean_bison/src/bin/lfortran` (fallback)
+- Runtime library preload: auto-detected when available:
+  - `<detected-lfortran-bin>/../runtime/liblfortran_runtime.so`
+  - env override: `$LFORTRAN_RUNTIME_LIBRARY_DIR/liblfortran_runtime.so`
 
 ## Build Prerequisites
 ```bash
@@ -58,6 +61,7 @@ Useful options:
 - `--skip-integration-cmake`: run only unit corpus
 - `--include-expected-fail`: include expected-failure/error-handling tests
 - `--load-lib <path>`: preload runtime libraries into liric JIT (repeatable)
+- `--no-auto-runtime-lib`: disable automatic preload of `liblfortran_runtime`
 
 ## Outputs
 All artifacts are written under `/tmp/liric_lfortran_mass/`:


### PR DESCRIPTION
## Summary
- auto-detect and auto-load `liblfortran_runtime` in the LFortran mass harness
- keep loading generic (`--load-lib` remains repeatable and backend-agnostic)
- add `--no-auto-runtime-lib` opt-out flag
- add resolver unit tests (env override + bin-adjacent runtime path)
- document new default behavior in mass testing docs

## Why
LFortran's normal LLVM flow resolves runtime symbols at link time (`-llfortran_runtime`).
The mass harness was JITing raw LLVM without that runtime by default, which caused pervasive unresolved `_lfortran_*` / `_lpython_*` symbols.

## Validation
- `python3 -m unittest tools.lfortran_mass.test_run_mass_helpers`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`
- `python3 -m tools.lfortran_mass.run_mass --workers $(nproc) --force`

Harness output now reports detected auto runtime library, e.g.:
`auto_runtime_lib: /home/ert/code/lfortran-dev/lfortran/build/src/runtime/liblfortran_runtime.so...`

## Current impact
This removes the LFortran runtime-library wiring gap from default harness behavior.
Remaining JIT blockers are now mostly LLVM intrinsics (`llvm.fabs.*`, `llvm.memcpy.*`, `llvm.memset.*`) and ABI/runtime execution gaps.
