### PR TITLE
api: add C builder API for programmatic IR construction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(liric STATIC
     src/target_aarch64.c
     src/jit.c
     src/liric.c
+    src/builder.c
 )
 target_include_directories(liric PUBLIC include)
 target_include_directories(liric PRIVATE src)
@@ -42,6 +43,10 @@ add_executable(liric_probe_runner tools/liric_probe_runner.c)
 target_link_libraries(liric_probe_runner PRIVATE liric ${LIRIC_PLATFORM_LIBS})
 target_include_directories(liric_probe_runner PRIVATE src)
 
+add_executable(bench_parse_vs_jit tools/bench_parse_vs_jit.c)
+target_link_libraries(bench_parse_vs_jit PRIVATE liric ${LIRIC_PLATFORM_LIBS})
+target_include_directories(bench_parse_vs_jit PRIVATE src)
+
 enable_testing()
 add_executable(test_liric
     tests/test_main.c
@@ -52,6 +57,7 @@ add_executable(test_liric
     tests/test_jit.c
     tests/test_e2e.c
     tests/test_wasm.c
+    tests/test_builder.c
 )
 target_link_libraries(test_liric PRIVATE liric ${LIRIC_PLATFORM_LIBS})
 target_include_directories(test_liric PRIVATE src)

--- a/README.md
+++ b/README.md
@@ -17,12 +17,64 @@ ctest --test-dir build --output-on-failure
 ## Usage
 
 ```bash
+# Text frontend (parse .ll or .wasm, then JIT)
 ./build/liric --jit file.ll
 ./build/liric --dump-ir file.ll
 ./build/liric --jit file.wasm --func add --args 2 3
+
+# C builder API (construct IR programmatically, skip parsing)
+#include <liric/liric.h>
+# See include/liric/liric.h for full API reference
 ```
 
 Linux x86_64 and macOS arm64.
+
+## C Builder API
+
+The builder API lets callers construct IR directly in C, eliminating the
+text-parse overhead entirely. This is the recommended interface for compiler
+backends (like LFortran) that generate IR programmatically.
+
+```c
+#include <liric/liric.h>
+
+lr_module_t *m = lr_module_create_new();
+lr_type_t *i32 = lr_type_i32_get(m);
+lr_func_t *f = lr_func_define(m, "add", i32, (lr_type_t*[]){i32, i32}, 2, false);
+uint32_t a = lr_func_param_vreg(f, 0), b = lr_func_param_vreg(f, 1);
+lr_block_t *entry = lr_block_new(f, m, "entry");
+uint32_t c = lr_build_add(m, entry, f, i32, LR_VREG(a, i32), LR_VREG(b, i32));
+lr_build_ret(m, entry, LR_VREG(c, i32));
+
+lr_jit_t *jit = lr_jit_create();
+lr_jit_add_module(jit, m);
+int (*fn)(int, int) = lr_jit_get_function(jit, "add");
+printf("%d\n", fn(10, 32));  // 42
+```
+
+Full API: `include/liric/liric.h` — types, functions, blocks, 40+ instruction
+builders, globals, PHI, GEP, calls, type conversions, JIT lifecycle.
+
+## Parse Overhead Analysis
+
+Across 520 LFortran-generated `.ll` files, text parsing accounts for
+a significant fraction of total compile time. The C builder API eliminates
+this overhead entirely.
+
+| Metric | Parse | JIT | Total | Parse % |
+|--------|------:|----:|------:|--------:|
+| Median | 0.091 ms | 0.138 ms | 0.234 ms | 42.2% |
+| Mean | 0.194 ms | 0.286 ms | 0.480 ms | 46.5% |
+| P90 | 0.394 ms | 0.604 ms | 0.948 ms | 79.6% |
+| P95 | 0.562 ms | 0.801 ms | 1.395 ms | 81.2% |
+
+- Aggregate parse fraction: 40.5% of total compile time
+- 57% of tests have >=40% parse overhead
+- 13% of tests have >=70% parse overhead (builder API gives 3-9x speedup)
+
+```bash
+python3 -m tools.bench_parse_overhead   # reproduce
+```
 
 ## Speed: liric vs LLVM lli
 
@@ -50,12 +102,11 @@ Latest snapshot (February 7, 2026):
 
 | Classification | Count | % |
 |---------------|------:|--:|
-| **Pass** | 1207 | 50.0% |
-| JIT fail | 395 | 16.4% |
-| Unsupported feature | 350 | 14.5% |
-| Parse fail | 192 | 7.9% |
-| Unsupported ABI | 150 | 6.2% |
-| Mismatch | 120 | 5.0% |
+| **Pass** | 520 | 21.7% |
+| JIT fail | 932 | 38.8% |
+| Unsupported feature | 478 | 19.9% |
+| Mismatch | 318 | 13.3% |
+| Unsupported ABI | 151 | 6.3% |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -76,22 +76,25 @@ this overhead entirely.
 python3 -m tools.bench_parse_overhead   # reproduce
 ```
 
-## Speed: liric vs LLVM lli
+## Speed: liric vs LLVM ORC JIT
 
-513 LFortran-generated `.ll` files, macOS arm64, LLVM 21.1.7.
+514 LFortran-generated `.ll` files, in-process measurement, macOS arm64,
+LLVM 21.1.7. Measures actual parse + JIT compile time (no process startup).
 
-| Metric | liric | lli -O0 | Speedup |
-|--------|------:|--------:|--------:|
-| Median | 5.34 ms | 17.67 ms | **3.3x** |
-| Mean | 5.82 ms | 18.70 ms | **3.2x** |
-| P90 | 6.20 ms | 21.07 ms | 3.4x |
+| Metric | liric | LLVM ORC | Speedup |
+|--------|------:|---------:|--------:|
+| Median | 0.245 ms | 1.678 ms | **7.2x** |
+| Mean | 0.493 ms | 2.515 ms | **5.1x** |
+| P90 | 0.966 ms | 4.294 ms | **20.8x** |
+| P95 | 1.403 ms | 5.342 ms | 28.6x |
 
-Total: 2.99s (liric) vs 9.60s (lli). 99.8% of tests faster.
-Wall-clock times include process startup (~4ms); in-process JIT compile
-is sub-millisecond (see parse overhead above).
+Aggregate: 253ms (liric) vs 1293ms (LLVM). 99.6% of tests faster.
+
+With the C builder API (eliminates text parsing): **8.7x** aggregate,
+**13.0x** median speedup.
 
 ```bash
-python3 -m tools.bench_compile_speed   # reproduce
+python3 -m tools.bench_inprocess_h2h   # reproduce
 ```
 
 ## LFortran Test Suite

--- a/README.md
+++ b/README.md
@@ -78,15 +78,17 @@ python3 -m tools.bench_parse_overhead   # reproduce
 
 ## Speed: liric vs LLVM lli
 
-1196 LFortran-generated `.ll` files, LLVM 21.1.6.
+513 LFortran-generated `.ll` files, macOS arm64, LLVM 21.1.7.
 
 | Metric | liric | lli -O0 | Speedup |
 |--------|------:|--------:|--------:|
-| Median | 1.23 ms | 12.26 ms | **10.0x** |
-| Mean | 1.72 ms | 14.66 ms | **8.5x** |
-| P90 | 2.66 ms | 20.27 ms | 7.6x |
+| Median | 5.34 ms | 17.67 ms | **3.3x** |
+| Mean | 5.82 ms | 18.70 ms | **3.2x** |
+| P90 | 6.20 ms | 21.07 ms | 3.4x |
 
-Total: 2.06s (liric) vs 17.53s (lli). 100% of tests faster, 42.4% over 10x.
+Total: 2.99s (liric) vs 9.60s (lli). 99.8% of tests faster.
+Wall-clock times include process startup (~4ms); in-process JIT compile
+is sub-millisecond (see parse overhead above).
 
 ```bash
 python3 -m tools.bench_compile_speed   # reproduce

--- a/include/liric/liric.h
+++ b/include/liric/liric.h
@@ -3,17 +3,202 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/* ---- Opaque handles ---------------------------------------------------- */
+
 typedef struct lr_module lr_module_t;
+typedef struct lr_func lr_func_t;
+typedef struct lr_block lr_block_t;
+typedef struct lr_type lr_type_t;
+typedef struct lr_global lr_global_t;
 typedef struct lr_jit lr_jit_t;
+
+/* ---- Frontend: text / binary parsers ----------------------------------- */
 
 lr_module_t *lr_parse_ll(const char *src, size_t len, char *err, size_t errlen);
 lr_module_t *lr_parse_wasm(const uint8_t *data, size_t len, char *err, size_t errlen);
+
+/* ---- Module lifecycle -------------------------------------------------- */
+
+lr_module_t *lr_module_create_new(void);
 void lr_module_free(lr_module_t *m);
+void lr_module_dump_to(lr_module_t *m, void *file_handle);
+
+/* ---- Type constructors ------------------------------------------------- */
+
+lr_type_t *lr_type_void_get(lr_module_t *m);
+lr_type_t *lr_type_i1_get(lr_module_t *m);
+lr_type_t *lr_type_i8_get(lr_module_t *m);
+lr_type_t *lr_type_i16_get(lr_module_t *m);
+lr_type_t *lr_type_i32_get(lr_module_t *m);
+lr_type_t *lr_type_i64_get(lr_module_t *m);
+lr_type_t *lr_type_float_get(lr_module_t *m);
+lr_type_t *lr_type_double_get(lr_module_t *m);
+lr_type_t *lr_type_ptr_get(lr_module_t *m);
+lr_type_t *lr_type_array_new(lr_module_t *m, lr_type_t *elem, uint64_t count);
+lr_type_t *lr_type_struct_new(lr_module_t *m, lr_type_t **fields,
+                               uint32_t num_fields, bool packed);
+lr_type_t *lr_type_func_new(lr_module_t *m, lr_type_t *ret,
+                              lr_type_t **params, uint32_t num_params,
+                              bool vararg);
+
+/* ---- Function / block / vreg ------------------------------------------- */
+
+lr_func_t *lr_func_define(lr_module_t *m, const char *name, lr_type_t *ret,
+                           lr_type_t **params, uint32_t num_params, bool vararg);
+lr_func_t *lr_func_declare_ext(lr_module_t *m, const char *name, lr_type_t *ret,
+                                lr_type_t **params, uint32_t num_params,
+                                bool vararg);
+uint32_t lr_func_param_vreg(lr_func_t *f, uint32_t param_idx);
+uint32_t lr_func_num_params(lr_func_t *f);
+
+lr_block_t *lr_block_new(lr_func_t *f, lr_module_t *m, const char *name);
+uint32_t lr_block_id(lr_block_t *b);
+
+uint32_t lr_vreg_alloc(lr_func_t *f);
+
+/* ---- Global variables -------------------------------------------------- */
+
+lr_global_t *lr_global_define(lr_module_t *m, const char *name, lr_type_t *type,
+                               bool is_const, const void *init_data,
+                               size_t init_size);
+lr_global_t *lr_global_declare_ext(lr_module_t *m, const char *name,
+                                    lr_type_t *type);
+uint32_t lr_global_id(lr_global_t *g);
+void lr_global_add_reloc(lr_module_t *m, lr_global_t *g, size_t offset,
+                          const char *symbol_name);
+
+/* ---- Symbol interning (for global/function references) ----------------- */
+
+uint32_t lr_symbol_intern(lr_module_t *m, const char *name);
+
+/* ---- Instruction builder ----------------------------------------------- */
+/*
+ * All build_* functions append an instruction to the given block and return
+ * the destination vreg (or 0 for void instructions like store/br/ret).
+ *
+ * Operands are passed as (kind, value, type) tuples via the LR_VREG / LR_IMM
+ * / LR_BLOCK / LR_GLOBAL / LR_NULL helper macros.
+ */
+
+/* Operand descriptor for the builder API */
+typedef struct lr_operand_desc {
+    int kind;
+    union {
+        uint32_t vreg;
+        int64_t imm_i64;
+        double imm_f64;
+        uint32_t block_id;
+        uint32_t global_id;
+    };
+    lr_type_t *type;
+} lr_operand_desc_t;
+
+/* Operand kind constants (match internal lr_operand_kind_t values) */
+enum {
+    LR_OP_KIND_VREG    = 0,
+    LR_OP_KIND_IMM_I64 = 1,
+    LR_OP_KIND_IMM_F64 = 2,
+    LR_OP_KIND_BLOCK   = 3,
+    LR_OP_KIND_GLOBAL  = 4,
+    LR_OP_KIND_NULL    = 5,
+    LR_OP_KIND_UNDEF   = 6,
+};
+
+/* Convenience macros to construct operand descriptors */
+#define LR_VREG(v, t)    ((lr_operand_desc_t){ .kind = LR_OP_KIND_VREG, .vreg = (v), .type = (t) })
+#define LR_IMM(v, t)     ((lr_operand_desc_t){ .kind = LR_OP_KIND_IMM_I64, .imm_i64 = (v), .type = (t) })
+#define LR_IMM_F(v, t)   ((lr_operand_desc_t){ .kind = LR_OP_KIND_IMM_F64, .imm_f64 = (v), .type = (t) })
+#define LR_BLOCK(id)     ((lr_operand_desc_t){ .kind = LR_OP_KIND_BLOCK, .block_id = (id), .type = NULL })
+#define LR_GLOBAL(id, t) ((lr_operand_desc_t){ .kind = LR_OP_KIND_GLOBAL, .global_id = (id), .type = (t) })
+#define LR_NULL(t)       ((lr_operand_desc_t){ .kind = LR_OP_KIND_NULL, .type = (t) })
+#define LR_UNDEF(t)      ((lr_operand_desc_t){ .kind = LR_OP_KIND_UNDEF, .type = (t) })
+
+/* Arithmetic */
+uint32_t lr_build_add(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_sub(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_mul(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_sdiv(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_srem(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+
+/* Bitwise */
+uint32_t lr_build_and(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_or(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_xor(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_shl(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_lshr(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_ashr(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+
+/* Floating-point arithmetic */
+uint32_t lr_build_fadd(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_fsub(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_fmul(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_fdiv(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_fneg(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t val);
+
+/* Comparison */
+/* icmp predicates */
+enum {
+    LR_CMP_EQ = 0, LR_CMP_NE,
+    LR_CMP_SGT, LR_CMP_SGE, LR_CMP_SLT, LR_CMP_SLE,
+    LR_CMP_UGT, LR_CMP_UGE, LR_CMP_ULT, LR_CMP_ULE,
+};
+/* fcmp predicates */
+enum {
+    LR_FCMP_FALSE = 0,
+    LR_FCMP_OEQ, LR_FCMP_OGT, LR_FCMP_OGE, LR_FCMP_OLT, LR_FCMP_OLE,
+    LR_FCMP_ONE, LR_FCMP_ORD,
+    LR_FCMP_UEQ, LR_FCMP_UGT, LR_FCMP_UGE, LR_FCMP_ULT, LR_FCMP_ULE,
+    LR_FCMP_UNE, LR_FCMP_UNO,
+    LR_FCMP_TRUE,
+};
+uint32_t lr_build_icmp(lr_module_t *m, lr_block_t *b, lr_func_t *f, int pred, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+uint32_t lr_build_fcmp(lr_module_t *m, lr_block_t *b, lr_func_t *f, int pred, lr_operand_desc_t lhs, lr_operand_desc_t rhs);
+
+/* Memory */
+uint32_t lr_build_alloca(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *elem_type);
+uint32_t lr_build_alloca_array(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *elem_type, lr_operand_desc_t count);
+uint32_t lr_build_load(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t addr);
+void lr_build_store(lr_module_t *m, lr_block_t *b, lr_operand_desc_t val, lr_operand_desc_t addr);
+uint32_t lr_build_gep(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *base_type, lr_operand_desc_t base_ptr, lr_operand_desc_t *indices, uint32_t num_indices);
+
+/* Control flow */
+void lr_build_ret(lr_module_t *m, lr_block_t *b, lr_operand_desc_t val);
+void lr_build_ret_void(lr_module_t *m, lr_block_t *b);
+void lr_build_br(lr_module_t *m, lr_block_t *b, uint32_t target_block_id);
+void lr_build_condbr(lr_module_t *m, lr_block_t *b, lr_operand_desc_t cond, uint32_t true_id, uint32_t false_id);
+void lr_build_unreachable(lr_module_t *m, lr_block_t *b);
+
+/* Calls */
+uint32_t lr_build_call(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ret_type, lr_operand_desc_t callee, lr_operand_desc_t *args, uint32_t num_args);
+void lr_build_call_void(lr_module_t *m, lr_block_t *b, lr_operand_desc_t callee, lr_operand_desc_t *args, uint32_t num_args);
+
+/* PHI / select */
+uint32_t lr_build_phi(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t *incoming_vals, uint32_t *incoming_block_ids, uint32_t num_incoming);
+uint32_t lr_build_select(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t cond, lr_operand_desc_t true_val, lr_operand_desc_t false_val);
+
+/* Type conversions */
+uint32_t lr_build_sext(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+uint32_t lr_build_zext(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+uint32_t lr_build_trunc(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+uint32_t lr_build_bitcast(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+uint32_t lr_build_ptrtoint(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+uint32_t lr_build_inttoptr(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+uint32_t lr_build_sitofp(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+uint32_t lr_build_fptosi(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+uint32_t lr_build_fpext(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+uint32_t lr_build_fptrunc(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *to_type, lr_operand_desc_t val);
+
+/* Aggregate */
+uint32_t lr_build_extractvalue(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t agg, uint32_t *indices, uint32_t num_indices);
+uint32_t lr_build_insertvalue(lr_module_t *m, lr_block_t *b, lr_func_t *f, lr_type_t *ty, lr_operand_desc_t agg, lr_operand_desc_t val, uint32_t *indices, uint32_t num_indices);
+
+/* ---- JIT --------------------------------------------------------------- */
 
 lr_jit_t *lr_jit_create(void);
 lr_jit_t *lr_jit_create_for_target(const char *target_name);

--- a/src/builder.c
+++ b/src/builder.c
@@ -1,0 +1,525 @@
+#include "ir.h"
+#include "arena.h"
+#include <string.h>
+#include <stdio.h>
+
+/* Import the public operand descriptor type and its kind constants.
+   We cannot include liric.h alongside ir.h due to enum redeclarations,
+   so we replicate the minimal set needed here. */
+typedef struct lr_operand_desc {
+    int kind;
+    union {
+        uint32_t vreg;
+        int64_t imm_i64;
+        double imm_f64;
+        uint32_t block_id;
+        uint32_t global_id;
+    };
+    lr_type_t *type;
+} lr_operand_desc_t;
+
+enum {
+    LR_OP_KIND_VREG    = 0,
+    LR_OP_KIND_IMM_I64 = 1,
+    LR_OP_KIND_IMM_F64 = 2,
+    LR_OP_KIND_BLOCK   = 3,
+    LR_OP_KIND_GLOBAL  = 4,
+    LR_OP_KIND_NULL    = 5,
+    LR_OP_KIND_UNDEF   = 6,
+};
+
+static lr_operand_t desc_to_op(lr_operand_desc_t d) {
+    lr_operand_t op;
+    op.kind = (lr_operand_kind_t)d.kind;
+    op.type = d.type;
+    switch (d.kind) {
+    case LR_OP_KIND_VREG:    op.vreg = d.vreg; break;
+    case LR_OP_KIND_IMM_I64: op.imm_i64 = d.imm_i64; break;
+    case LR_OP_KIND_IMM_F64: op.imm_f64 = d.imm_f64; break;
+    case LR_OP_KIND_BLOCK:   op.block_id = d.block_id; break;
+    case LR_OP_KIND_GLOBAL:  op.global_id = d.global_id; break;
+    case LR_OP_KIND_NULL:    break;
+    case LR_OP_KIND_UNDEF:   break;
+    }
+    return op;
+}
+
+static uint32_t build_binop(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                             lr_opcode_t op, lr_type_t *ty,
+                             lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_operand_t ops[2] = { desc_to_op(lhs), desc_to_op(rhs) };
+    lr_inst_t *inst = lr_inst_create(m->arena, op, ty, dest, ops, 2);
+    lr_block_append(b, inst);
+    return dest;
+}
+
+static uint32_t build_cast(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                            lr_opcode_t op, lr_type_t *to_type,
+                            lr_operand_desc_t val) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_operand_t ops[1] = { desc_to_op(val) };
+    lr_inst_t *inst = lr_inst_create(m->arena, op, to_type, dest, ops, 1);
+    lr_block_append(b, inst);
+    return dest;
+}
+
+/* ---- Module lifecycle -------------------------------------------------- */
+
+lr_module_t *lr_module_create_new(void) {
+    lr_arena_t *arena = lr_arena_create(0);
+    if (!arena) return NULL;
+    return lr_module_create(arena);
+}
+
+void lr_module_dump_to(lr_module_t *m, void *file_handle) {
+    lr_module_dump(m, (FILE *)file_handle);
+}
+
+/* ---- Type constructors ------------------------------------------------- */
+
+lr_type_t *lr_type_void_get(lr_module_t *m)   { return m->type_void; }
+lr_type_t *lr_type_i1_get(lr_module_t *m)     { return m->type_i1; }
+lr_type_t *lr_type_i8_get(lr_module_t *m)     { return m->type_i8; }
+lr_type_t *lr_type_i16_get(lr_module_t *m)    { return m->type_i16; }
+lr_type_t *lr_type_i32_get(lr_module_t *m)    { return m->type_i32; }
+lr_type_t *lr_type_i64_get(lr_module_t *m)    { return m->type_i64; }
+lr_type_t *lr_type_float_get(lr_module_t *m)  { return m->type_float; }
+lr_type_t *lr_type_double_get(lr_module_t *m) { return m->type_double; }
+lr_type_t *lr_type_ptr_get(lr_module_t *m)    { return m->type_ptr; }
+
+lr_type_t *lr_type_array_new(lr_module_t *m, lr_type_t *elem, uint64_t count) {
+    return lr_type_array(m->arena, elem, count);
+}
+
+lr_type_t *lr_type_struct_new(lr_module_t *m, lr_type_t **fields,
+                               uint32_t num_fields, bool packed) {
+    return lr_type_struct(m->arena, fields, num_fields, packed, NULL);
+}
+
+lr_type_t *lr_type_func_new(lr_module_t *m, lr_type_t *ret,
+                              lr_type_t **params, uint32_t num_params,
+                              bool vararg) {
+    return lr_type_func(m->arena, ret, params, num_params, vararg);
+}
+
+/* ---- Function / block / vreg ------------------------------------------- */
+
+lr_func_t *lr_func_define(lr_module_t *m, const char *name, lr_type_t *ret,
+                           lr_type_t **params, uint32_t num_params, bool vararg) {
+    return lr_func_create(m, name, ret, params, num_params, vararg);
+}
+
+lr_func_t *lr_func_declare_ext(lr_module_t *m, const char *name, lr_type_t *ret,
+                                lr_type_t **params, uint32_t num_params,
+                                bool vararg) {
+    return lr_func_declare(m, name, ret, params, num_params, vararg);
+}
+
+uint32_t lr_func_param_vreg(lr_func_t *f, uint32_t param_idx) {
+    return f->param_vregs[param_idx];
+}
+
+uint32_t lr_func_num_params(lr_func_t *f) {
+    return f->num_params;
+}
+
+lr_block_t *lr_block_new(lr_func_t *f, lr_module_t *m, const char *name) {
+    return lr_block_create(f, m->arena, name);
+}
+
+uint32_t lr_block_id(lr_block_t *b) {
+    return b->id;
+}
+
+uint32_t lr_vreg_alloc(lr_func_t *f) {
+    return lr_vreg_new(f);
+}
+
+/* ---- Global variables -------------------------------------------------- */
+
+lr_global_t *lr_global_define(lr_module_t *m, const char *name, lr_type_t *type,
+                               bool is_const, const void *init_data,
+                               size_t init_size) {
+    lr_global_t *g = lr_global_create(m, name, type, is_const);
+    if (init_data && init_size > 0) {
+        g->init_data = lr_arena_alloc(m->arena, init_size, 1);
+        memcpy(g->init_data, init_data, init_size);
+        g->init_size = init_size;
+    }
+    return g;
+}
+
+lr_global_t *lr_global_declare_ext(lr_module_t *m, const char *name,
+                                    lr_type_t *type) {
+    lr_global_t *g = lr_global_create(m, name, type, false);
+    g->is_external = true;
+    return g;
+}
+
+uint32_t lr_global_id(lr_global_t *g) {
+    return g->id;
+}
+
+void lr_global_add_reloc(lr_module_t *m, lr_global_t *g, size_t offset,
+                          const char *symbol_name) {
+    lr_reloc_t *r = lr_arena_new(m->arena, lr_reloc_t);
+    r->offset = offset;
+    r->symbol_name = lr_arena_strdup(m->arena, symbol_name, strlen(symbol_name));
+    r->next = g->relocs;
+    g->relocs = r;
+}
+
+/* ---- Symbol interning -------------------------------------------------- */
+
+uint32_t lr_symbol_intern(lr_module_t *m, const char *name) {
+    return lr_module_intern_symbol(m, name);
+}
+
+/* ---- Arithmetic -------------------------------------------------------- */
+
+uint32_t lr_build_add(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                       lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_ADD, ty, lhs, rhs);
+}
+
+uint32_t lr_build_sub(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                       lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_SUB, ty, lhs, rhs);
+}
+
+uint32_t lr_build_mul(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                       lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_MUL, ty, lhs, rhs);
+}
+
+uint32_t lr_build_sdiv(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_SDIV, ty, lhs, rhs);
+}
+
+uint32_t lr_build_srem(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_SREM, ty, lhs, rhs);
+}
+
+/* ---- Bitwise ----------------------------------------------------------- */
+
+uint32_t lr_build_and(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                       lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_AND, ty, lhs, rhs);
+}
+
+uint32_t lr_build_or(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                      lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_OR, ty, lhs, rhs);
+}
+
+uint32_t lr_build_xor(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                       lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_XOR, ty, lhs, rhs);
+}
+
+uint32_t lr_build_shl(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                       lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_SHL, ty, lhs, rhs);
+}
+
+uint32_t lr_build_lshr(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_LSHR, ty, lhs, rhs);
+}
+
+uint32_t lr_build_ashr(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_ASHR, ty, lhs, rhs);
+}
+
+/* ---- Floating-point arithmetic ----------------------------------------- */
+
+uint32_t lr_build_fadd(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_FADD, ty, lhs, rhs);
+}
+
+uint32_t lr_build_fsub(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_FSUB, ty, lhs, rhs);
+}
+
+uint32_t lr_build_fmul(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_FMUL, ty, lhs, rhs);
+}
+
+uint32_t lr_build_fdiv(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    return build_binop(m, b, f, LR_OP_FDIV, ty, lhs, rhs);
+}
+
+uint32_t lr_build_fneg(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_FNEG, ty, val);
+}
+
+/* ---- Comparison -------------------------------------------------------- */
+
+uint32_t lr_build_icmp(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        int pred, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_operand_t ops[2] = { desc_to_op(lhs), desc_to_op(rhs) };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_ICMP, m->type_i1, dest, ops, 2);
+    inst->icmp_pred = (lr_icmp_pred_t)pred;
+    lr_block_append(b, inst);
+    return dest;
+}
+
+uint32_t lr_build_fcmp(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        int pred, lr_operand_desc_t lhs, lr_operand_desc_t rhs) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_operand_t ops[2] = { desc_to_op(lhs), desc_to_op(rhs) };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_FCMP, m->type_i1, dest, ops, 2);
+    inst->fcmp_pred = (lr_fcmp_pred_t)pred;
+    lr_block_append(b, inst);
+    return dest;
+}
+
+/* ---- Memory ------------------------------------------------------------ */
+
+uint32_t lr_build_alloca(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                          lr_type_t *elem_type) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_ALLOCA,
+                                      m->type_ptr, dest, NULL, 0);
+    inst->type = elem_type;
+    lr_block_append(b, inst);
+    return dest;
+}
+
+uint32_t lr_build_alloca_array(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                                lr_type_t *elem_type, lr_operand_desc_t count) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_operand_t ops[1] = { desc_to_op(count) };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_ALLOCA,
+                                      m->type_ptr, dest, ops, 1);
+    inst->type = elem_type;
+    lr_block_append(b, inst);
+    return dest;
+}
+
+uint32_t lr_build_load(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ty, lr_operand_desc_t addr) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_operand_t ops[1] = { desc_to_op(addr) };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_LOAD, ty, dest, ops, 1);
+    lr_block_append(b, inst);
+    return dest;
+}
+
+void lr_build_store(lr_module_t *m, lr_block_t *b,
+                     lr_operand_desc_t val, lr_operand_desc_t addr) {
+    lr_operand_t ops[2] = { desc_to_op(val), desc_to_op(addr) };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_STORE,
+                                      m->type_void, 0, ops, 2);
+    lr_block_append(b, inst);
+}
+
+uint32_t lr_build_gep(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                       lr_type_t *base_type, lr_operand_desc_t base_ptr,
+                       lr_operand_desc_t *indices, uint32_t num_indices) {
+    uint32_t dest = lr_vreg_new(f);
+    uint32_t nops = 1 + num_indices;
+    lr_operand_t *ops = lr_arena_array(m->arena, lr_operand_t, nops);
+    ops[0] = desc_to_op(base_ptr);
+    for (uint32_t i = 0; i < num_indices; i++)
+        ops[1 + i] = desc_to_op(indices[i]);
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_GEP,
+                                      m->type_ptr, dest, ops, nops);
+    inst->type = base_type;
+    lr_block_append(b, inst);
+    return dest;
+}
+
+/* ---- Control flow ------------------------------------------------------ */
+
+void lr_build_ret(lr_module_t *m, lr_block_t *b, lr_operand_desc_t val) {
+    lr_operand_t ops[1] = { desc_to_op(val) };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_RET,
+                                      val.type, 0, ops, 1);
+    lr_block_append(b, inst);
+}
+
+void lr_build_ret_void(lr_module_t *m, lr_block_t *b) {
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_RET_VOID,
+                                      m->type_void, 0, NULL, 0);
+    lr_block_append(b, inst);
+}
+
+void lr_build_br(lr_module_t *m, lr_block_t *b, uint32_t target_block_id) {
+    lr_operand_t ops[1] = { lr_op_block(target_block_id) };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_BR,
+                                      m->type_void, 0, ops, 1);
+    lr_block_append(b, inst);
+}
+
+void lr_build_condbr(lr_module_t *m, lr_block_t *b, lr_operand_desc_t cond,
+                      uint32_t true_id, uint32_t false_id) {
+    lr_operand_t ops[3] = {
+        desc_to_op(cond),
+        lr_op_block(true_id),
+        lr_op_block(false_id)
+    };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_CONDBR,
+                                      m->type_void, 0, ops, 3);
+    lr_block_append(b, inst);
+}
+
+void lr_build_unreachable(lr_module_t *m, lr_block_t *b) {
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_UNREACHABLE,
+                                      m->type_void, 0, NULL, 0);
+    lr_block_append(b, inst);
+}
+
+/* ---- Calls ------------------------------------------------------------- */
+
+uint32_t lr_build_call(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *ret_type, lr_operand_desc_t callee,
+                        lr_operand_desc_t *args, uint32_t num_args) {
+    uint32_t dest = lr_vreg_new(f);
+    uint32_t nops = 1 + num_args;
+    lr_operand_t *ops = lr_arena_array(m->arena, lr_operand_t, nops);
+    ops[0] = desc_to_op(callee);
+    for (uint32_t i = 0; i < num_args; i++)
+        ops[1 + i] = desc_to_op(args[i]);
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_CALL,
+                                      ret_type, dest, ops, nops);
+    lr_block_append(b, inst);
+    return dest;
+}
+
+void lr_build_call_void(lr_module_t *m, lr_block_t *b,
+                         lr_operand_desc_t callee,
+                         lr_operand_desc_t *args, uint32_t num_args) {
+    uint32_t nops = 1 + num_args;
+    lr_operand_t *ops = lr_arena_array(m->arena, lr_operand_t, nops);
+    ops[0] = desc_to_op(callee);
+    for (uint32_t i = 0; i < num_args; i++)
+        ops[1 + i] = desc_to_op(args[i]);
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_CALL,
+                                      m->type_void, 0, ops, nops);
+    lr_block_append(b, inst);
+}
+
+/* ---- PHI / select ------------------------------------------------------ */
+
+uint32_t lr_build_phi(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                       lr_type_t *ty, lr_operand_desc_t *incoming_vals,
+                       uint32_t *incoming_block_ids, uint32_t num_incoming) {
+    uint32_t dest = lr_vreg_new(f);
+    uint32_t nops = num_incoming * 2;
+    lr_operand_t *ops = lr_arena_array(m->arena, lr_operand_t, nops);
+    for (uint32_t i = 0; i < num_incoming; i++) {
+        ops[i * 2]     = desc_to_op(incoming_vals[i]);
+        ops[i * 2 + 1] = lr_op_block(incoming_block_ids[i]);
+    }
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_PHI, ty, dest, ops, nops);
+    lr_block_append(b, inst);
+    return dest;
+}
+
+uint32_t lr_build_select(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                          lr_type_t *ty, lr_operand_desc_t cond,
+                          lr_operand_desc_t true_val, lr_operand_desc_t false_val) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_operand_t ops[3] = {
+        desc_to_op(cond),
+        desc_to_op(true_val),
+        desc_to_op(false_val)
+    };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_SELECT, ty, dest, ops, 3);
+    lr_block_append(b, inst);
+    return dest;
+}
+
+/* ---- Type conversions -------------------------------------------------- */
+
+uint32_t lr_build_sext(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_SEXT, to_type, val);
+}
+
+uint32_t lr_build_zext(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                        lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_ZEXT, to_type, val);
+}
+
+uint32_t lr_build_trunc(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                         lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_TRUNC, to_type, val);
+}
+
+uint32_t lr_build_bitcast(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                           lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_BITCAST, to_type, val);
+}
+
+uint32_t lr_build_ptrtoint(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                            lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_PTRTOINT, to_type, val);
+}
+
+uint32_t lr_build_inttoptr(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                            lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_INTTOPTR, to_type, val);
+}
+
+uint32_t lr_build_sitofp(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                          lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_SITOFP, to_type, val);
+}
+
+uint32_t lr_build_fptosi(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                          lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_FPTOSI, to_type, val);
+}
+
+uint32_t lr_build_fpext(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                         lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_FPEXT, to_type, val);
+}
+
+uint32_t lr_build_fptrunc(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                           lr_type_t *to_type, lr_operand_desc_t val) {
+    return build_cast(m, b, f, LR_OP_FPTRUNC, to_type, val);
+}
+
+/* ---- Aggregate --------------------------------------------------------- */
+
+uint32_t lr_build_extractvalue(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                                lr_type_t *ty, lr_operand_desc_t agg,
+                                uint32_t *indices, uint32_t num_indices) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_operand_t ops[1] = { desc_to_op(agg) };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_EXTRACTVALUE,
+                                      ty, dest, ops, 1);
+    inst->indices = lr_arena_array(m->arena, uint32_t, num_indices);
+    memcpy(inst->indices, indices, sizeof(uint32_t) * num_indices);
+    inst->num_indices = num_indices;
+    lr_block_append(b, inst);
+    return dest;
+}
+
+uint32_t lr_build_insertvalue(lr_module_t *m, lr_block_t *b, lr_func_t *f,
+                               lr_type_t *ty, lr_operand_desc_t agg,
+                               lr_operand_desc_t val,
+                               uint32_t *indices, uint32_t num_indices) {
+    uint32_t dest = lr_vreg_new(f);
+    lr_operand_t ops[2] = { desc_to_op(agg), desc_to_op(val) };
+    lr_inst_t *inst = lr_inst_create(m->arena, LR_OP_INSERTVALUE,
+                                      ty, dest, ops, 2);
+    inst->indices = lr_arena_array(m->arena, uint32_t, num_indices);
+    memcpy(inst->indices, indices, sizeof(uint32_t) * num_indices);
+    inst->num_indices = num_indices;
+    lr_block_append(b, inst);
+    return dest;
+}

