### PR TITLE
Harness: make entrypoint JIT execution ABI-safe

### DIFF
--- a/tools/lfortran_mass/test_run_mass_helpers.py
+++ b/tools/lfortran_mass/test_run_mass_helpers.py
@@ -94,6 +94,34 @@ class RunMassHelperTests(unittest.TestCase):
                 got = run_mass.resolve_default_runtime_lib(root, lfortran_bin)
             self.assertEqual(got, runtime_lib.resolve())
 
+    def test_choose_entrypoint_non_run_prefers_callable_signature(self) -> None:
+        ir_text = (
+            "define i32 @main(i32 %argc, i8** %argv) {\n"
+            "entry:\n"
+            "  ret i32 0\n"
+            "}\n"
+            "define i32 @helper() {\n"
+            "entry:\n"
+            "  ret i32 7\n"
+            "}\n"
+        )
+        got = run_mass.choose_entrypoint(ir_text, run_requested=False)
+        self.assertEqual(got, ("helper", "i32"))
+
+    def test_choose_entrypoint_run_requested_keeps_main_preference(self) -> None:
+        ir_text = (
+            "define i32 @main(i32 %argc, i8** %argv) {\n"
+            "entry:\n"
+            "  ret i32 0\n"
+            "}\n"
+            "define i32 @helper() {\n"
+            "entry:\n"
+            "  ret i32 7\n"
+            "}\n"
+        )
+        got = run_mass.choose_entrypoint(ir_text, run_requested=True)
+        self.assertEqual(got, ("main", "unsupported"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Implements issue #36 by making mass harness entrypoint selection/execution ABI-safe.

### Changes
- `choose_entrypoint()` now accepts `run_requested` and selects differently:
  - runnable cases: keep preferred entrypoint order (`main`, `_lfortran_main_program`, `_QQmain`)
  - non-runnable cases: prefer callable no-arg signatures (`i32/i64/void`) to avoid invalid calls
- Add early guard before JIT execution:
  - if selected entry signature is unsupported, classify as `unsupported_abi` at `entrypoint` stage and skip `--jit` execution
- Add unit tests covering both selection modes.

## Why
`liric_cli --jit --func` invokes symbols as `int (*)(void)`. Calling `main(i32, i8**)` as no-arg was causing crashy/opaque failures.

## Validation
- `python3 -m unittest tools.lfortran_mass.test_run_mass_helpers`
- `ctest --test-dir build --output-on-failure`
- `python3 -m tools.lfortran_mass.run_mass --workers $(nproc) --force`

## Impact
- JIT attempts now occur only for ABI-callable entrypoints.
- Latest run changed from broad crashy JIT attempts to explicit reasons:
  - `unsupported entry signature for JIT execution: unsupported` (1229 cases)
- `jit_attempted` became deterministic (`1`) with `jit_ok=1`.
