### PR TITLE
Parse aggregate initializers and implement pointer relocation

### DIFF
--- a/src/ir.h
+++ b/src/ir.h
@@ -148,11 +148,18 @@ typedef struct lr_func {
     struct lr_func *next;
 } lr_func_t;
 
+typedef struct lr_global_init_elem {
+    lr_operand_t value;
+    uint32_t offset;
+    struct lr_global_init_elem *next;
+} lr_global_init_elem_t;
+
 typedef struct lr_global {
     char *name;
     lr_type_t *type;
     uint8_t *init_data;
     size_t init_size;
+    lr_global_init_elem_t *init_exprs;
     bool is_const;
     bool is_external;
     uint32_t id;


### PR DESCRIPTION
Implement parsing of struct/array aggregate initializers in global variable declarations. Support both packed <{...}> and unpacked {...} syntax. Store GEP expressions that reference other globals and resolve them during JIT materialize via two-pass relocation.

- Parser: add parse_aggregate_initializer and parse_struct_initializer to handle complex initializer expressions
- IR: add lr_global_init_elem_t linked list to store relocation entries
- JIT: implement two-pass global materialization (allocate, then relocate)

Fixes #56