### PR TITLE
lexer: optimize keyword lookup hot path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Linux x86_64 and macOS arm64.
 
 | Metric | liric | lli -O0 | Speedup |
 |--------|------:|--------:|--------:|
-| Median | 1.43 ms | 12.55 ms | **8.8x** |
-| Mean | 2.27 ms | 14.98 ms | **6.6x** |
-| P90 | 3.97 ms | 20.40 ms | 5.1x |
+| Median | 1.23 ms | 12.35 ms | **10.0x** |
+| Mean | 1.79 ms | 14.76 ms | **8.2x** |
+| P90 | 2.73 ms | 20.63 ms | 7.5x |
 
-Total: 2.7s (liric) vs 17.9s (lli). 100% of tests faster, 24% over 10x.
+Total: 2.1s (liric) vs 17.6s (lli). 100% of tests faster, 45% over 10x.
 
 ```bash
 python3 -m tools.bench_compile_speed   # reproduce


### PR DESCRIPTION
## Summary
- replace linear keyword lookup in the LLVM lexer with FNV-1a hash dispatch and exact string guards
- keep i1/i8/i16/i32/i64 on a dedicated fast path
- refresh README benchmark numbers after rerun

Closes #86.

## Why
Perf profiling on the largest real-world test case showed lexer keyword matching as the top compile-time hotspot.

## Profiling snapshot (largest .ll case)
- parse-only wall time before: 28.57 ms
- parse-only wall time after: 11.90 ms
- parse+isel+encode before: 45.01 ms
- parse+isel+encode after: 27.76 ms

## Updated benchmark (1196 matched pairs)
- total liric time: 2146.6 ms (was 2714.4 ms)
- median: 1.23 ms (was 1.43 ms)
- mean: 1.79 ms (was 2.27 ms)
- speedup vs lli -O0: 8.2x mean, 10.0x median

## Validation
- cmake --build build -j$(nproc)
- ctest --test-dir build --output-on-failure
- python3 -m tools.bench_compile_speed --results /tmp/liric_lfortran_mass/results.jsonl --output /tmp/compile_speed_results_post_lexer_hash.md
