### PR TITLE
ISel: implement stack argument passing for calls with >6 args

### DIFF
--- a/src/target_aarch64.c
+++ b/src/target_aarch64.c
@@ -322,6 +322,18 @@ static int aarch64_isel_func(lr_func_t *func, lr_mfunc_t *mf, lr_module_t *mod) 
     for (uint32_t i = 0; i < func->num_params && i < 8; i++) {
         emit_store_slot(mf, entry_mb, func->param_vregs[i], param_regs[i]);
     }
+    /* Load stack-passed parameters (args 9+) from caller's frame.
+       After stp x29,x30,[sp,#-16]!; mov x29,sp the caller's stack args
+       are at [FP + 16], [FP + 24], ... */
+    for (uint32_t i = 8; i < func->num_params; i++) {
+        int32_t caller_off = 16 + (int32_t)(i - 8) * 8;
+        lr_minst_t *ld = minst_new(mf->arena, LR_MIR_MOV);
+        ld->dst = (lr_moperand_t){ .kind = LR_MOP_REG, .reg = A64_X9 };
+        ld->src = (lr_moperand_t){ .kind = LR_MOP_MEM, .mem = { .base = A64_FP, .disp = caller_off } };
+        ld->size = 8;
+        mblock_append(entry_mb, ld);
+        emit_store_slot(mf, entry_mb, func->param_vregs[i], A64_X9);
+    }
 
     bi = 0;
     for (lr_block_t *b = func->first_block; b; b = b->next, bi++) {
@@ -750,13 +762,45 @@ static int aarch64_isel_func(lr_func_t *func, lr_mfunc_t *mf, lr_module_t *mod) 
                     A64_X0, A64_X1, A64_X2, A64_X3, A64_X4, A64_X5, A64_X6, A64_X7
                 };
                 uint32_t nargs = inst->num_operands - 1;
+                uint32_t nstack = nargs > 8 ? nargs - 8 : 0;
+                /* Round stack arg space to 16-byte alignment (AAPCS64) */
+                uint32_t stack_bytes = ((nstack * 8 + 15) & ~15u);
+
+                /* Reserve stack space for arguments beyond the first 8 */
+                if (stack_bytes > 0) {
+                    lr_minst_t *alloc = minst_new(mf->arena, LR_MIR_FRAME_ALLOC);
+                    alloc->src = (lr_moperand_t){ .kind = LR_MOP_IMM, .imm = (int64_t)stack_bytes };
+                    mblock_append(mb, alloc);
+                }
+
+                /* Store stack args to [SP + offset] */
+                for (uint32_t i = 0; i < nstack; i++) {
+                    uint32_t arg_idx = 8 + i;
+                    emit_load_operand(mf, mb, &inst->operands[arg_idx + 1], A64_X9);
+                    lr_minst_t *st = minst_new(mf->arena, LR_MIR_MOV);
+                    st->dst = (lr_moperand_t){ .kind = LR_MOP_MEM, .mem = { .base = A64_SP, .disp = (int32_t)(i * 8) } };
+                    st->src = (lr_moperand_t){ .kind = LR_MOP_REG, .reg = A64_X9 };
+                    st->size = 8;
+                    mblock_append(mb, st);
+                }
+
+                /* Place first 8 args in AAPCS64 registers */
                 for (uint32_t i = 0; i < nargs && i < 8; i++) {
                     emit_load_operand(mf, mb, &inst->operands[i + 1], call_regs[i]);
                 }
+
                 emit_load_operand(mf, mb, &inst->operands[0], A64_X16);
                 lr_minst_t *call = minst_new(mf->arena, LR_MIR_CALL);
                 call->src = (lr_moperand_t){ .kind = LR_MOP_REG, .reg = A64_X16 };
                 mblock_append(mb, call);
+
+                /* Reclaim stack space after call */
+                if (stack_bytes > 0) {
+                    lr_minst_t *dealloc = minst_new(mf->arena, LR_MIR_FRAME_FREE);
+                    dealloc->src = (lr_moperand_t){ .kind = LR_MOP_IMM, .imm = (int64_t)stack_bytes };
+                    mblock_append(mb, dealloc);
+                }
+
                 if (inst->type && inst->type->kind != LR_TYPE_VOID)
                     emit_store_slot(mf, mb, inst->dest, A64_X0);
                 break;