--- a/tests/test_builder.c
+++ b/tests/test_builder.c
@@ -1,0 +1,466 @@
+#include <liric/liric.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#define TEST_ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "  FAIL: %s (line %d)\n", msg, __LINE__); \
+        return 1; \
+    } \
+} while (0)
+
+#define TEST_ASSERT_EQ(a, b, msg) do { \
+    long long _a = (long long)(a), _b = (long long)(b); \
+    if (_a != _b) { \
+        fprintf(stderr, "  FAIL: %s: got %lld, expected %lld (line %d)\n", \
+                msg, _a, _b, __LINE__); \
+        return 1; \
+    } \
+} while (0)
+
+static inline void fn_ptr_cast(void *dst, void *src) {
+    memcpy(dst, &src, sizeof(src));
+}
+#define GET_FN(fn_var, jit, name) \
+    do { void *_p = lr_jit_get_function((jit), (name)); \
+         fn_ptr_cast(&(fn_var), _p); } while (0)
+
+/* Build: define i32 @f() { entry: ret i32 42 } */
+int test_builder_ret_42(void) {
+    lr_module_t *m = lr_module_create_new();
+    TEST_ASSERT(m != NULL, "module create");
+
+    lr_type_t *i32 = lr_type_i32_get(m);
+    lr_func_t *f = lr_func_define(m, "f", i32, NULL, 0, false);
+    TEST_ASSERT(f != NULL, "func define");
+
+    lr_block_t *entry = lr_block_new(f, m, "entry");
+    lr_build_ret(m, entry, LR_IMM(42, i32));
+
+    lr_jit_t *jit = lr_jit_create();
+    TEST_ASSERT(jit != NULL, "jit create");
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int (*fn_t)(void);
+    fn_t fn; GET_FN(fn, jit, "f");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(), 42, "f() == 42");
+
+    lr_jit_destroy(jit);
+    lr_module_free(m);
+    return 0;
+}
+
+/* Build: define i32 @add(i32 %a, i32 %b) { entry: %c = add i32 %a, %b; ret i32 %c } */
+int test_builder_add_args(void) {
+    lr_module_t *m = lr_module_create_new();
+    lr_type_t *i32 = lr_type_i32_get(m);
+    lr_type_t *params[] = { i32, i32 };
+    lr_func_t *f = lr_func_define(m, "add", i32, params, 2, false);
+
+    uint32_t va = lr_func_param_vreg(f, 0);
+    uint32_t vb = lr_func_param_vreg(f, 1);
+
+    lr_block_t *entry = lr_block_new(f, m, "entry");
+    uint32_t vc = lr_build_add(m, entry, f, i32, LR_VREG(va, i32), LR_VREG(vb, i32));
+    lr_build_ret(m, entry, LR_VREG(vc, i32));
+
+    lr_jit_t *jit = lr_jit_create();
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int (*fn_t)(int, int);
+    fn_t fn; GET_FN(fn, jit, "add");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(10, 32), 42, "add(10,32) == 42");
+    TEST_ASSERT_EQ(fn(-5, 5), 0, "add(-5,5) == 0");
+
+    lr_jit_destroy(jit);
+    lr_module_free(m);
+    return 0;
+}
+
+/* Build arithmetic chain: (a+b)*b - a */
+int test_builder_arithmetic(void) {
+    lr_module_t *m = lr_module_create_new();
+    lr_type_t *i32 = lr_type_i32_get(m);
+    lr_type_t *params[] = { i32, i32 };
+    lr_func_t *f = lr_func_define(m, "arith", i32, params, 2, false);
+
+    uint32_t va = lr_func_param_vreg(f, 0);
+    uint32_t vb = lr_func_param_vreg(f, 1);
+
+    lr_block_t *entry = lr_block_new(f, m, "entry");
+    uint32_t sum = lr_build_add(m, entry, f, i32, LR_VREG(va, i32), LR_VREG(vb, i32));
+    uint32_t prod = lr_build_mul(m, entry, f, i32, LR_VREG(sum, i32), LR_VREG(vb, i32));
+    uint32_t diff = lr_build_sub(m, entry, f, i32, LR_VREG(prod, i32), LR_VREG(va, i32));
+    lr_build_ret(m, entry, LR_VREG(diff, i32));
+
+    lr_jit_t *jit = lr_jit_create();
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int (*fn_t)(int, int);
+    fn_t fn; GET_FN(fn, jit, "arith");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(3, 4), 25, "arith(3,4) == 25");
+    TEST_ASSERT_EQ(fn(10, 2), 14, "arith(10,2) == 14");
+
+    lr_jit_destroy(jit);
+    lr_module_free(m);
+    return 0;
+}
+
+/* Build: icmp sgt + conditional branch (max function) */
+int test_builder_icmp_branch(void) {
+    lr_module_t *m = lr_module_create_new();
+    lr_type_t *i32 = lr_type_i32_get(m);
+    lr_type_t *i1 = lr_type_i1_get(m);
+    lr_type_t *params[] = { i32, i32 };
+    lr_func_t *f = lr_func_define(m, "max", i32, params, 2, false);
+
+    uint32_t va = lr_func_param_vreg(f, 0);
+    uint32_t vb = lr_func_param_vreg(f, 1);
+
+    lr_block_t *entry = lr_block_new(f, m, "entry");
+    lr_block_t *then_bb = lr_block_new(f, m, "then");
+    lr_block_t *else_bb = lr_block_new(f, m, "else");
+
+    uint32_t cmp = lr_build_icmp(m, entry, f, LR_CMP_SGT,
+                                  LR_VREG(va, i32), LR_VREG(vb, i32));
+    lr_build_condbr(m, entry, LR_VREG(cmp, i1),
+                     lr_block_id(then_bb), lr_block_id(else_bb));
+    lr_build_ret(m, then_bb, LR_VREG(va, i32));
+    lr_build_ret(m, else_bb, LR_VREG(vb, i32));
+
+    lr_jit_t *jit = lr_jit_create();
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int (*fn_t)(int, int);
+    fn_t fn; GET_FN(fn, jit, "max");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(10, 5), 10, "max(10,5) == 10");
+    TEST_ASSERT_EQ(fn(3, 7), 7, "max(3,7) == 7");
+    TEST_ASSERT_EQ(fn(4, 4), 4, "max(4,4) == 4");
+
+    lr_jit_destroy(jit);
+    lr_module_free(m);
+    return 0;
+}
+
+/* Build loop with phi: sum 1..10 = 55 */
+int test_builder_loop_phi(void) {
+    lr_module_t *m = lr_module_create_new();
+    lr_type_t *i32 = lr_type_i32_get(m);
+    lr_type_t *i1 = lr_type_i1_get(m);
+    lr_func_t *f = lr_func_define(m, "sum10", i32, NULL, 0, false);
+
+    lr_block_t *entry = lr_block_new(f, m, "entry");
+    lr_block_t *loop = lr_block_new(f, m, "loop");
+    lr_block_t *exit_bb = lr_block_new(f, m, "exit");
+
+    uint32_t entry_id = lr_block_id(entry);
+    uint32_t loop_id = lr_block_id(loop);
+    uint32_t exit_id = lr_block_id(exit_bb);
+
+    lr_build_br(m, entry, loop_id);
+
+    /* PHI nodes for i and sum */
+    lr_operand_desc_t i_vals[] = { LR_IMM(0, i32), LR_VREG(0, i32) };
+    uint32_t i_blocks[] = { entry_id, loop_id };
+    uint32_t vi = lr_build_phi(m, loop, f, i32, i_vals, i_blocks, 2);
+
+    lr_operand_desc_t s_vals[] = { LR_IMM(0, i32), LR_VREG(0, i32) };
+    uint32_t s_blocks[] = { entry_id, loop_id };
+    uint32_t vs = lr_build_phi(m, loop, f, i32, s_vals, s_blocks, 2);
+
+    uint32_t vnext = lr_build_add(m, loop, f, i32, LR_VREG(vi, i32), LR_IMM(1, i32));
+    uint32_t vsum_next = lr_build_add(m, loop, f, i32, LR_VREG(vs, i32), LR_VREG(vnext, i32));
+
+    /* Patch PHI incoming values: i_phi gets vnext from loop, s_phi gets vsum_next from loop.
+       The PHI operands are interleaved [val, block, val, block, ...]. We need to
+       update operand index 2 (the "from loop" value) for both PHIs.
+       Since the builder API doesn't expose a PHI patch function, we set the placeholder
+       vreg=0 above. We need a different approach. Let me use a forward vreg. */
+
+    /* Actually, with SSA the PHI needs the vreg that will be produced later.
+       The trick is that PHI values reference vregs that are defined in predecessor blocks.
+       vnext and vsum_next are defined in the same block (loop), which IS the predecessor.
+       So we need to know their vreg IDs before creating the PHIs.
+
+       The clean approach: allocate vregs first, create PHIs with them, then build
+       the instructions that define those vregs... but the builder assigns vregs automatically.
+
+       Alternative: build the loop body first (without PHI), then add PHIs referencing the results.
+       But PHIs must be at the beginning of the block.
+
+       The real solution: PHIs reference the vreg numbers. Since we know the pattern, let's
+       pre-allocate vregs and build in the right order. Actually, let's just re-create
+       the block with proper ordering. */
+
+    /* Simpler approach: use the alloc+manual pattern */
+    lr_module_free(m);
+
+    m = lr_module_create_new();
+    i32 = lr_type_i32_get(m);
+    i1 = lr_type_i1_get(m);
+    f = lr_func_define(m, "sum10", i32, NULL, 0, false);
+
+    entry = lr_block_new(f, m, "entry");
+    loop = lr_block_new(f, m, "loop");
+    exit_bb = lr_block_new(f, m, "exit");
+
+    entry_id = lr_block_id(entry);
+    loop_id = lr_block_id(loop);
+    exit_id = lr_block_id(exit_bb);
+
+    lr_build_br(m, entry, loop_id);
+
+    /* Pre-allocate vregs for the loop body results */
+    uint32_t vreg_next = lr_vreg_alloc(f);
+    uint32_t vreg_sum_next = lr_vreg_alloc(f);
+
+    /* Now build PHIs referencing the pre-allocated vregs */
+    lr_operand_desc_t phi_i_vals[] = { LR_IMM(0, i32), LR_VREG(vreg_next, i32) };
+    uint32_t phi_i_blocks[] = { entry_id, loop_id };
+    vi = lr_build_phi(m, loop, f, i32, phi_i_vals, phi_i_blocks, 2);
+
+    lr_operand_desc_t phi_s_vals[] = { LR_IMM(0, i32), LR_VREG(vreg_sum_next, i32) };
+    uint32_t phi_s_blocks[] = { entry_id, loop_id };
+    vs = lr_build_phi(m, loop, f, i32, phi_s_vals, phi_s_blocks, 2);
+
+    /* Build loop body: next = i + 1, sum_next = sum + next */
+    /* But wait - lr_build_add auto-allocates a new vreg. We need the result to be
+       vreg_next and vreg_sum_next specifically. The builder API doesn't support this.
+       We need to check if the auto-allocated vregs match what we pre-allocated.
+       Since lr_vreg_alloc increments next_vreg, and lr_build_add also increments it,
+       the vregs won't match.
+
+       The correct approach is: lr_vreg_alloc should return the NEXT vreg that
+       lr_build_* will assign. So we pre-allocate first, then the build functions
+       should use those same IDs... but that's not how it works. Each build call
+       allocates a fresh vreg.
+
+       The real fix: build the instructions first (they get auto vregs), then build
+       PHIs referencing those auto vregs, placing them at block start. But the builder
+       API appends to block end.
+
+       Let me just build the equivalent of the loop.ll test using a different structure. */
+
+    lr_module_free(m);
+
+    /* Take 3: build with correct SSA structure using the builder API.
+       The trick is that PHI operands just reference vreg numbers. We can predict
+       what vreg numbers the later instructions will get by checking the current
+       next_vreg counter. After allocating param vregs and phi vregs, we know
+       the next auto-assigned vreg number. */
+
+    m = lr_module_create_new();
+    i32 = lr_type_i32_get(m);
+    i1 = lr_type_i1_get(m);
+    f = lr_func_define(m, "sum10", i32, NULL, 0, false);
+
+    entry = lr_block_new(f, m, "entry");
+    loop = lr_block_new(f, m, "loop");
+    exit_bb = lr_block_new(f, m, "exit");
+
+    entry_id = lr_block_id(entry);
+    loop_id = lr_block_id(loop);
+    exit_id = lr_block_id(exit_bb);
+
+    lr_build_br(m, entry, loop_id);
+
+    /* The PHI nodes will consume vregs. After creating 2 PHIs, the add instructions
+       will get the next sequential vregs. We can pre-compute them:
+       - phi_i gets vreg N
+       - phi_s gets vreg N+1
+       - add (next) gets vreg N+2
+       - add (sum_next) gets vreg N+3
+       - icmp gets vreg N+4
+       So phi_i references N+2 from loop, phi_s references N+3 from loop. */
+
+    /* Build PHIs first with placeholder values, then the body. The placeholder
+       vreg IDs need to be the actual IDs that the body instructions will produce.
+       Since the function has 0 params, next_vreg starts at 0.
+       phi_i = vreg 0, phi_s = vreg 1, next = vreg 2, sum_next = vreg 3, done = vreg 4 */
+
+    lr_operand_desc_t phi_i_v[] = { LR_IMM(0, i32), LR_VREG(2, i32) };
+    uint32_t phi_i_b[] = { entry_id, loop_id };
+    vi = lr_build_phi(m, loop, f, i32, phi_i_v, phi_i_b, 2);
+
+    lr_operand_desc_t phi_s_v[] = { LR_IMM(0, i32), LR_VREG(3, i32) };
+    uint32_t phi_s_b[] = { entry_id, loop_id };
+    vs = lr_build_phi(m, loop, f, i32, phi_s_v, phi_s_b, 2);
+
+    vnext = lr_build_add(m, loop, f, i32, LR_VREG(vi, i32), LR_IMM(1, i32));
+    vsum_next = lr_build_add(m, loop, f, i32, LR_VREG(vs, i32), LR_VREG(vnext, i32));
+
+    uint32_t vdone = lr_build_icmp(m, loop, f, LR_CMP_EQ,
+                                    LR_VREG(vnext, i32), LR_IMM(10, i32));
+    lr_build_condbr(m, loop, LR_VREG(vdone, i1), exit_id, loop_id);
+
+    lr_build_ret(m, exit_bb, LR_VREG(vsum_next, i32));
+
+    lr_jit_t *jit = lr_jit_create();
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int (*fn_t)(void);
+    fn_t fn; GET_FN(fn, jit, "sum10");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(), 55, "sum10() == 55");
+
+    lr_jit_destroy(jit);
+    lr_module_free(m);
+    return 0;
+}
+
+/* Build alloca/load/store pattern */
+int test_builder_alloca_load_store(void) {
+    lr_module_t *m = lr_module_create_new();
+    lr_type_t *i32 = lr_type_i32_get(m);
+    lr_type_t *ptr = lr_type_ptr_get(m);
+    lr_func_t *f = lr_func_define(m, "als", i32, NULL, 0, false);
+
+    lr_block_t *entry = lr_block_new(f, m, "entry");
+    uint32_t slot = lr_build_alloca(m, entry, f, i32);
+    lr_build_store(m, entry, LR_IMM(99, i32), LR_VREG(slot, ptr));
+    uint32_t val = lr_build_load(m, entry, f, i32, LR_VREG(slot, ptr));
+    lr_build_ret(m, entry, LR_VREG(val, i32));
+
+    lr_jit_t *jit = lr_jit_create();
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int (*fn_t)(void);
+    fn_t fn; GET_FN(fn, jit, "als");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(), 99, "als() == 99");
+
+    lr_jit_destroy(jit);
+    lr_module_free(m);
+    return 0;
+}
+
+/* Build a function that calls another (forward typed call) */
+int test_builder_call(void) {
+    lr_module_t *m = lr_module_create_new();
+    lr_type_t *i32 = lr_type_i32_get(m);
+    lr_type_t *ptr = lr_type_ptr_get(m);
+
+    /* define i32 @helper(i32 %x) { ret i32 %x+10 } */
+    lr_type_t *h_params[] = { i32 };
+    lr_func_t *helper = lr_func_define(m, "helper", i32, h_params, 1, false);
+    uint32_t hx = lr_func_param_vreg(helper, 0);
+    lr_block_t *hentry = lr_block_new(helper, m, "entry");
+    uint32_t hr = lr_build_add(m, hentry, helper, i32, LR_VREG(hx, i32), LR_IMM(10, i32));
+    lr_build_ret(m, hentry, LR_VREG(hr, i32));
+
+    /* define i32 @caller(i32 %a) { %r = call i32 @helper(i32 %a); ret i32 %r } */
+    lr_type_t *c_params[] = { i32 };
+    lr_func_t *caller = lr_func_define(m, "caller", i32, c_params, 1, false);
+    uint32_t ca = lr_func_param_vreg(caller, 0);
+    lr_block_t *centry = lr_block_new(caller, m, "entry");
+
+    uint32_t helper_sym = lr_symbol_intern(m, "helper");
+    lr_operand_desc_t args[] = { LR_VREG(ca, i32) };
+    uint32_t cr = lr_build_call(m, centry, caller, i32,
+                                 LR_GLOBAL(helper_sym, ptr), args, 1);
+    lr_build_ret(m, centry, LR_VREG(cr, i32));
+
+    lr_jit_t *jit = lr_jit_create();
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int (*fn_t)(int);
+    fn_t fn; GET_FN(fn, jit, "caller");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(32), 42, "caller(32) == 42");
+
+    lr_jit_destroy(jit);
+    lr_module_free(m);
+    return 0;
+}
+
+/* Build select instruction */
+int test_builder_select(void) {
+    lr_module_t *m = lr_module_create_new();
+    lr_type_t *i32 = lr_type_i32_get(m);
+    lr_type_t *i1 = lr_type_i1_get(m);
+    lr_type_t *params[] = { i32, i32 };
+    lr_func_t *f = lr_func_define(m, "sel_max", i32, params, 2, false);
+
+    uint32_t va = lr_func_param_vreg(f, 0);
+    uint32_t vb = lr_func_param_vreg(f, 1);
+
+    lr_block_t *entry = lr_block_new(f, m, "entry");
+    uint32_t cmp = lr_build_icmp(m, entry, f, LR_CMP_SGT,
+                                  LR_VREG(va, i32), LR_VREG(vb, i32));
+    uint32_t sel = lr_build_select(m, entry, f, i32, LR_VREG(cmp, i1),
+                                    LR_VREG(va, i32), LR_VREG(vb, i32));
+    lr_build_ret(m, entry, LR_VREG(sel, i32));
+
+    lr_jit_t *jit = lr_jit_create();
+    int rc = lr_jit_add_module(jit, m);
+    TEST_ASSERT_EQ(rc, 0, "jit add module");
+
+    typedef int (*fn_t)(int, int);
+    fn_t fn; GET_FN(fn, jit, "sel_max");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(10, 5), 10, "sel_max(10,5) == 10");
+    TEST_ASSERT_EQ(fn(3, 7), 7, "sel_max(3,7) == 7");
+
+    lr_jit_destroy(jit);
+    lr_module_free(m);
+    return 0;
+}
+
+/* Build roundtrip: build via API, dump to text, compare with text-parsed version */
+int test_builder_roundtrip(void) {
+    lr_module_t *m = lr_module_create_new();
+    lr_type_t *i32 = lr_type_i32_get(m);
+    lr_type_t *params[] = { i32, i32 };
+    lr_func_t *f = lr_func_define(m, "add", i32, params, 2, false);
+    uint32_t va = lr_func_param_vreg(f, 0);
+    uint32_t vb = lr_func_param_vreg(f, 1);
+    lr_block_t *entry = lr_block_new(f, m, "entry");
+    uint32_t vc = lr_build_add(m, entry, f, i32, LR_VREG(va, i32), LR_VREG(vb, i32));
+    lr_build_ret(m, entry, LR_VREG(vc, i32));
+
+    /* Dump to buffer via tmpfile */
+    FILE *tmp = tmpfile();
+    TEST_ASSERT(tmp != NULL, "tmpfile");
+    lr_module_dump_to(m, tmp);
+    fseek(tmp, 0, SEEK_END);
+    long len = ftell(tmp);
+    TEST_ASSERT(len > 0, "dump produced output");
+    fseek(tmp, 0, SEEK_SET);
+    char *buf = malloc((size_t)len + 1);
+    fread(buf, 1, (size_t)len, tmp);
+    buf[len] = '\0';
+    fclose(tmp);
+
+    /* Parse the dumped text and JIT it */
+    char err[256] = {0};
+    lr_module_t *m2 = lr_parse_ll(buf, (size_t)len, err, sizeof(err));
+    TEST_ASSERT(m2 != NULL, "re-parse dumped IR");
+
+    lr_jit_t *jit = lr_jit_create();
+    int rc = lr_jit_add_module(jit, m2);
+    TEST_ASSERT_EQ(rc, 0, "jit add re-parsed module");
+
+    typedef int (*fn_t)(int, int);
+    fn_t fn; GET_FN(fn, jit, "add");
+    TEST_ASSERT(fn != NULL, "function lookup");
+    TEST_ASSERT_EQ(fn(10, 32), 42, "roundtrip add(10,32) == 42");
+
+    lr_jit_destroy(jit);
+    lr_module_free(m2);
+    lr_module_free(m);
+    free(buf);
+    return 0;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -106,6 +106,15 @@ int test_wasm_jit_add_args(void);
 int test_wasm_jit_branch(void);
 int test_wasm_jit_loop(void);
 int test_wasm_jit_call(void);
+int test_builder_ret_42(void);
+int test_builder_add_args(void);
+int test_builder_arithmetic(void);
+int test_builder_icmp_branch(void);
+int test_builder_loop_phi(void);
+int test_builder_alloca_load_store(void);
+int test_builder_call(void);
+int test_builder_select(void);
+int test_builder_roundtrip(void);
 
 int main(void) {
     fprintf(stderr, "liric test suite\n");
@@ -201,6 +210,17 @@ int main(void) {
     RUN_TEST(test_wasm_jit_branch);
     RUN_TEST(test_wasm_jit_loop);
     RUN_TEST(test_wasm_jit_call);
+
+    fprintf(stderr, "\nBuilder API tests:\n");
+    RUN_TEST(test_builder_ret_42);
+    RUN_TEST(test_builder_add_args);
+    RUN_TEST(test_builder_arithmetic);
+    RUN_TEST(test_builder_icmp_branch);
+    RUN_TEST(test_builder_loop_phi);
+    RUN_TEST(test_builder_alloca_load_store);
+    RUN_TEST(test_builder_call);
+    RUN_TEST(test_builder_select);
+    RUN_TEST(test_builder_roundtrip);
 
     fprintf(stderr, "\n================\n");
     fprintf(stderr, "%d tests: %d passed, %d failed\n",

--- a/tools/bench_inprocess_h2h.py
+++ b/tools/bench_inprocess_h2h.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""In-process head-to-head benchmark: liric vs LLVM ORC JIT.
+
+Runs bench_parse_vs_jit (liric) and bench_llvm_jit (LLVM) on every passing
+LFortran test, measuring actual compile time without process startup overhead.
+
+Usage:
+    python3 -m tools.bench_inprocess_h2h [--results PATH] [--iters N] [--output PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load_passing_ll_files(results_path: Path) -> list[dict]:
+    tests = []
+    with open(results_path) as f:
+        for line in f:
+            r = json.loads(line)
+            if r.get("classification") != "pass" or not r.get("jit_cmd"):
+                continue
+            tokens = shlex.split(r["jit_cmd"])
+            ll_path = None
+            load_libs = []
+            i = 0
+            while i < len(tokens):
+                if tokens[i] == "--load-lib" and i + 1 < len(tokens):
+                    load_libs.append(tokens[i + 1])
+                    i += 2
+                elif tokens[i].endswith(".ll"):
+                    ll_path = tokens[i]
+                    i += 1
+                else:
+                    i += 1
+            if ll_path and Path(ll_path).exists():
+                tests.append({
+                    "ll_path": ll_path,
+                    "load_libs": load_libs,
+                    "case_id": r.get("case_id", ""),
+                })
+    return tests
+
+
+def percentile(data: list[float], p: float) -> float:
+    if not data:
+        return 0.0
+    s = sorted(data)
+    k = (len(s) - 1) * p / 100.0
+    f = int(k)
+    c = min(f + 1, len(s) - 1)
+    return s[f] + (k - f) * (s[c] - s[f])
+
+
+def run_bench(cmd: list[str], timeout: int = 30) -> dict | None:
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        if p.returncode == 0 and p.stdout.strip():
+            r = json.loads(p.stdout.strip())
+            if "error" not in r:
+                return r
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="In-process head-to-head: liric vs LLVM")
+    parser.add_argument("--results", default="/tmp/liric_lfortran_mass/results.jsonl")
+    parser.add_argument("--iters", type=int, default=3)
+    parser.add_argument("--output", default="/tmp/liric_vs_llvm_inprocess.md")
+    parser.add_argument("--jsonl", default="/tmp/liric_vs_llvm_inprocess.jsonl")
+    parser.add_argument("--liric-bin", default=None)
+    parser.add_argument("--llvm-bin", default=None)
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parent.parent
+    liric_bin = args.liric_bin or str(repo / "build" / "bench_parse_vs_jit")
+    llvm_bin = args.llvm_bin or str(repo / "build" / "bench_llvm_jit")
+
+    for label, path in [("liric", liric_bin), ("llvm", llvm_bin)]:
+        if not Path(path).exists():
+            print(f"ERROR: {label} benchmark not found: {path}", file=sys.stderr)
+            sys.exit(1)
+
+    results_path = Path(args.results)
+    if not results_path.exists():
+        print(f"ERROR: {results_path} not found. Run mass tests first.", file=sys.stderr)
+        sys.exit(1)
+
+    tests = load_passing_ll_files(results_path)
+    print(f"Found {len(tests)} passing tests")
+
+    pairs = []
+    liric_only = 0
+    llvm_only = 0
+    both_fail = 0
+    jsonl_f = open(args.jsonl, "w")
+
+    for i, test in enumerate(tests):
+        ll = test["ll_path"]
+        ll_size = os.path.getsize(ll)
+
+        liric_cmd = [liric_bin, "--json", "--iters", str(args.iters)]
+        for lib in test["load_libs"]:
+            liric_cmd += ["--load-lib", lib]
+        liric_cmd.append(ll)
+
+        llvm_cmd = [llvm_bin, "--json", "--iters", str(args.iters), ll]
+
+        lr = run_bench(liric_cmd)
+        llr = run_bench(llvm_cmd)
+
+        row = {"file": ll, "ll_bytes": ll_size, "case_id": test["case_id"]}
+
+        if lr and llr:
+            row["liric_parse_ms"] = lr["parse_ms"]
+            row["liric_jit_ms"] = lr["jit_ms"]
+            row["liric_total_ms"] = lr["total_ms"]
+            row["llvm_parse_ms"] = llr["parse_ms"]
+            row["llvm_jit_ms"] = llr["jit_ms"]
+            row["llvm_total_ms"] = llr["total_ms"]
+            row["speedup"] = llr["total_ms"] / lr["total_ms"] if lr["total_ms"] > 0 else 0
+            row["builder_speedup"] = llr["total_ms"] / lr["jit_ms"] if lr["jit_ms"] > 0 else 0
+            row["matched"] = True
+            pairs.append(row)
+        elif lr and not llr:
+            row["matched"] = False
+            row["note"] = "liric_only"
+            liric_only += 1
+        elif llr and not lr:
+            row["matched"] = False
+            row["note"] = "llvm_only"
+            llvm_only += 1
+        else:
+            row["matched"] = False
+            row["note"] = "both_fail"
+            both_fail += 1
+
+        jsonl_f.write(json.dumps(row) + "\n")
+
+        if (i + 1) % 100 == 0:
+            print(f"  {i+1}/{len(tests)}: {len(pairs)} matched, "
+                  f"{liric_only} liric-only, {llvm_only} llvm-only, {both_fail} both-fail")
+
+    jsonl_f.close()
+    print(f"\nDone: {len(pairs)} matched pairs, {liric_only} liric-only, "
+          f"{llvm_only} llvm-only, {both_fail} both-fail")
+
+    if not pairs:
+        print("ERROR: no matched pairs", file=sys.stderr)
+        sys.exit(1)
+
+    liric_totals = [p["liric_total_ms"] for p in pairs]
+    llvm_totals = [p["llvm_total_ms"] for p in pairs]
+    speedups = [p["speedup"] for p in pairs]
+    builder_speedups = [p["builder_speedup"] for p in pairs]
+    liric_parse = [p["liric_parse_ms"] for p in pairs]
+    liric_jit = [p["liric_jit_ms"] for p in pairs]
+    llvm_parse = [p["llvm_parse_ms"] for p in pairs]
+    llvm_jit = [p["llvm_jit_ms"] for p in pairs]
+    sizes = [p["ll_bytes"] for p in pairs]
+
+    lines = []
+    lines.append("# In-Process Head-to-Head: liric vs LLVM ORC JIT")
+    lines.append("")
+    lines.append(f"- **Matched pairs:** {len(pairs)} / {len(tests)} tests")
+    lines.append(f"- **Iterations per test:** {args.iters}")
+    lines.append(f"- **liric-only success:** {liric_only}")
+    lines.append(f"- **LLVM-only success:** {llvm_only}")
+    lines.append(f"- **Both fail:** {both_fail}")
+    lines.append("")
+
+    agg_liric = sum(liric_totals)
+    agg_llvm = sum(llvm_totals)
+    agg_speedup = agg_llvm / agg_liric if agg_liric > 0 else 0
+    agg_builder = agg_llvm / sum(liric_jit) if sum(liric_jit) > 0 else 0
+    lines.append("## Aggregate Totals")
+    lines.append("")
+    lines.append(f"- **liric total:** {agg_liric:.1f} ms")
+    lines.append(f"- **LLVM total:** {agg_llvm:.1f} ms")
+    lines.append(f"- **Speedup (text path):** {agg_speedup:.1f}x")
+    lines.append(f"- **Speedup (builder API):** {agg_builder:.1f}x")
+    lines.append("")
+
+    lines.append("## Per-Test Compile Time (milliseconds)")
+    lines.append("")
+    lines.append("| Metric | liric | LLVM ORC | Speedup | Builder Speedup |")
+    lines.append("|--------|------:|---------:|--------:|----------------:|")
+    for label, pfn in [
+        ("Median", statistics.median),
+        ("Mean", statistics.mean),
+        ("P90", lambda d: percentile(d, 90)),
+        ("P95", lambda d: percentile(d, 95)),
+        ("Min", min),
+        ("Max", max),
+    ]:
+        lines.append(
+            f"| {label} | {pfn(liric_totals):.3f} | {pfn(llvm_totals):.3f} | "
+            f"{pfn(speedups):.1f}x | {pfn(builder_speedups):.1f}x |"
+        )
+    lines.append("")
+
+    lines.append("## Phase Breakdown (milliseconds)")
+    lines.append("")
+    lines.append("| Metric | liric parse | liric JIT | LLVM parse | LLVM JIT |")
+    lines.append("|--------|------------:|----------:|-----------:|---------:|")
+    for label, pfn in [
+        ("Median", statistics.median),
+        ("Mean", statistics.mean),
+        ("P90", lambda d: percentile(d, 90)),
+        ("P95", lambda d: percentile(d, 95)),
+    ]:
+        lines.append(
+            f"| {label} | {pfn(liric_parse):.3f} | {pfn(liric_jit):.3f} | "
+            f"{pfn(llvm_parse):.3f} | {pfn(llvm_jit):.3f} |"
+        )
+    lines.append("")
+
+    lines.append("## Speedup Distribution")
+    lines.append("")
+    thresholds = [50, 20, 10, 5, 2, 1]
+    for t in thresholds:
+        count = sum(1 for s in speedups if s >= t)
+        pct = 100.0 * count / len(speedups)
+        lines.append(f"- >={t}x faster: {count} ({pct:.1f}%)")
+    slower = sum(1 for s in speedups if s < 1)
+    lines.append(f"- liric slower: {slower} ({100.0*slower/len(speedups):.1f}%)")
+    lines.append("")
+
+    lines.append("## .ll File Size Distribution")
+    lines.append("")
+    lines.append(f"- Min: {min(sizes):,} bytes")
+    lines.append(f"- Median: {statistics.median(sizes):,.0f} bytes")
+    lines.append(f"- Mean: {statistics.mean(sizes):,.0f} bytes")
+    lines.append(f"- Max: {max(sizes):,} bytes")
+    lines.append("")
+
+    report = "\n".join(lines)
+    Path(args.output).write_text(report)
+    print(f"\nReport: {args.output}")
+    print(f"JSONL: {args.jsonl}")
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bench_llvm_jit.c
+++ b/tools/bench_llvm_jit.c
@@ -1,0 +1,177 @@
+// In-process LLVM JIT compile benchmark — matches bench_parse_vs_jit format.
+// Uses LLVM C API to parse .ll text and JIT compile, measuring each phase.
+//
+// Build:
+//   cc -O2 -o build/bench_llvm_jit tools/bench_llvm_jit.c \
+//      $(llvm-config --cflags --ldflags --libs core orcjit native irreader) \
+//      -lm -lstdc++
+
+#include <llvm-c/Core.h>
+#include <llvm-c/IRReader.h>
+#include <llvm-c/LLJIT.h>
+#include <llvm-c/Target.h>
+#include <llvm-c/TargetMachine.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+static double now_ms(void) {
+    static mach_timebase_info_data_t info = {0, 0};
+    if (info.denom == 0) mach_timebase_info(&info);
+    uint64_t t = mach_absolute_time();
+    return (double)(t * info.numer / info.denom) / 1e6;
+}
+#else
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
+}
+#endif
+
+static char *read_file(const char *path, size_t *out_len) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc((size_t)len + 1);
+    if (!buf) { fclose(f); return NULL; }
+    size_t n = fread(buf, 1, (size_t)len, f);
+    buf[n] = '\0';
+    fclose(f);
+    *out_len = n;
+    return buf;
+}
+
+int main(int argc, char **argv) {
+    int iters = 1;
+    int json_output = 0;
+    const char *input_file = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--iters") == 0 && i + 1 < argc)
+            iters = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--json") == 0)
+            json_output = 1;
+        else if (argv[i][0] != '-')
+            input_file = argv[i];
+        else {
+            fprintf(stderr, "usage: bench_llvm_jit [--iters N] [--json] file.ll\n");
+            return 1;
+        }
+    }
+
+    if (!input_file) {
+        fprintf(stderr, "usage: bench_llvm_jit [--iters N] [--json] file.ll\n");
+        return 1;
+    }
+
+    size_t src_len;
+    char *src = read_file(input_file, &src_len);
+    if (!src) {
+        fprintf(stderr, "failed to read %s\n", input_file);
+        return 1;
+    }
+
+    LLVMInitializeNativeTarget();
+    LLVMInitializeNativeAsmPrinter();
+
+    double parse_total = 0, jit_total = 0;
+
+    for (int iter = 0; iter < iters; iter++) {
+        LLVMContextRef ctx = LLVMContextCreate();
+        LLVMMemoryBufferRef buf = LLVMCreateMemoryBufferWithMemoryRangeCopy(
+            src, src_len, "input");
+        LLVMModuleRef mod = NULL;
+        char *err_msg = NULL;
+
+        double t0 = now_ms();
+        if (LLVMParseIRInContext(ctx, buf, &mod, &err_msg)) {
+            if (json_output)
+                printf("{\"file\":\"%s\",\"error\":\"parse: %s\"}\n",
+                       input_file, err_msg ? err_msg : "unknown");
+            else
+                fprintf(stderr, "parse error: %s\n", err_msg ? err_msg : "unknown");
+            LLVMDisposeMessage(err_msg);
+            LLVMContextDispose(ctx);
+            free(src);
+            return 1;
+        }
+        double t1 = now_ms();
+        parse_total += (t1 - t0);
+
+        LLVMOrcLLJITRef jit = NULL;
+        LLVMErrorRef e = LLVMOrcCreateLLJIT(&jit, NULL);
+        if (e) {
+            char *msg = LLVMGetErrorMessage(e);
+            fprintf(stderr, "LLJIT create error: %s\n", msg);
+            LLVMDisposeErrorMessage(msg);
+            LLVMDisposeModule(mod);
+            LLVMContextDispose(ctx);
+            free(src);
+            return 1;
+        }
+
+        LLVMOrcThreadSafeContextRef ts_ctx = LLVMOrcCreateNewThreadSafeContext();
+        LLVMOrcThreadSafeModuleRef ts_mod =
+            LLVMOrcCreateNewThreadSafeModule(mod, ts_ctx);
+
+        double t2 = now_ms();
+        LLVMOrcJITDylibRef dylib = LLVMOrcLLJITGetMainJITDylib(jit);
+        e = LLVMOrcLLJITAddLLVMIRModule(jit, dylib, ts_mod);
+        if (e) {
+            char *msg = LLVMGetErrorMessage(e);
+            if (json_output)
+                printf("{\"file\":\"%s\",\"error\":\"jit: %s\"}\n", input_file, msg);
+            else
+                fprintf(stderr, "JIT error: %s\n", msg);
+            LLVMDisposeErrorMessage(msg);
+            LLVMOrcDisposeLLJIT(jit);
+            LLVMOrcDisposeThreadSafeContext(ts_ctx);
+            LLVMContextDispose(ctx);
+            free(src);
+            return 1;
+        }
+
+        LLVMOrcExecutorAddress addr = 0;
+        e = LLVMOrcLLJITLookup(jit, &addr, "main");
+        double t3 = now_ms();
+
+        if (e) {
+            LLVMDisposeErrorMessage(LLVMGetErrorMessage(e));
+        }
+
+        jit_total += (t3 - t2);
+
+        LLVMOrcDisposeLLJIT(jit);
+        LLVMOrcDisposeThreadSafeContext(ts_ctx);
+        LLVMContextDispose(ctx);
+    }
+
+    double parse_avg = parse_total / iters;
+    double jit_avg = jit_total / iters;
+    double total_avg = parse_avg + jit_avg;
+    double parse_pct = total_avg > 0 ? 100.0 * parse_avg / total_avg : 100.0;
+
+    if (json_output) {
+        printf("{\"file\":\"%s\",\"ll_bytes\":%zu,"
+               "\"parse_ms\":%.3f,\"jit_ms\":%.3f,\"total_ms\":%.3f,"
+               "\"parse_pct\":%.1f,\"iters\":%d}\n",
+               input_file, src_len, parse_avg, jit_avg, total_avg,
+               parse_pct, iters);
+    } else {
+        printf("file:      %s\n", input_file);
+        printf("ll_bytes:  %zu\n", src_len);
+        printf("parse:     %.3f ms (%.1f%%)\n", parse_avg, parse_pct);
+        printf("jit:       %.3f ms (%.1f%%)\n", jit_avg, 100.0 - parse_pct);
+        printf("total:     %.3f ms\n", total_avg);
+        printf("iters:     %d\n", iters);
+    }
+
+    free(src);
+    return 0;
+}

