### PR TITLE
Parser: handle bitcast in aggregate initializers and linkage keywords

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -56,6 +56,7 @@ int test_parser_function_pointer_type(void);
 int test_parser_quoted_label_names(void);
 int test_parser_boolean_literals(void);
 int test_parser_named_params_no_collision(void);
+int test_parser_cast_expr_in_aggregate_init(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
 int test_host_target_name(void);
@@ -134,6 +135,7 @@ int main(void) {
     RUN_TEST(test_parser_quoted_label_names);
     RUN_TEST(test_parser_boolean_literals);
     RUN_TEST(test_parser_named_params_no_collision);
+    RUN_TEST(test_parser_cast_expr_in_aggregate_init);
 
     fprintf(stderr, "\nCodegen tests:\n");
     RUN_TEST(test_codegen_ret_42);


### PR DESCRIPTION
## Summary

- Handle bitcast/inttoptr/ptrtoint/sext/zext/trunc/sitofp/fptosi/fpext/fptrunc inside aggregate initializer field values, recording relocations for global refs
- Add linkonce_odr and other linkage keywords to skip_attrs() for function definitions

Fixes #74

## Test

All 192 previously parse-failing tests now parse successfully.