### PR TITLE
ir: optimize module symbol interning lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Linux x86_64 and macOS arm64.
 
 ## Speed: liric vs LLVM lli
 
-1196 LFortran-generated `.ll` files, LLVM 21.1.6.
+1195 LFortran-generated `.ll` files, LLVM 21.1.6.
 
 | Metric | liric | lli -O0 | Speedup |
 |--------|------:|--------:|--------:|
 | Median | 1.23 ms | 12.35 ms | **10.0x** |
-| Mean | 1.79 ms | 14.76 ms | **8.2x** |
-| P90 | 2.73 ms | 20.63 ms | 7.5x |
+| Mean | 1.78 ms | 14.72 ms | **8.3x** |
+| P90 | 2.77 ms | 20.56 ms | 7.4x |
 
 Total: 2.1s (liric) vs 17.6s (lli). 100% of tests faster, 45% over 10x.
 

--- a/src/ir.h
+++ b/src/ir.h
@@ -174,8 +174,11 @@ typedef struct lr_module {
     lr_global_t *last_global;
     uint32_t num_globals;
     char **symbol_names;
+    uint32_t *symbol_hashes;
     uint32_t num_symbols;
     uint32_t symbol_cap;
+    uint32_t *symbol_index;
+    uint32_t symbol_index_cap;
     lr_type_t *type_void;
     lr_type_t *type_i1;
     lr_type_t *type_i8;


### PR DESCRIPTION
## Summary
- replace `lr_module_intern_symbol()` linear scan with open-addressed hash index in `lr_module_t`
- keep exact symbol identity/semantics; this is an internal data-structure change only
- refresh README benchmark numbers from latest run

## Why this bottleneck
After lexer keyword hashing, perf showed the next meaningful parser hotspot was symbol interning lookup work in `lr_module_intern_symbol`.

## Profiling
Largest real-world IR case (`arrays_30.f90`, 1,081,256-byte .ll):
- parse-only wall time before this change: **11.90 ms**
- parse-only wall time after this change: **7.08 ms**
- `lr_module_intern_symbol` dropped from a major contributor to low self share (now ~0.57% in parse-only profile)

## Benchmark update
`python3 -m tools.bench_compile_speed` (1195 matched pairs):
- total liric: **2125.3 ms**
- total lli -O0: **17595.6 ms** (8.3x)
- median: **1.23 ms** vs 12.34 ms
- mean: **1.78 ms** vs 14.72 ms

## Validation
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`
- `python3 -m tools.bench_compile_speed --results /tmp/liric_lfortran_mass/results.jsonl --output /tmp/compile_speed_results_post_symbol_hash.md`
