### PR TITLE
Parser: parse vector types (<N x T>)

### DIFF
--- a/tests/test_packed_struct.ll
+++ b/tests/test_packed_struct.ll
@@ -1,0 +1,6 @@
+; Test that packed struct parsing still works
+define i32 @packed_struct_test() {
+entry:
+  %s = alloca <{ i8, i32 }>, align 4
+  ret i32 0
+}

--- a/tests/test_vector.ll
+++ b/tests/test_vector.ll
@@ -1,0 +1,8 @@
+; Test vector type parsing
+define i32 @vector_alloca_test() {
+entry:
+  %complex_ret_tmp = alloca <2 x float>, align 8
+  %vec4 = alloca <4 x i32>, align 16
+  %vec2d = alloca <2 x double>, align 16
+  ret i32 0
+}

--- a/tests/test_vector_ops.ll
+++ b/tests/test_vector_ops.ll
@@ -1,0 +1,10 @@
+; Test vector type with operations
+define i32 @vector_load_store_test() {
+entry:
+  %vec = alloca <2 x float>, align 8
+  %ptr = bitcast <2 x float>* %vec to i8*
+  store i8 42, i8* %ptr, align 1
+  %val = load i8, i8* %ptr, align 1
+  %result = zext i8 %val to i32
+  ret i32 %result
+}


### PR DESCRIPTION
## Summary
- Parse vector type syntax (`<N x T>`) in LLVM IR
- Represent internally as array types (same memory layout, SIMD ops not yet needed)
- Preserve existing packed struct syntax (`<{ ... }>`)

Fixes #53

## Why
LFortran uses vector types for complex numbers (`<2 x float>` for complex*4, `<2 x double>` for complex*8). The parser was rejecting this syntax, causing 37 test failures in the lfortran mass test.

**Stage:** Parser

## Changes
- [`src/ll_parser.c#L225-L242`](https://github.com/krystophny/liric/blob/dd64e7328b5b9ff82746e2810f2a09d28e4c0c36/src/ll_parser.c#L225-L242): Distinguish between vector types (`<N x T>`) and packed structs (`<{ ... }>`) by checking if the token after `<` is an integer literal

## Tests
- [`tests/test_vector.ll`](https://github.com/krystophny/liric/blob/dd64e7328b5b9ff82746e2810f2a09d28e4c0c36/tests/test_vector.ll): Vector type alloca for `<2 x float>`, `<4 x i32>`, `<2 x double>`
- [`tests/test_vector_ops.ll`](https://github.com/krystophny/liric/blob/dd64e7328b5b9ff82746e2810f2a09d28e4c0c36/tests/test_vector_ops.ll): Vector type with load/store operations via bitcast
- [`tests/test_packed_struct.ll`](https://github.com/krystophny/liric/blob/dd64e7328b5b9ff82746e2810f2a09d28e4c0c36/tests/test_packed_struct.ll): Verify packed struct parsing still works

## Verification

### Test fails on main
```
$ git checkout main
Already on 'main'
$ cmake -S . -B build -G Ninja && cmake --build build -j$(nproc)
$ ./build/liric_cli --dump-ir tests/test_vector.ll
parse error: line 4 col 30: expected '{', got 'int_lit'
```

### Test passes after fix
```
$ git checkout fix/issue-53
$ cmake -S . -B build -G Ninja && cmake --build build -j$(nproc)
$ ./build/liric_cli --dump-ir tests/test_vector.ll
define i32 @vector_alloca_test() {
entry:
  %v0 = alloca [2 x float] 
  %v1 = alloca [4 x i32] 
  %v2 = alloca [2 x double] 
  ret i32 0
}
```

### JIT execution works
```
$ ./build/liric_cli --jit tests/test_vector_ops.ll --func vector_load_store_test
42
```

All existing tests pass:
```
$ ctest --test-dir build --output-on-failure
Test project /tmp/liric-issue-53/build
    Start 1: liric_tests
1/1 Test #1: liric_tests ......................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1
```