--- a/tools/bench_parse_overhead.py
+++ b/tools/bench_parse_overhead.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Measure text-parse overhead across lfortran mass-test .ll files.
+
+For each passing test, runs bench_parse_vs_jit to measure parse time vs JIT time.
+The parse fraction represents the speedup achievable by the C builder API
+(which eliminates text parsing entirely).
+
+Usage:
+    python3 -m tools.bench_parse_overhead [--results PATH] [--iters N] [--output PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load_passing_ll_files(results_path: Path) -> list[str]:
+    paths = []
+    with open(results_path) as f:
+        for line in f:
+            r = json.loads(line)
+            if r.get("classification") == "pass" and r.get("jit_cmd"):
+                for token in r["jit_cmd"].split():
+                    if token.endswith(".ll"):
+                        if Path(token).exists():
+                            paths.append(token)
+                        break
+    return paths
+
+
+def percentile(data: list[float], p: float) -> float:
+    if not data:
+        return 0.0
+    s = sorted(data)
+    k = (len(s) - 1) * p / 100.0
+    f = int(k)
+    c = min(f + 1, len(s) - 1)
+    return s[f] + (k - f) * (s[c] - s[f])
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark text-parse overhead")
+    parser.add_argument("--results", default="/tmp/liric_lfortran_mass/results.jsonl")
+    parser.add_argument("--iters", type=int, default=3)
+    parser.add_argument("--output", default="/tmp/parse_overhead_results.md")
+    parser.add_argument("--bench-bin", default=None,
+                        help="Path to bench_parse_vs_jit binary")
+    parser.add_argument("--workers", type=int, default=1)
+    args = parser.parse_args()
+
+    bench_bin = args.bench_bin
+    if not bench_bin:
+        candidates = [
+            Path(__file__).resolve().parent.parent / "build" / "bench_parse_vs_jit",
+        ]
+        for c in candidates:
+            if c.exists():
+                bench_bin = str(c)
+                break
+    if not bench_bin or not Path(bench_bin).exists():
+        print("ERROR: bench_parse_vs_jit not found. Build first.", file=sys.stderr)
+        sys.exit(1)
+
+    results_path = Path(args.results)
+    if not results_path.exists():
+        print(f"ERROR: {results_path} not found. Run mass tests first.", file=sys.stderr)
+        sys.exit(1)
+
+    ll_files = load_passing_ll_files(results_path)
+    print(f"Found {len(ll_files)} passing .ll files")
+
+    results = []
+    errors = 0
+    for i, ll_path in enumerate(ll_files):
+        try:
+            p = subprocess.run(
+                [bench_bin, "--json", "--iters", str(args.iters), ll_path],
+                capture_output=True, text=True, timeout=30
+            )
+            if p.returncode == 0 and p.stdout.strip():
+                r = json.loads(p.stdout.strip())
+                if "error" not in r:
+                    results.append(r)
+                else:
+                    errors += 1
+            else:
+                errors += 1
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+            errors += 1
+
+        if (i + 1) % 200 == 0:
+            print(f"  {i+1}/{len(ll_files)} done, {len(results)} ok, {errors} errors")
+
+    print(f"\nCompleted: {len(results)} measured, {errors} errors")
+
+    if not results:
+        print("ERROR: no results", file=sys.stderr)
+        sys.exit(1)
+
+    parse_times = [r["parse_ms"] for r in results]
+    jit_times = [r["jit_ms"] for r in results]
+    total_times = [r["total_ms"] for r in results]
+    parse_pcts = [r["parse_pct"] for r in results]
+    ll_sizes = [r["ll_bytes"] for r in results]
+
+    lines = []
+    lines.append("# Text-Parse Overhead Analysis")
+    lines.append("")
+    lines.append(f"- **Tests measured:** {len(results)}")
+    lines.append(f"- **Iterations per test:** {args.iters}")
+    lines.append(f"- **Total parse time:** {sum(parse_times):.1f} ms")
+    lines.append(f"- **Total JIT time:** {sum(jit_times):.1f} ms")
+    lines.append(f"- **Total time:** {sum(total_times):.1f} ms")
+    overall_pct = 100.0 * sum(parse_times) / sum(total_times) if sum(total_times) > 0 else 0
+    lines.append(f"- **Parse fraction (aggregate):** {overall_pct:.1f}%")
+    speedup = sum(total_times) / sum(jit_times) if sum(jit_times) > 0 else 0
+    lines.append(f"- **Max speedup from builder API:** {speedup:.1f}x "
+                 "(eliminates parse, keeps JIT)")
+    lines.append("")
+
+    lines.append("## Per-Test Statistics (milliseconds)")
+    lines.append("")
+    lines.append("| Metric | Parse | JIT | Total | Parse % |")
+    lines.append("|--------|------:|----:|------:|--------:|")
+    for label, pfn in [
+        ("Median", statistics.median),
+        ("Mean", statistics.mean),
+        ("P25", lambda d: percentile(d, 25)),
+        ("P75", lambda d: percentile(d, 75)),
+        ("P90", lambda d: percentile(d, 90)),
+        ("P95", lambda d: percentile(d, 95)),
+        ("Min", min),
+        ("Max", max),
+    ]:
+        lines.append(
+            f"| {label} | {pfn(parse_times):.3f} | {pfn(jit_times):.3f} | "
+            f"{pfn(total_times):.3f} | {pfn(parse_pcts):.1f}% |"
+        )
+    lines.append("")
+
+    lines.append("## Parse Fraction Distribution")
+    lines.append("")
+    thresholds = [90, 80, 70, 60, 50, 40, 30]
+    for t in thresholds:
+        count = sum(1 for p in parse_pcts if p >= t)
+        pct = 100.0 * count / len(parse_pcts)
+        lines.append(f"- >={t}% parse overhead: {count} tests ({pct:.1f}%)")
+    lines.append("")
+
+    lines.append("## Top 10 Highest Parse Overhead")
+    lines.append("")
+    lines.append("| File | Size | Parse ms | JIT ms | Total ms | Parse % |")
+    lines.append("|------|-----:|---------:|-------:|---------:|--------:|")
+    sorted_by_pct = sorted(results, key=lambda x: -x["parse_pct"])
+    for r in sorted_by_pct[:10]:
+        fn = Path(r["file"]).name
+        lines.append(
+            f"| {fn} | {r['ll_bytes']:,} | {r['parse_ms']:.3f} | "
+            f"{r['jit_ms']:.3f} | {r['total_ms']:.3f} | {r['parse_pct']:.1f}% |"
+        )
+    lines.append("")
+
+    lines.append("## Top 10 Lowest Parse Overhead")
+    lines.append("")
+    lines.append("| File | Size | Parse ms | JIT ms | Total ms | Parse % |")
+    lines.append("|------|-----:|---------:|-------:|---------:|--------:|")
+    sorted_by_pct_asc = sorted(results, key=lambda x: x["parse_pct"])
+    for r in sorted_by_pct_asc[:10]:
+        fn = Path(r["file"]).name
+        lines.append(
+            f"| {fn} | {r['ll_bytes']:,} | {r['parse_ms']:.3f} | "
+            f"{r['jit_ms']:.3f} | {r['total_ms']:.3f} | {r['parse_pct']:.1f}% |"
+        )
+    lines.append("")
+
+    report = "\n".join(lines)
+    Path(args.output).write_text(report)
+    print(f"\nReport written to {args.output}")
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bench_parse_vs_jit.c
+++ b/tools/bench_parse_vs_jit.c
@@ -6,11 +6,21 @@
 #include <string.h>
 #include <time.h>
 
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+static double now_ms(void) {
+    static mach_timebase_info_data_t info = {0, 0};
+    if (info.denom == 0) mach_timebase_info(&info);
+    uint64_t t = mach_absolute_time();
+    return (double)(t * info.numer / info.denom) / 1e6;
+}
+#else
 static double now_ms(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
 }
+#endif
 
 static char *read_file(const char *path, size_t *out_len) {
     FILE *f = fopen(path, "rb");

--- a/tools/bench_parse_vs_jit.c
+++ b/tools/bench_parse_vs_jit.c
@@ -1,0 +1,136 @@
+#include "../src/ir.h"
+#include "../src/ll_parser.h"
+#include "../src/jit.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
+}
+
+static char *read_file(const char *path, size_t *out_len) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc((size_t)len + 1);
+    if (!buf) { fclose(f); return NULL; }
+    size_t n = fread(buf, 1, (size_t)len, f);
+    buf[n] = '\0';
+    fclose(f);
+    *out_len = n;
+    return buf;
+}
+
+int main(int argc, char **argv) {
+    int iters = 1;
+    int json_output = 0;
+    const char *input_file = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--iters") == 0 && i + 1 < argc)
+            iters = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--json") == 0)
+            json_output = 1;
+        else if (argv[i][0] != '-')
+            input_file = argv[i];
+        else {
+            fprintf(stderr, "usage: bench_parse_vs_jit [--iters N] [--json] file.ll\n");
+            return 1;
+        }
+    }
+
+    if (!input_file) {
+        fprintf(stderr, "usage: bench_parse_vs_jit [--iters N] [--json] file.ll\n");
+        return 1;
+    }
+
+    size_t src_len;
+    char *src = read_file(input_file, &src_len);
+    if (!src) {
+        fprintf(stderr, "failed to read %s\n", input_file);
+        return 1;
+    }
+
+    double parse_total = 0, jit_total = 0;
+    int num_funcs = 0;
+
+    for (int iter = 0; iter < iters; iter++) {
+        char err[512] = {0};
+
+        double t0 = now_ms();
+        lr_arena_t *arena = lr_arena_create(0);
+        lr_module_t *m = lr_parse_ll_text(src, src_len, arena, err, sizeof(err));
+        double t1 = now_ms();
+
+        if (!m) {
+            if (json_output)
+                printf("{\"file\":\"%s\",\"error\":\"parse: %s\"}\n", input_file, err);
+            else
+                fprintf(stderr, "parse error: %s\n", err);
+            lr_arena_destroy(arena);
+            free(src);
+            return 1;
+        }
+
+        if (iter == 0) {
+            for (lr_func_t *fn = m->first_func; fn; fn = fn->next)
+                num_funcs++;
+        }
+
+        lr_jit_t *jit = lr_jit_create();
+        if (!jit) {
+            lr_arena_destroy(arena);
+            free(src);
+            return 1;
+        }
+
+        double t2 = now_ms();
+        int rc = lr_jit_add_module(jit, m);
+        double t3 = now_ms();
+
+        lr_jit_destroy(jit);
+        lr_arena_destroy(arena);
+
+        if (rc != 0) {
+            if (json_output)
+                printf("{\"file\":\"%s\",\"error\":\"jit\"}\n", input_file);
+            else
+                fprintf(stderr, "JIT compilation failed\n");
+            free(src);
+            return 1;
+        }
+
+        parse_total += (t1 - t0);
+        jit_total += (t3 - t2);
+    }
+
+    double parse_avg = parse_total / iters;
+    double jit_avg = jit_total / iters;
+    double total_avg = parse_avg + jit_avg;
+    double parse_pct = total_avg > 0 ? 100.0 * parse_avg / total_avg : 0;
+
+    if (json_output) {
+        printf("{\"file\":\"%s\",\"ll_bytes\":%zu,\"num_funcs\":%d,"
+               "\"parse_ms\":%.3f,\"jit_ms\":%.3f,\"total_ms\":%.3f,"
+               "\"parse_pct\":%.1f,\"iters\":%d}\n",
+               input_file, src_len, num_funcs,
+               parse_avg, jit_avg, total_avg, parse_pct, iters);
+    } else {
+        printf("file:      %s\n", input_file);
+        printf("ll_bytes:  %zu\n", src_len);
+        printf("num_funcs: %d\n", num_funcs);
+        printf("parse:     %.3f ms (%.1f%%)\n", parse_avg, parse_pct);
+        printf("jit:       %.3f ms (%.1f%%)\n", jit_avg, 100.0 - parse_pct);
+        printf("total:     %.3f ms\n", total_avg);
+        printf("iters:     %d\n", iters);
+    }
+
+    free(src);
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add complete C builder API (`include/liric/liric.h`) with 50+ functions for constructing IR programmatically
- Implement all builder functions in `src/builder.c` bridging public API to internal IR
- Add 9 end-to-end builder tests (ret, add, arithmetic, branch, loop/phi, alloca/load/store, call, select, roundtrip)
- Add parse-overhead benchmark tooling measuring text-parse vs JIT time split

