### PR TITLE
Fix #78: reduce JIT SIGSEGV bucket, add mass diagnostics, refresh docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,38 @@ For LFortran mass runs, prefer:
 python3 -m tools.lfortran_mass.run_mass --workers $(nproc)
 ```
 
+For a full refresh (ignore cache) with optional diagnostics:
+
+```bash
+python3 -m tools.lfortran_mass.run_mass --workers $(nproc) --force
+python3 -m tools.lfortran_mass.run_mass --workers $(nproc) --force \
+  --diag-fail-logs --diag-jit-coredump
+```
+
+Diagnostics flags are opt-in and write into `cache/<case_id>/diag/`:
+- `--diag-fail-logs`: saves stage stdout/stderr/meta for failing stages.
+- `--diag-jit-coredump`: on JIT signal failures (`jit_rc < 0`), captures
+  `coredumpctl info` and `eu-stack` output when available.
+
+Useful outputs from each run:
+- `/tmp/liric_lfortran_mass/summary.md`
+- `/tmp/liric_lfortran_mass/results.jsonl`
+- `/tmp/liric_lfortran_mass/failures.csv`
+
+Quick SIGSEGV count (`jit_rc = -11`) from canonical results:
+
+```bash
+python3 - <<'PY'
+import json
+seg = 0
+for line in open('/tmp/liric_lfortran_mass/results.jsonl'):
+    r = json.loads(line)
+    if r.get('classification') == 'liric_jit_fail' and r.get('jit_rc') == -11:
+        seg += 1
+print(seg)
+PY
+```
+
 ## Pipeline
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ Linux x86_64 and macOS arm64.
 
 ## Speed: liric vs LLVM lli
 
-1095 LFortran-generated `.ll` files, LLVM 21.1.6. `-O0` and `-O2` are
-nearly identical because LLVM JIT startup overhead dominates.
+1095 LFortran-generated `.ll` files, LLVM 21.1.6.
 
-| Metric | liric | lli -O0 | Speedup | lli -O2 | Speedup |
-|--------|------:|--------:|--------:|--------:|--------:|
-| Median | 1.35 ms | 12.87 ms | **9.5x** | 12.84 ms | **9.5x** |
-| Mean | 2.46 ms | 15.03 ms | **6.1x** | 15.01 ms | **6.1x** |
-| P90 | 4.12 ms | 20.37 ms | 4.9x | 19.96 ms | 4.8x |
+| Metric | liric | lli -O0 | Speedup |
+|--------|------:|--------:|--------:|
+| Median | 1.35 ms | 12.87 ms | **9.5x** |
+| Mean | 2.46 ms | 15.03 ms | **6.1x** |
+| P90 | 4.12 ms | 20.37 ms | 4.9x |
 
 Total: 2.7s (liric) vs 16.5s (lli). 100% of tests faster, 38% over 10x.
 
@@ -47,14 +46,16 @@ python3 -m tools.bench_compile_speed   # reproduce
 python3 -m tools.lfortran_mass.run_mass --workers $(nproc)
 ```
 
+Latest snapshot (February 7, 2026):
+
 | Classification | Count | % |
 |---------------|------:|--:|
-| **Pass** | 1107 | 45.8% |
-| JIT fail | 506 | 20.9% |
-| Unsupported feature | 351 | 14.5% |
+| **Pass** | 1207 | 50.0% |
+| JIT fail | 395 | 16.4% |
+| Unsupported feature | 350 | 14.5% |
 | Parse fail | 192 | 7.9% |
 | Unsupported ABI | 150 | 6.2% |
-| Mismatch | 108 | 4.5% |
+| Mismatch | 120 | 5.0% |
 
 ## License
 

--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -62,6 +62,8 @@ Useful options:
 - `--include-expected-fail`: include expected-failure/error-handling tests
 - `--load-lib <path>`: preload runtime libraries into liric JIT (repeatable)
 - `--no-auto-runtime-lib`: disable automatic preload of `liblfortran_runtime`
+- `--diag-fail-logs`: write failing-stage stdout/stderr/meta under `cache/<case_id>/diag/`
+- `--diag-jit-coredump`: on JIT signal failures, capture `coredumpctl info` and `eu-stack` output when available
 
 ## Outputs
 All artifacts are written under `/tmp/liric_lfortran_mass/`:


### PR DESCRIPTION
## Summary
- fix x86_64 backend bugs contributing to JIT crashes:
  - aggregate `zeroinitializer` stores now zero the full aggregate destination
  - epilogue now restores stack with `mov rsp, rbp` before `pop rbp; ret` (safe with dynamic stack adjustments)
  - byte-sized MOV encoding correctness for 1-byte register/memory moves
  - set `%al` to `0` before calls to satisfy SysV vararg ABI requirements
- add optional mass-run diagnostics to `tools/lfortran_mass/run_mass.py`:
  - `--diag-fail-logs`
  - `--diag-jit-coredump`
- update docs and metrics workflow in `README.md` and `CLAUDE.md`
- remove LLVM `-O2` results from the README speed table

## Validation
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`
- `python3 -m tools.lfortran_mass.test_run_mass_helpers`
- `python3 -m tools.lfortran_mass.run_mass --workers $(nproc) --force`

## Metrics (`/tmp/liric_lfortran_mass/summary.md`)
- `liric_jit_fail`: `506` -> `395`
- JIT passed: `1215` -> `1327`
- `jit_rc = -11` bucket: `427` -> `335`

