### PR TITLE
Parser: add comprehensive test coverage for boolean literals

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -51,6 +51,7 @@ int test_parser_store_with_struct_constant(void);
 int test_parser_urem_instruction(void);
 int test_parser_canonical_phi_pairs(void);
 int test_parser_select_with_ptr_operands(void);
+int test_parser_boolean_literals(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
 int test_host_target_name(void);
@@ -120,6 +121,7 @@ int main(void) {
     RUN_TEST(test_parser_urem_instruction);
     RUN_TEST(test_parser_canonical_phi_pairs);
     RUN_TEST(test_parser_select_with_ptr_operands);
+    RUN_TEST(test_parser_boolean_literals);
 
     fprintf(stderr, "\nCodegen tests:\n");
     RUN_TEST(test_codegen_ret_42);

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -408,3 +408,77 @@ int test_parser_select_with_ptr_operands(void) {
     lr_arena_destroy(arena);
     return 0;
 }
+
+int test_parser_boolean_literals(void) {
+    const char *src =
+        "define i1 @test_true() {\n"
+        "entry:\n"
+        "  ret i1 true\n"
+        "}\n"
+        "define i1 @test_false() {\n"
+        "entry:\n"
+        "  ret i1 false\n"
+        "}\n"
+        "define void @test_store() {\n"
+        "entry:\n"
+        "  %ptr = alloca i1\n"
+        "  store i1 false, ptr %ptr, align 1\n"
+        "  ret void\n"
+        "}\n"
+        "define i32 @test_br() {\n"
+        "entry:\n"
+        "  br i1 true, label %a, label %b\n"
+        "a:\n"
+        "  ret i32 1\n"
+        "b:\n"
+        "  ret i32 0\n"
+        "}\n";
+    lr_arena_t *arena = lr_arena_create(0);
+    char err[256] = {0};
+
+    lr_module_t *m = lr_parse_ll_text(src, strlen(src), arena, err, sizeof(err));
+    TEST_ASSERT(m != NULL, err);
+
+    lr_func_t *f = m->first_func;
+    TEST_ASSERT(f != NULL, "test_true exists");
+    TEST_ASSERT(strcmp(f->name, "test_true") == 0, "first function is test_true");
+    lr_block_t *b = f->first_block;
+    TEST_ASSERT(b != NULL, "entry block exists");
+    lr_inst_t *ret = b->first;
+    TEST_ASSERT(ret != NULL, "ret instruction exists");
+    TEST_ASSERT_EQ(ret->op, LR_OP_RET, "instruction is ret");
+    TEST_ASSERT_EQ(ret->operands[0].kind, LR_VAL_IMM_I64, "true is immediate");
+    TEST_ASSERT_EQ(ret->operands[0].imm_i64, 1, "true is 1");
+
+    f = f->next;
+    TEST_ASSERT(f != NULL, "test_false exists");
+    TEST_ASSERT(strcmp(f->name, "test_false") == 0, "second function is test_false");
+    b = f->first_block;
+    ret = b->first;
+    TEST_ASSERT_EQ(ret->operands[0].imm_i64, 0, "false is 0");
+
+    f = f->next;
+    TEST_ASSERT(f != NULL, "test_store exists");
+    TEST_ASSERT(strcmp(f->name, "test_store") == 0, "third function is test_store");
+    b = f->first_block;
+    lr_inst_t *alloca_inst = b->first;
+    TEST_ASSERT_EQ(alloca_inst->op, LR_OP_ALLOCA, "alloca parsed");
+    lr_inst_t *store = alloca_inst->next;
+    TEST_ASSERT(store != NULL, "store exists");
+    TEST_ASSERT_EQ(store->op, LR_OP_STORE, "store parsed");
+    TEST_ASSERT_EQ(store->operands[0].kind, LR_VAL_IMM_I64, "false is immediate");
+    TEST_ASSERT_EQ(store->operands[0].imm_i64, 0, "false is 0");
+
+    f = f->next;
+    TEST_ASSERT(f != NULL, "test_br exists");
+    TEST_ASSERT(strcmp(f->name, "test_br") == 0, "fourth function is test_br");
+    b = f->first_block;
+    lr_inst_t *br = b->first;
+    TEST_ASSERT(br != NULL, "br exists");
+    TEST_ASSERT_EQ(br->op, LR_OP_CONDBR, "br parsed");
+    TEST_ASSERT_EQ(br->operands[0].kind, LR_VAL_IMM_I64, "true is immediate");
+    TEST_ASSERT_EQ(br->operands[0].imm_i64, 1, "true is 1");
+
+    lr_arena_destroy(arena);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add test_parser_boolean_literals to verify parsing of true/false keywords in all common contexts

Addresses #48

## Why
Issue #48 mentioned that boolean literals (true/false) were not recognized, affecting 204 cases in the lfortran mass test. Upon investigation, the feature was already implemented in the initial commit (lines 337-343 of ll_parser.c) and is used in existing test_parser_call_arg_with_align_attr. However, there was no dedicated test explicitly covering all common boolean literal usage patterns.

**Stage:** Parser

## Changes
- [tests/test_parser.c](https://github.com/krystophny/liric/blob/585f821/tests/test_parser.c#L412-L490): Add test_parser_boolean_literals covering ret, store, and br with true/false
- [tests/test_main.c](https://github.com/krystophny/liric/blob/585f821/tests/test_main.c#L54-L123): Register new test

## Tests
- test_parser_boolean_literals: verifies true → i1 1, false → i1 0 in ret/store/br contexts
- All 62 existing tests still pass

## Verification

### Before this PR
The feature worked but lacked explicit test coverage:
```
$ git checkout main
$ /tmp/liric-issue-48/build/test_liric 2>&1 | grep -c "boolean"
0
```

### After this PR
```
$ git checkout fix/issue-48
$ cmake --build /tmp/liric-issue-48/build -j$(nproc)
$ /tmp/liric-issue-48/build/test_liric 2>&1 | grep boolean
  test_parser_boolean_literals... ok
```

All tests pass:
```
$ ctest --test-dir /tmp/liric-issue-48/build --output-on-failure
Test project /tmp/liric-issue-48/build
    Start 1: liric_tests
1/1 Test #1: liric_tests ......................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1
```

Sample test coverage:
```llvm
define i1 @test_true() {
entry:
  ret i1 true
}

define void @test_store() {
entry:
  %ptr = alloca i1
  store i1 false, ptr %ptr, align 1
  ret void
}

define i32 @test_br() {
entry:
  br i1 true, label %a, label %b
a:
  ret i32 1
b:
  ret i32 0
}
```

All parse correctly and true→1, false→0 as expected.

## Notes
The parser implementation (LR_TOK_TRUE/LR_TOK_FALSE handling) was already present from the initial commit. This PR only adds missing test coverage to prevent regression and document the feature.