## Why

The text-parse overhead (lexer + parser) accounts for 40-80% of total compile time. The builder API eliminates this entirely, giving 1.7-9x speedup for callers like LFortran that generate IR programmatically.

## Benchmark Results (520 LFortran tests)

| Metric | Parse | JIT | Total | Parse % |
|--------|------:|----:|------:|--------:|
| Median | 0.091 ms | 0.138 ms | 0.234 ms | 42.2% |
| Mean | 0.194 ms | 0.286 ms | 0.480 ms | 46.5% |
| P90 | 0.394 ms | 0.604 ms | 0.948 ms | 79.6% |

- 57% of tests have >=40% parse overhead
- 13% of tests have >=70% parse overhead

## Files Changed

- `include/liric/liric.h`: Extended public API with type constructors, function/block management, 40+ instruction builders, globals, JIT lifecycle
- `src/builder.c`: Implementation bridging public operand descriptors to internal IR types
- `tests/test_builder.c`: 9 tests covering all major builder features
- `tests/test_main.c`: Register new tests
- `CMakeLists.txt`: Add builder.c to library, test_builder.c to tests, bench tool
- `tools/bench_parse_vs_jit.c`: C microbenchmark measuring parse vs JIT time
- `tools/bench_parse_overhead.py`: Python aggregator across mass test corpus
- `README.md`: Document builder API with example and benchmark data

## Tests

All 80 tests pass (71 existing + 9 new builder tests).