### PR TITLE
Harness: tighten JIT failure classification precision

### DIFF
--- a/tools/lfortran_mass/test_classify.py
+++ b/tools/lfortran_mass/test_classify.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Unit tests for mass harness classification helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from tools.lfortran_mass import classify
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_jit_unresolved_symbol_is_unsupported_abi(self) -> None:
+        got = classify.classify_jit_failure("unresolved symbol: llvm.powi.f32\n", "")
+        self.assertEqual(got, classify.UNSUPPORTED_ABI)
+
+    def test_jit_function_not_found_is_unsupported_abi(self) -> None:
+        got = classify.classify_jit_failure("function 'main' not found\n", "")
+        self.assertEqual(got, classify.UNSUPPORTED_ABI)
+
+    def test_jit_unsupported_signature_is_unsupported_abi(self) -> None:
+        got = classify.classify_jit_failure("unsupported signature: i32(i32)\n", "")
+        self.assertEqual(got, classify.UNSUPPORTED_ABI)
+
+    def test_jit_generic_failure_is_liric_jit_fail(self) -> None:
+        ir = "declare void @_lfortran_runtime_error(ptr)\n"
+        got = classify.classify_jit_failure("segmentation fault\n", ir)
+        self.assertEqual(got, classify.LIRIC_JIT_FAIL)
+
+    def test_jit_explicit_unsupported_message_is_unsupported_feature(self) -> None:
+        got = classify.classify_jit_failure("unsupported opcode in backend\n", "")
+        self.assertEqual(got, classify.UNSUPPORTED_FEATURE)
+
+    def test_jit_ir_feature_pattern_is_unsupported_feature(self) -> None:
+        ir = "%1 = fcmp oeq float %a, %b\n"
+        got = classify.classify_jit_failure("jit failed\n", ir)
+        self.assertEqual(got, classify.UNSUPPORTED_FEATURE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- tighten `classify_jit_failure()` so `unsupported_abi` is only emitted for explicit JIT stderr ABI/linkage signatures
- remove broad IR-name heuristics that previously over-attributed generic JIT failures to ABI
- keep `unsupported_feature` classification for explicit unsupported feature patterns (stderr and IR op-patterns)
- add unit tests for ABI-vs-feature-vs-generic JIT failure outcomes

## Validation
- `python3 -m unittest tools.lfortran_mass.test_classify tools.lfortran_mass.test_run_mass_helpers tools.lfortran_mass.test_report_selection`
- `ctest --test-dir build --output-on-failure`
- `python3 -m tools.lfortran_mass.run_mass --workers "$(nproc)" --force`

## Mass bucket delta
- before classification counts: `unsupported_abi=1230`, `unsupported_feature=1156`, `liric_parse_fail=27`, `lfortran_emit_fail=1`, `pass=1`
- after classification counts: `unsupported_abi=1230`, `unsupported_feature=1156`, `liric_parse_fail=27`, `lfortran_emit_fail=1`, `pass=1`
- current corpus had no JIT-stage failures (`jit:pass=1`, `jit failures=0`), so numeric bucket deltas are unchanged in this run; precision improvement is guarded by the new unit tests and explicit rule narrowing.

Closes #34
