### PR TITLE
Parser: support constant expressions and function pointer types in operand position

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -51,6 +51,8 @@ int test_parser_store_with_struct_constant(void);
 int test_parser_urem_instruction(void);
 int test_parser_canonical_phi_pairs(void);
 int test_parser_select_with_ptr_operands(void);
+int test_parser_bitcast_const_expr_operand(void);
+int test_parser_function_pointer_type(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
 int test_host_target_name(void);
@@ -120,6 +122,8 @@ int main(void) {
     RUN_TEST(test_parser_urem_instruction);
     RUN_TEST(test_parser_canonical_phi_pairs);
     RUN_TEST(test_parser_select_with_ptr_operands);
+    RUN_TEST(test_parser_bitcast_const_expr_operand);
+    RUN_TEST(test_parser_function_pointer_type);
 
     fprintf(stderr, "\nCodegen tests:\n");
     RUN_TEST(test_codegen_ret_42);

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -408,3 +408,67 @@ int test_parser_select_with_ptr_operands(void) {
     lr_arena_destroy(arena);
     return 0;
 }
+
+int test_parser_bitcast_const_expr_operand(void) {
+    const char *src =
+        "@arr = global [3 x i32] zeroinitializer\n"
+        "declare void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)\n"
+        "define void @f(ptr %dst) {\n"
+        "entry:\n"
+        "  call void @llvm.memcpy.p0i8.p0i8.i32("
+        "i8* %dst, i8* bitcast ([3 x i32]* @arr to i8*), i32 12, i1 false)\n"
+        "  ret void\n"
+        "}\n";
+    lr_arena_t *arena = lr_arena_create(0);
+    char err[256] = {0};
+
+    lr_module_t *m = lr_parse_ll_text(src, strlen(src), arena, err, sizeof(err));
+    TEST_ASSERT(m != NULL, err);
+
+    lr_func_t *f = m->first_func;
+    while (f && strcmp(f->name, "f") != 0)
+        f = f->next;
+    TEST_ASSERT(f != NULL, "function f exists");
+    lr_block_t *b = f->first_block;
+    TEST_ASSERT(b != NULL, "entry block exists");
+    lr_inst_t *call = b->first;
+    TEST_ASSERT(call != NULL, "call exists");
+    TEST_ASSERT_EQ(call->op, LR_OP_CALL, "call parsed");
+    TEST_ASSERT_EQ(call->operands[2].kind, LR_VAL_GLOBAL,
+                   "bitcast const expr lowered to global ref");
+
+    lr_arena_destroy(arena);
+    return 0;
+}
+
+int test_parser_function_pointer_type(void) {
+    const char *src =
+        "@f_ptr = global ptr null\n"
+        "define void @f() {\n"
+        "entry:\n"
+        "  %0 = load void ()*, void ()** @f_ptr\n"
+        "  ret void\n"
+        "}\n";
+    lr_arena_t *arena = lr_arena_create(0);
+    char err[256] = {0};
+
+    lr_module_t *m = lr_parse_ll_text(src, strlen(src), arena, err, sizeof(err));
+    TEST_ASSERT(m != NULL, err);
+
+    lr_func_t *f = m->first_func;
+    while (f && strcmp(f->name, "f") != 0)
+        f = f->next;
+    TEST_ASSERT(f != NULL, "function f exists");
+    lr_block_t *b = f->first_block;
+    TEST_ASSERT(b != NULL, "entry block exists");
+    lr_inst_t *load = b->first;
+    TEST_ASSERT(load != NULL, "load exists");
+    TEST_ASSERT_EQ(load->op, LR_OP_LOAD, "load parsed");
+    TEST_ASSERT_EQ(load->type->kind, LR_TYPE_PTR,
+                   "void ()* collapsed to ptr");
+    TEST_ASSERT_EQ(load->operands[0].kind, LR_VAL_GLOBAL,
+                   "load source is global");
+
+    lr_arena_destroy(arena);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Parse cast constant expressions (bitcast, inttoptr, ptrtoint, sext, zext, trunc, sitofp, fptosi, fpext, fptrunc) in operand positions
- Parse legacy function pointer types (e.g. `void ()*`, `i32 (i32, i32)**`) by recognizing parenthesized parameter lists as function signature suffixes

Fixes #57

## Why

LLVM IR emitted by lfortran uses constant expressions inline in instructions (e.g. `bitcast ([3 x i32]* @arr to i8*)`) and legacy typed function pointers (e.g. `void ()*`). Both triggered parse errors, blocking 14+ cases with `expected operand, got '('` and 7 cases with `unexpected token '('`.

**Stage:** Parser

## Changes
- [`src/ll_parser.c#L246-L256`](https://github.com/krystophny/liric/blob/3aba2af03b9452cb6bb6c035b2db6a20bf195af8/src/ll_parser.c#L246-L256): Extend type parser to handle function pointer suffixes `type (params)*` by consuming balanced parens and collapsing to ptr
- [`src/ll_parser.c#L387-L400`](https://github.com/krystophny/liric/blob/3aba2af03b9452cb6bb6c035b2db6a20bf195af8/src/ll_parser.c#L387-L400): Add constant cast expression parsing in `parse_operand` -- parse `keyword (typed_operand to type)` and lower to the underlying operand

## Tests
- [`tests/test_parser.c`](https://github.com/krystophny/liric/blob/3aba2af03b9452cb6bb6c035b2db6a20bf195af8/tests/test_parser.c#L411-L474): Two new parser tests:
  - `test_parser_bitcast_const_expr_operand`: bitcast constant expression inside a call argument
  - `test_parser_function_pointer_type`: load with `void ()*` / `void ()**` typed pointer types

## Verification

### Test fails on main
```
$ /tmp/liric-main-build/liric_cli --dump-ir /tmp/test_constexpr.ll
parse error: line 7 col 54: expected operand, got '?'

$ /tmp/liric-main-build/liric_cli --dump-ir /tmp/test_fnptr_load.ll
parse error: line 5 col 18: expected ',', got '('
```

### Test passes after fix
```
$ /tmp/liric-issue-57/build/liric_cli --dump-ir /tmp/test_constexpr.ll
declare void @llvm.memcpy.p0i8.p0i8.i32(ptr, ptr, i32, i1)
define void @f(ptr %v0) {
entry:
  %v0 = call void @g1, %v0, @g0, 12, 0
  ret void 
}

$ /tmp/liric-issue-57/build/liric_cli --dump-ir /tmp/test_fnptr_load.ll
define void @f() {
entry:
  %v0 = load ptr @g0
  ret void 
}
```

### Full test suite
```
$ /tmp/liric-issue-57/build/test_liric
63 tests: 63 passed, 0 failed
```