### PR TITLE
Parser: handle quoted label names correctly

### DIFF
--- a/src/ll_parser.c
+++ b/src/ll_parser.c
@@ -905,7 +905,7 @@ static void parse_function_body(lr_parser_t *p, lr_func_t *func, char **param_na
 
     while (!check(p, LR_TOK_RBRACE) && !check(p, LR_TOK_EOF) && !p->had_error) {
         /* Check for label: name followed by colon */
-        if (check(p, LR_TOK_LOCAL_ID)) {
+        if (check(p, LR_TOK_LOCAL_ID) || check(p, LR_TOK_STRING_LIT)) {
             /* peek: is next token a colon? */
             lr_token_t saved_tok = p->cur;
             size_t saved_pos = p->lex.pos;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -51,6 +51,7 @@ int test_parser_store_with_struct_constant(void);
 int test_parser_urem_instruction(void);
 int test_parser_canonical_phi_pairs(void);
 int test_parser_select_with_ptr_operands(void);
+int test_parser_quoted_label_names(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
 int test_host_target_name(void);
@@ -120,6 +121,7 @@ int main(void) {
     RUN_TEST(test_parser_urem_instruction);
     RUN_TEST(test_parser_canonical_phi_pairs);
     RUN_TEST(test_parser_select_with_ptr_operands);
+    RUN_TEST(test_parser_quoted_label_names);
 
     fprintf(stderr, "\nCodegen tests:\n");
     RUN_TEST(test_codegen_ret_42);


### PR DESCRIPTION
## Summary
- Parse quoted identifiers in label positions correctly (e.g., `"some label":`)
- Add test coverage for quoted block labels

Fixes #49

## Why
LLVM IR allows labels with special characters to use quoted syntax. The lexer
already handled quoted identifiers in local IDs (`%"name"`) and global IDs
(`@"name"`), but the parser was not recognizing standalone quoted strings as
potential block labels.

Common in lfortran-generated code for module finalization and deallocator labels
containing brackets.

**Stage:** Parser

## Changes
- [`src/ll_parser.c#L906-L928`](https://github.com/krystophny/liric/blob/d674c7c/src/ll_parser.c#L906-L928): Accept `LR_TOK_STRING_LIT` in addition to `LR_TOK_LOCAL_ID` when checking for block labels
- [`tests/test_parser.c#L436-L463`](https://github.com/krystophny/liric/blob/d674c7c/tests/test_parser.c#L436-L463): New test for quoted label names
- [`tests/test_main.c`](https://github.com/krystophny/liric/blob/d674c7c/tests/test_main.c): Register new test

## Tests
- New test `test_parser_quoted_label_names` verifies quoted labels parse correctly
- All existing tests pass

## Verification

### Test fails on main
```
$ git checkout origin/main
$ echo 'define void @test() {
"FINALIZE_SYMTABLE__lcompilers_trim_Allocatable[str]":
  ret void
}' > /tmp/test.ll
$ /tmp/liric-issue-49/build/liric_cli /tmp/test.ll --dump-ir
parse error: line 2 col 1: unexpected token 'string_lit' in basic block
```

### Test passes after fix
```
$ git checkout fix/issue-49
$ cmake --build /tmp/liric-issue-49/build -j$(nproc)
$ /tmp/liric-issue-49/build/liric_cli /tmp/test.ll --dump-ir
define void @test() {
FINALIZE_SYMTABLE__lcompilers_trim_Allocatable[str]:
  ret void 
}
$ ctest --test-dir /tmp/liric-issue-49/build --output-on-failure
Test project /tmp/liric-issue-49/build
    Start 1: liric_tests
1/1 Test #1: liric_tests ......................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1
```