### PR TITLE
Implement GEP, named types, packed structs, and global initializers

### DIFF
--- a/src/ll_lexer.c
+++ b/src/ll_lexer.c
@@ -203,6 +203,8 @@ lr_token_t lr_lexer_next(lr_lexer_t *lex) {
     case '=': tok = make_token(lex, LR_TOK_EQUALS, start, 1); break;
     case '*': tok = make_token(lex, LR_TOK_STAR, start, 1); break;
     case ':': tok = make_token(lex, LR_TOK_COLON, start, 1); break;
+    case '<': tok = make_token(lex, LR_TOK_LANGLE, start, 1); break;
+    case '>': tok = make_token(lex, LR_TOK_RANGLE, start, 1); break;
     case '.':
         if (lex->pos + 1 < lex->src_len &&
             lex->src[lex->pos] == '.' && lex->src[lex->pos + 1] == '.') {
@@ -417,6 +419,8 @@ const char *lr_tok_name(lr_tok_t kind) {
     case LR_TOK_EQUALS:    return "=";
     case LR_TOK_STAR:      return "*";
     case LR_TOK_COLON:     return ":";
+    case LR_TOK_LANGLE:    return "<";
+    case LR_TOK_RANGLE:    return ">";
     case LR_TOK_DOTDOTDOT: return "...";
     default: return "?";
     }

--- a/src/ll_lexer.h
+++ b/src/ll_lexer.h
@@ -137,6 +137,8 @@ typedef enum lr_tok {
     LR_TOK_STAR,
     LR_TOK_DOTDOTDOT,
     LR_TOK_COLON,
+    LR_TOK_LANGLE,
+    LR_TOK_RANGLE,
     LR_TOK_EXCLAIM,
     LR_TOK_X,           /* 'x' in array types like [4 x i32] */
     LR_TOK_HASH,        /* # for attribute groups */

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -76,6 +76,9 @@ int test_jit_external_call_abs(void);
 int test_jit_varargs_printf_call(void);
 int test_jit_llvm_intrinsic_fabs_f32(void);
 int test_jit_llvm_intrinsic_memcpy_memset(void);
+int test_jit_gep_struct_field(void);
+int test_jit_gep_array_index(void);
+int test_jit_global_string_constant(void);
 int test_e2e_ret_42(void);
 int test_e2e_add_i32(void);
 int test_e2e_branch(void);
@@ -148,6 +151,9 @@ int main(void) {
     RUN_TEST(test_jit_varargs_printf_call);
     RUN_TEST(test_jit_llvm_intrinsic_fabs_f32);
     RUN_TEST(test_jit_llvm_intrinsic_memcpy_memset);
+    RUN_TEST(test_jit_gep_struct_field);
+    RUN_TEST(test_jit_gep_array_index);
+    RUN_TEST(test_jit_global_string_constant);
 
     fprintf(stderr, "\nE2E tests:\n");
     RUN_TEST(test_e2e_ret_42);

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -189,7 +189,10 @@ int test_parser_named_type_operand(void) {
     lr_inst_t *alloca_inst = b->first;
     TEST_ASSERT(alloca_inst != NULL, "has alloca");
     TEST_ASSERT_EQ(alloca_inst->op, LR_OP_ALLOCA, "first op is alloca");
-    TEST_ASSERT_EQ(alloca_inst->type->kind, LR_TYPE_PTR, "named type parsed as opaque ptr");
+    TEST_ASSERT_EQ(alloca_inst->type->kind, LR_TYPE_STRUCT, "named type resolved to struct");
+    TEST_ASSERT_EQ(alloca_inst->type->struc.packed, true, "struct is packed");
+    TEST_ASSERT_EQ(alloca_inst->type->struc.num_fields, 2, "struct has 2 fields");
+    TEST_ASSERT_EQ(lr_type_size(alloca_inst->type), 16, "packed struct is 16 bytes");
 
     lr_arena_destroy(arena);
     return 0;


### PR DESCRIPTION
## Summary

- Implement `getelementptr` in x86_64 ISel (struct fields + array indexing)
- Parse named type aliases (`%name = type {...}`), packed structs (`<{...}>`), global constant initializers (`c"..."`, integer, zeroinitializer)
- Add ISel for FCMP, SITOFP, FPTOSI, FPEXT, FPTRUNC, EXTRACTVALUE, INSERTVALUE
- Add `<` `>` tokens to lexer for packed struct syntax

Fixes #40

## Why

100% of sampled SIGSEGV crash cases from the mass test used `getelementptr`, which had no ISel implementation. The instruction fell through to `default: break;`, leaving stack slots uninitialized and causing garbage pointer dereferences. Named types were also lost during parsing (resolved to opaque `ptr`), causing wrong alloca sizes.

**Stage:** Lexer, Parser, ISel

## Changes

- [`src/ll_lexer.h`](https://github.com/krystophny/liric/blob/49014b1a79ac2f0a4f27079e652a6ea43235660d/src/ll_lexer.h), [`src/ll_lexer.c`](https://github.com/krystophny/liric/blob/49014b1a79ac2f0a4f27079e652a6ea43235660d/src/ll_lexer.c): Add `LR_TOK_LANGLE`/`LR_TOK_RANGLE` tokens
- [`src/ll_parser.c`](https://github.com/krystophny/liric/blob/49014b1a79ac2f0a4f27079e652a6ea43235660d/src/ll_parser.c): Type alias map, packed struct parsing, global constant initializer parsing, fix `skip_line()` to stop at `LOCAL_ID` at column 1
- [`src/target_x86_64.c`](https://github.com/krystophny/liric/blob/49014b1a79ac2f0a4f27079e652a6ea43235660d/src/target_x86_64.c): GEP ISel (struct field offset + array index with runtime multiply), FP helpers, EXTRACTVALUE/INSERTVALUE
- [`tests/test_jit.c`](https://github.com/krystophny/liric/blob/49014b1a79ac2f0a4f27079e652a6ea43235660d/tests/test_jit.c): 3 new tests (GEP struct, GEP array, global string constant)

## Tests

- `test_jit_gep_struct_field`: packed struct `<{ i32, i64 }>`, GEP to each field, verify 10+32=42
- `test_jit_gep_array_index`: `[3 x i64]` array, GEP to elements 0 and 2, verify 10+12=22
- `test_jit_global_string_constant`: global `c"Hello"`, GEP to first byte, verify 'H'=72

## Mass test results

| Metric | main | fix | Change |
|--------|------|-----|--------|
| Liric JIT passed | 185 | 319 | +72% |
| Differential exact matches | 129 | 171 | +33% |
| Supported passed | 131 | 174 | +33% |
| JIT failures | 833 | 716 | -14% |
| Unsupported feature | 1348 | 1128 | -16% |

220 tests moved out of `unsupported_feature` gate (now attempted). Of those, 43 now pass end-to-end, 91 produce output (mismatch), and the rest hit other parse/JIT limitations.

## Verification

### Test fails on main
```
$ git checkout main
$ cmake --build build -j$(nproc) && ./build/test_liric 2>&1 | grep -c "passed"
58 tests: 58 passed, 0 failed
(no GEP, named type, or global init tests exist)
```

### Test passes after fix
```
$ git checkout fix/issue-40-gep-crashes
$ cmake --build build -j$(nproc) && ./build/test_liric 2>&1 | tail -3
61 tests: 61 passed, 0 failed

$ ./build/test_liric 2>&1 | grep gep
  test_jit_gep_struct_field... ok
  test_jit_gep_array_index... ok

$ ./build/test_liric 2>&1 | grep global_string
  test_jit_global_string_constant... ok
```