### PR TITLE
Optimize overall pipeline bottlenecks and refresh performance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ Linux x86_64 and macOS arm64.
 
 ## Speed: liric vs LLVM lli
 
-1195 LFortran-generated `.ll` files, LLVM 21.1.6.
+1196 LFortran-generated `.ll` files, LLVM 21.1.6.
 
 | Metric | liric | lli -O0 | Speedup |
 |--------|------:|--------:|--------:|
-| Median | 1.23 ms | 12.35 ms | **10.0x** |
-| Mean | 1.78 ms | 14.72 ms | **8.3x** |
-| P90 | 2.77 ms | 20.56 ms | 7.4x |
+| Median | 1.23 ms | 12.26 ms | **10.0x** |
+| Mean | 1.72 ms | 14.66 ms | **8.5x** |
+| P90 | 2.66 ms | 20.27 ms | 7.6x |
 
-Total: 2.1s (liric) vs 17.6s (lli). 100% of tests faster, 45% over 10x.
+Total: 2.06s (liric) vs 17.53s (lli). 100% of tests faster, 42.4% over 10x.
 
 ```bash
 python3 -m tools.bench_compile_speed   # reproduce

--- a/src/jit.h
+++ b/src/jit.h
@@ -7,14 +7,22 @@
 
 typedef struct lr_sym_entry {
     char *name;
+    uint32_t hash;
     void *addr;
-    struct lr_sym_entry *next;
+    struct lr_sym_entry *next;        /* insertion order chain */
+    struct lr_sym_entry *bucket_next; /* hash bucket chain */
 } lr_sym_entry_t;
 
 typedef struct lr_lib_entry {
     void *handle;
     struct lr_lib_entry *next;
 } lr_lib_entry_t;
+
+typedef struct lr_sym_miss_entry {
+    char *name;
+    uint32_t hash;
+    struct lr_sym_miss_entry *bucket_next;
+} lr_sym_miss_entry_t;
 
 typedef struct lr_jit {
     const lr_target_t *target;
@@ -26,6 +34,10 @@ typedef struct lr_jit {
     size_t data_size;
     size_t data_cap;
     lr_sym_entry_t *symbols;
+    lr_sym_entry_t **sym_buckets;
+    uint32_t sym_bucket_count;
+    lr_sym_miss_entry_t **miss_buckets;
+    uint32_t miss_bucket_count;
     lr_lib_entry_t *libs;
     lr_arena_t *arena;
 } lr_jit_t;

--- a/src/target_aarch64.c
+++ b/src/target_aarch64.c
@@ -1347,6 +1347,8 @@ static int aarch64_encode_func(lr_mfunc_t *mf, uint8_t *buf, size_t buflen,
     }
 
     *out_len = pos;
+    if (pos > buflen)
+        return -1;
     return 0;
 }
 

--- a/src/target_x86_64.c
+++ b/src/target_x86_64.c
@@ -1393,6 +1393,8 @@ static int x86_64_encode_func(lr_mfunc_t *mf, uint8_t *buf, size_t buflen, size_
     }
 
     *out_len = pos;
+    if (pos > buflen)
+        return -1;
     return 0;
 }
 


### PR DESCRIPTION
## Summary
This PR addresses the next three end-to-end (not parse-only) bottlenecks in one clean set:

1. `src/jit.c`: expensive symbol resolution during JIT compilation
- Added hash-bucketed symbol table lookup in JIT (`sym_buckets`) instead of linear scans.
- Added unresolved-symbol miss cache (`miss_buckets`) to avoid repeated failed lookups.
- Cached successful external `dlsym` lookups into JIT symbols.
- Invalidated miss cache on `lr_jit_load_library()` so newly loaded libraries can satisfy prior misses.

2. `src/jit.c`: avoid extra encode copy in JIT code emission
- Removed per-function temporary code buffer + `memcpy`.
- Encode now writes directly into remaining executable code buffer space.

3. `src/ll_parser.c`: reduce per-function parser index reset overhead
- Replaced full-array index clears on each function with targeted reset of used slots.
- Keeps O(total used slots) behavior per function instead of clearing full index tables repeatedly.

Also:
- `src/target_x86_64.c` and `src/target_aarch64.c`: encoder now returns `-1` if encoded length exceeds provided buffer.
- `README.md`: updated compile-speed metrics from fresh run.

## Performance (full pipeline benchmark)
Using `python3 -m tools.bench_compile_speed` on 1196 matched passing LFortran-generated `.ll` files:

Baseline:
- Total liric wall-clock: **2142.9 ms**
- Median: **1.24 ms**
- Mean: **1.79 ms**
- P90: **2.78 ms**

After this PR:
- Total liric wall-clock: **2062.7 ms**
- Median: **1.23 ms**
- Mean: **1.72 ms**
- P90: **2.66 ms**

Net:
- **-80.2 ms total** (**3.74% faster** overall vs baseline)

## New bottleneck (post-change)
From callgrind on a large representative end-to-end case (`arrays_30`):
- The prior dominant JIT symbol-resolution hotspot is no longer dominant.
- The largest remaining cost is now LLVM IR lexing/parsing (`lr_lexer_next`, `advance`, `peek`, parser token flow).
- The largest non-parse backend hotspot is x86_64 encoder byte emission (`emit_byte` / `x86_64_encode_func`).

## Validation
- Build: `cmake --build build -j$(nproc)`
- Tests: `ctest --test-dir build --output-on-failure`
- Benchmarks: `python3 -m tools.bench_compile_speed`