--- a/src/target_x86_64.c
+++ b/src/target_x86_64.c
@@ -326,6 +326,18 @@ static int x86_64_isel_func(lr_func_t *func, lr_mfunc_t *mf, lr_module_t *mod) {
     for (uint32_t i = 0; i < func->num_params && i < 6; i++) {
         emit_store_slot(mf, entry_mb, func->param_vregs[i], param_regs[i]);
     }
+    /* Load stack-passed parameters (args 7+) from caller's frame.
+       After push rbp; mov rbp,rsp the caller's stack args are at
+       [RBP + 16], [RBP + 24], ... (return address at +8, saved RBP at +0). */
+    for (uint32_t i = 6; i < func->num_params; i++) {
+        int32_t caller_off = 16 + (int32_t)(i - 6) * 8;
+        lr_minst_t *ld = minst_new(mf->arena, LR_MIR_MOV);
+        ld->dst = (lr_moperand_t){ .kind = LR_MOP_REG, .reg = X86_RAX };
+        ld->src = (lr_moperand_t){ .kind = LR_MOP_MEM, .mem = { .base = X86_RBP, .disp = caller_off } };
+        ld->size = 8;
+        mblock_append(entry_mb, ld);
+        emit_store_slot(mf, entry_mb, func->param_vregs[i], X86_RAX);
+    }
 
     /* Lower each IR instruction */
     bi = 0;
@@ -752,17 +764,48 @@ static int x86_64_isel_func(lr_func_t *func, lr_mfunc_t *mf, lr_module_t *mod) {
             }
             case LR_OP_CALL: {
                 /* operands[0] = callee, operands[1..] = args */
-                /* Place args in System V registers */
                 static const uint8_t call_regs[] = { X86_RDI, X86_RSI, X86_RDX, X86_RCX, X86_R8, X86_R9 };
                 uint32_t nargs = inst->num_operands - 1;
+                uint32_t nstack = nargs > 6 ? nargs - 6 : 0;
+                /* Round stack arg space to 16-byte alignment */
+                uint32_t stack_bytes = ((nstack * 8 + 15) & ~15u);
+
+                /* Reserve stack space for arguments beyond the first 6 */
+                if (stack_bytes > 0) {
+                    lr_minst_t *alloc = minst_new(mf->arena, LR_MIR_FRAME_ALLOC);
+                    alloc->src = (lr_moperand_t){ .kind = LR_MOP_IMM, .imm = (int64_t)stack_bytes };
+                    mblock_append(mb, alloc);
+                }
+
+                /* Store stack args in forward order to [RSP + offset] */
+                for (uint32_t i = 0; i < nstack; i++) {
+                    uint32_t arg_idx = 6 + i;
+                    emit_load_operand(mf, mb, &inst->operands[arg_idx + 1], X86_RAX);
+                    lr_minst_t *st = minst_new(mf->arena, LR_MIR_MOV);
+                    st->dst = (lr_moperand_t){ .kind = LR_MOP_MEM, .mem = { .base = X86_RSP, .disp = (int32_t)(i * 8) } };
+                    st->src = (lr_moperand_t){ .kind = LR_MOP_REG, .reg = X86_RAX };
+                    st->size = 8;
+                    mblock_append(mb, st);
+                }
+
+                /* Place first 6 args in System V registers */
                 for (uint32_t i = 0; i < nargs && i < 6; i++) {
                     emit_load_operand(mf, mb, &inst->operands[i + 1], call_regs[i]);
                 }
+
                 /* Load callee address into r10 */
                 emit_load_operand(mf, mb, &inst->operands[0], X86_R10);
                 lr_minst_t *call = minst_new(mf->arena, LR_MIR_CALL);
                 call->src = (lr_moperand_t){ .kind = LR_MOP_REG, .reg = X86_R10 };
                 mblock_append(mb, call);
+
+                /* Reclaim stack space after call */
+                if (stack_bytes > 0) {
+                    lr_minst_t *dealloc = minst_new(mf->arena, LR_MIR_FRAME_FREE);
+                    dealloc->src = (lr_moperand_t){ .kind = LR_MOP_IMM, .imm = (int64_t)stack_bytes };
+                    mblock_append(mb, dealloc);
+                }
+
                 /* result in rax */
                 if (inst->type && inst->type->kind != LR_TYPE_VOID)
                     emit_store_slot(mf, mb, inst->dest, X86_RAX);
@@ -1143,6 +1186,24 @@ static int x86_64_encode_func(lr_mfunc_t *mf, uint8_t *buf, size_t buflen, size_
                 break;
             }
 
+            case LR_MIR_FRAME_ALLOC: {
+                /* sub rsp, imm32 */
+                emit_byte(buf, &pos, buflen, rex(true, false, false, false));
+                emit_byte(buf, &pos, buflen, 0x81);
+                emit_byte(buf, &pos, buflen, modrm(3, 5, X86_RSP));
+                emit_u32(buf, &pos, buflen, (uint32_t)(int32_t)mi->src.imm);
+                break;
+            }
+
+            case LR_MIR_FRAME_FREE: {
+                /* add rsp, imm32 */
+                emit_byte(buf, &pos, buflen, rex(true, false, false, false));
+                emit_byte(buf, &pos, buflen, 0x81);
+                emit_byte(buf, &pos, buflen, modrm(3, 0, X86_RSP));
+                emit_u32(buf, &pos, buflen, (uint32_t)(int32_t)mi->src.imm);
+                break;
+            }
+
             case LR_MIR_MOVSX: {
                 /* movsxd rax, eax: 48 63 C0 */
                 emit_byte(buf, &pos, buflen, rex(true, mi->dst.reg >= 8, false, mi->src.reg >= 8));
@@ -1215,6 +1276,8 @@ static int x86_64_print_inst(const lr_minst_t *mi, char *buf, size_t len) {
     case LR_MIR_JMP:  return snprintf(buf, len, "jmp .L%u", mi->dst.label);
     case LR_MIR_JCC:  return snprintf(buf, len, "j%u .L%u", mi->cc, mi->dst.label);
     case LR_MIR_LEA:  return snprintf(buf, len, "lea %s, [%s%+d]", reg_names_64[mi->dst.reg], reg_names_64[mi->src.mem.base], mi->src.mem.disp);
+    case LR_MIR_FRAME_ALLOC: return snprintf(buf, len, "sub rsp, %ld", (long)mi->src.imm);
+    case LR_MIR_FRAME_FREE:  return snprintf(buf, len, "add rsp, %ld", (long)mi->src.imm);
     default: return snprintf(buf, len, "<?>");
     }
 }

--- a/tests/test_jit.c
+++ b/tests/test_jit.c
@@ -715,3 +715,83 @@ int test_jit_global_string_constant(void) {
     lr_arena_destroy(arena);
     return 0;
 }
+
+static int64_t sum8(int64_t a, int64_t b, int64_t c, int64_t d,
+                    int64_t e, int64_t f, int64_t g, int64_t h) {
+    return a + b + c + d + e + f + g + h;
+}
+
+int test_jit_call_stack_args(void) {
+    const char *src =
+        "declare i64 @sum8(i64, i64, i64, i64, i64, i64, i64, i64)\n"
+        "define i64 @call_sum8() {\n"
+        "entry:\n"
+        "  %r = call i64 @sum8(i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8)\n"
+        "  ret i64 %r\n"
+        "}\n";
+    lr_arena_t *arena = lr_arena_create(0);
+    lr_module_t *m = parse(src, arena);
+    TEST_ASSERT(m != NULL, "parse");
+
+    lr_jit_t *jit = lr_jit_create();
+    TEST_ASSERT(jit != NULL, "jit create");
+
+    int64_t (*sum8_fn)(int64_t, int64_t, int64_t, int64_t,
+                       int64_t, int64_t, int64_t, int64_t) = sum8;
+    void *sum8_addr = NULL;
+    memcpy(&sum8_addr, &sum8_fn, sizeof(sum8_addr));
+    lr_jit_add_symbol(jit, "sum8", sum8_addr);
+
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int64_t (*fn_t)(void);
+    fn_t fn; LR_JIT_GET_FN(fn, jit, "call_sum8");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(), 36, "sum8(1..8) = 36 via stack args");
+
+    lr_jit_destroy(jit);
+    lr_arena_destroy(arena);
+    return 0;
+}
+
+static int64_t sum10(int64_t a, int64_t b, int64_t c, int64_t d,
+                     int64_t e, int64_t f, int64_t g, int64_t h,
+                     int64_t i, int64_t j) {
+    return a + b + c + d + e + f + g + h + i + j;
+}
+
+int test_jit_call_many_stack_args(void) {
+    const char *src =
+        "declare i64 @sum10(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64)\n"
+        "define i64 @call_sum10() {\n"
+        "entry:\n"
+        "  %r = call i64 @sum10(i64 1, i64 2, i64 3, i64 4, i64 5,"
+        " i64 6, i64 7, i64 8, i64 9, i64 10)\n"
+        "  ret i64 %r\n"
+        "}\n";
+    lr_arena_t *arena = lr_arena_create(0);
+    lr_module_t *m = parse(src, arena);
+    TEST_ASSERT(m != NULL, "parse");
+
+    lr_jit_t *jit = lr_jit_create();
+    TEST_ASSERT(jit != NULL, "jit create");
+
+    int64_t (*sum10_fn)(int64_t, int64_t, int64_t, int64_t, int64_t,
+                        int64_t, int64_t, int64_t, int64_t, int64_t) = sum10;
+    void *sum10_addr = NULL;
+    memcpy(&sum10_addr, &sum10_fn, sizeof(sum10_addr));
+    lr_jit_add_symbol(jit, "sum10", sum10_addr);
+
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int64_t (*fn_t)(void);
+    fn_t fn; LR_JIT_GET_FN(fn, jit, "call_sum10");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(), 55, "sum10(1..10) = 55 via stack args");
+
+    lr_jit_destroy(jit);
+    lr_arena_destroy(arena);
+    return 0;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -79,6 +79,8 @@ int test_jit_llvm_intrinsic_memcpy_memset(void);
 int test_jit_gep_struct_field(void);
 int test_jit_gep_array_index(void);
 int test_jit_global_string_constant(void);
+int test_jit_call_stack_args(void);
+int test_jit_call_many_stack_args(void);
 int test_e2e_ret_42(void);
 int test_e2e_add_i32(void);
 int test_e2e_branch(void);
@@ -154,6 +156,8 @@ int main(void) {
     RUN_TEST(test_jit_gep_struct_field);
     RUN_TEST(test_jit_gep_array_index);
     RUN_TEST(test_jit_global_string_constant);
+    RUN_TEST(test_jit_call_stack_args);
+    RUN_TEST(test_jit_call_many_stack_args);
 
     fprintf(stderr, "\nE2E tests:\n");
     RUN_TEST(test_e2e_ret_42);


### PR DESCRIPTION
## Summary
- Push call arguments beyond the first 6 (x86_64) / 8 (aarch64) onto the stack per ABI
- Ensure 16-byte stack alignment via FRAME_ALLOC/FRAME_FREE MIR opcodes
- Handle callee side: load incoming stack parameters from caller's frame
- Add x86_64 encoder support for FRAME_ALLOC (sub rsp, imm32) and FRAME_FREE (add rsp, imm32)

Fixes #44

## Why
86% of JIT crash cases in the lfortran mass test involve calls with >6 arguments (e.g. `_lcompilers_string_format_fortran` with 13+ args, `_lfortran_open` with 25 args). These arguments were silently dropped, producing garbage values.

**Stage:** ISel + Encoder

## Changes
- [`src/target_x86_64.c#L329-L340`](https://github.com/krystophny/liric/blob/2c02a935e73a7c96791d30244955e154158be094/src/target_x86_64.c#L329-L340): Load incoming stack params from `[RBP + 16 + i*8]`
- [`src/target_x86_64.c#L764-L811`](https://github.com/krystophny/liric/blob/2c02a935e73a7c96791d30244955e154158be094/src/target_x86_64.c#L764-L811): Reserve stack space, store args 7+ to `[RSP + offset]`, clean up after call
- [`src/target_x86_64.c#L1186-L1203`](https://github.com/krystophny/liric/blob/2c02a935e73a7c96791d30244955e154158be094/src/target_x86_64.c#L1186-L1203): Encode FRAME_ALLOC/FRAME_FREE as SUB/ADD RSP
- [`src/target_aarch64.c#L325-L336`](https://github.com/krystophny/liric/blob/2c02a935e73a7c96791d30244955e154158be094/src/target_aarch64.c#L325-L336): Load incoming stack params from `[FP + 16 + i*8]` (AAPCS64)
- [`src/target_aarch64.c#L762-L806`](https://github.com/krystophny/liric/blob/2c02a935e73a7c96791d30244955e154158be094/src/target_aarch64.c#L762-L806): Same stack arg passing for aarch64 (args 9+)
- [`tests/test_jit.c`](https://github.com/krystophny/liric/blob/2c02a935e73a7c96791d30244955e154158be094/tests/test_jit.c#L718-L797): Two new tests: 8-arg and 10-arg external calls

## Tests
- `test_jit_call_stack_args`: calls `sum8(1..8)` via JIT, verifies result = 36
- `test_jit_call_many_stack_args`: calls `sum10(1..10)` via JIT, verifies result = 55

## Verification

### Test fails on main
```
$ gcc -o /tmp/test_stack_args_main /tmp/test_stack_args_main.c -I. /tmp/liric-main-build/libliric.a -lm -ldl
$ /tmp/test_stack_args_main
sum8(1..8) = 189204680402026 (expected 36)
FAIL: got 189204680402026, expected 36
```

### Test passes after fix
```
$ gcc -o /tmp/test_stack_args_fixed /tmp/test_stack_args_main.c -I/tmp/liric-issue-44 /tmp/liric-issue-44/build/libliric.a -lm -ldl
$ /tmp/test_stack_args_fixed
sum8(1..8) = 36 (expected 36)
PASS
```

### Full test suite passes (63/63)
```
$ /tmp/liric-issue-44/build/test_liric
liric test suite
================
...
  test_jit_call_stack_args... ok
  test_jit_call_many_stack_args... ok
...
================
63 tests: 63 passed, 0 failed
```