### PR TITLE
perf(parser): optimize lexer/parser hot paths and add split benchmark summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,32 +79,39 @@ Outputs are written to `/tmp/liric_bench/`:
 - `compat_api.txt`
 - `compat_ll.txt`
 - `bench_ll.jsonl`
+- `bench_ll_summary.json`
 
 Latest run (February 8, 2026, CachyOS x86_64, `lfortran` LLVM backend, `lli -O0`):
 
 - Compatibility sweep (`bench_compat_check`):
   - Processed: `2266`
   - `llvm_ok`: `2246` (99.1%)
-  - `liric_match`: `1027` (45.3%)
-  - `lli_match`: `2166` (95.6%)
-  - `both_match` (`compat_ll`): `1014` (44.7%)
+  - `liric_match`: `1025` (45.2%)
+  - `lli_match`: `2162` (95.4%)
+  - `both_match` (`compat_ll`): `1013` (44.7%)
 
 - LL benchmark (`bench_ll --iters 3`) on `compat_ll`:
-  - Benchmarked files: `989`
+  - Benchmarked files: `988`
 
 | Metric | liric wall | lli wall | Wall speedup |
 |--------|-----------:|---------:|-------------:|
-| Median | 10.065 ms | 20.121 ms | **2.00x** |
-| Aggregate | 10045 ms | 20855 ms | 2.08x |
+| Median | 10.064 ms | 20.120 ms | **2.00x** |
+| Aggregate | 10024 ms | 20606 ms | 2.06x |
 | P90 / P95 | - | - | 2.00x / 3.00x |
 
 | Metric | liric internal | lli internal | Internal speedup |
 |--------|---------------:|-------------:|-----------------:|
-| Median | 0.383600 ms | 0.226347 ms | **0.52x** |
-| Aggregate | 659.689 ms | 312.038 ms | 0.47x |
+| Median | 0.368150 ms | 0.223440 ms | **0.54x** |
+| Aggregate | 590.492 ms | 309.075 ms | 0.52x |
 | P90 / P95 | - | - | 0.66x / 0.70x |
 
-The internal metric is now fair (in-process parse+compile vs in-process parse+compile).
+| Internal Split (median) | liric | lli |
+|-------------------------|------:|----:|
+| parse | 0.315400 ms | 0.220214 ms |
+| compile/jit | 0.054450 ms | 0.003066 ms |
+| lookup/materialization | n/a | 3.331356 ms |
+
+The internal metric remains parse+compile parity (`liric`: parse+compile vs `LLVM`: parse+jit). `bench_ll_summary.json` additionally tracks `parse+jit+lookup` for LLVM materialization visibility.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Benchmark flow is fully C-based:
 ./build/bench_ll --iters 3
 ```
 
+Both harnesses run executed test binaries in isolated temporary working
+directories under `/tmp/liric_bench/` to avoid polluting the repository root
+with runtime-generated files.
+
 3. The fair in-process LLVM phase timer used by `bench_ll`:
 ```bash
 ./build/bench_lli_phases --json --iters 1 --sig i32_argc_argv /tmp/liric_bench/ll/<test>.ll

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Latest run (February 8, 2026, CachyOS x86_64, `lfortran` LLVM backend, `lli -O0`
 | Aggregate | 10024 ms | 20606 ms | 2.06x |
 | P90 / P95 | - | - | 2.00x / 3.00x |
 
-| Metric | liric internal | lli internal | Internal speedup |
+| Metric | liric parse+compile | lli parse+jit | Legacy speedup |
 |--------|---------------:|-------------:|-----------------:|
 | Median | 0.368150 ms | 0.223440 ms | **0.54x** |
 | Aggregate | 590.492 ms | 309.075 ms | 0.52x |
@@ -115,7 +115,9 @@ Latest run (February 8, 2026, CachyOS x86_64, `lfortran` LLVM backend, `lli -O0`
 | compile/jit | 0.054450 ms | 0.003066 ms |
 | lookup/materialization | n/a | 3.331356 ms |
 
-The internal metric remains parse+compile parity (`liric`: parse+compile vs `LLVM`: parse+jit). `bench_ll_summary.json` additionally tracks `parse+jit+lookup` for LLVM materialization visibility.
+`bench_ll` now uses materialization-fair internal speedup as the primary metric:
+`liric` parse+compile+lookup vs `LLVM` parse+jit+lookup. The parse+compile vs
+parse+jit value is still emitted as a legacy metric for diagnostic use.
 
 ## License
 

--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -130,8 +130,9 @@ These do NOT depend on mass run results; they discover tests directly from CMake
    ```
    Reports two metrics:
    - WALL-CLOCK: subprocess `liric_probe_runner` vs subprocess `lli -O0`
-   - JIT-INTERNAL: in-process `liric` parse+compile vs in-process LLVM ORC parse+jit
-   Also writes split summary (`parse`, `compile/jit`, LLVM `lookup`) to
+   - JIT-INTERNAL (fair): in-process `liric` parse+compile+lookup vs in-process LLVM ORC parse+jit+lookup
+   Also writes split summary (`parse`, `compile/jit`, `lookup`) plus legacy
+   parse+compile-vs-parse+jit speedup to
    `/tmp/liric_bench/bench_ll_summary.json`.
 
 3. **Optional per-file LLVM in-process phase timing**:

--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -120,6 +120,8 @@ These do NOT depend on mass run results; they discover tests directly from CMake
    ```
    Runs each eligible integration test through lfortran LLVM native, liric JIT, and lli.
    Only tests producing identical output are included in benchmarks.
+   Executed binaries run in isolated temp workdirs under `/tmp/liric_bench/`
+   so benchmark runs do not leave generated files in the repo root.
    Outputs: `/tmp/liric_bench/compat_api.txt`, `/tmp/liric_bench/compat_ll.txt`
 
 2. **LL-file benchmark** (liric JIT vs LLVM lli):

--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -128,7 +128,9 @@ These do NOT depend on mass run results; they discover tests directly from CMake
    ```
    Reports two metrics:
    - WALL-CLOCK: subprocess `liric_probe_runner` vs subprocess `lli -O0`
-   - JIT-INTERNAL: in-process `liric` parse+compile vs in-process LLVM ORC parse+compile
+   - JIT-INTERNAL: in-process `liric` parse+compile vs in-process LLVM ORC parse+jit
+   Also writes split summary (`parse`, `compile/jit`, LLVM `lookup`) to
+   `/tmp/liric_bench/bench_ll_summary.json`.
 
 3. **Optional per-file LLVM in-process phase timing**:
    ```bash
@@ -146,3 +148,4 @@ All artifacts in `/tmp/liric_bench/`:
 - `compat_api.txt`: test names passing liric compat
 - `compat_ll.txt`: test names passing liric + lli compat
 - `bench_ll.jsonl`: LL-file benchmark timing data
+- `bench_ll_summary.json`: aggregate medians/sums including parser-vs-compile split


### PR DESCRIPTION
## Summary
- optimize `ll_lexer.c` hot path using pointer/ASCII fast scanning (reduced per-char helper overhead)
- optimize parser symbol lookup in `ll_parser.c` by using token name slices + length-aware hashed lookup (avoids repeated temporary name allocations on hot paths)
- make `bench_ll` internal metric materialization-fair by comparing `liric(parse+compile+lookup)` vs `llvm(parse+jit+lookup)`
- extend benchmark output JSON/summary with split phase medians and keep legacy parse+jit speedup as diagnostic-only
- refresh benchmark docs with the fair metric semantics and output artifacts

Closes #110
Closes #111
Closes #112

## Why
Profiles showed parser/lexer dominating internal `.ll` timing. After those optimizations, the benchmark harness still highlighted a non-equivalent internal metric (LLVM lookup excluded), so this update makes the default internal comparison fair.

## Changes
- `src/ll_lexer.c`
  - fused whitespace/comment scanning into local pointer loop
  - switched hot identifier/digit scanning to ASCII fast checks
  - reduced token construction/position updates to one write-back per token
- `src/ll_parser.c`
  - added token name-view extraction (`start,len`) to avoid temporary string duplication in hot paths
  - switched vreg/block/global lookup to length-aware hash+memcmp checks
  - updated hot parse sites (`parse_operand`, assignment dests, branch/phi labels, block labels) to use slice-based lookup
- `tools/liric_probe_runner.c`
  - separate timing for symbol lookup and execution (`lookup_us`, `exec_us`)
- `tools/bench_ll.c`
  - internal headline metric now uses materialization-equivalent phases on both sides
  - per-test JSON adds `materialization_speedup` and keeps `legacy_parse_jit_speedup`
  - summary JSON now reports `liric_materialized_*` / `lli_materialized_*` and split medians
- `README.md`, `docs/lfortran_mass_testing.md`
  - document fair internal metric semantics and updated summary contents

## Verification
```bash
cd /home/ert/code/lfortran-dev/liric
cmake -S . -B build
cmake --build build -j$(nproc)
ctest --test-dir build --output-on-failure
```
- `ctest`: 1/1 passed

```bash
cd /home/ert/code/lfortran-dev/liric
./build/bench_compat_check --timeout 15 --limit 200
./build/bench_ll --iters 1
```
- compat sweep (limited):
  - processed: `200`
  - `llvm_ok`: `196`
  - `liric_match`: `131`
  - `lli_match`: `190`
  - `both_match`: `130`
- benchmark (`128` runnable tests from `compat_ll`):
  - wall median speedup: `2.00x`
  - internal fair (materialized) median speedup: `9.54x`
  - legacy parse+compile vs parse+jit median speedup: `0.54x` (diagnostic-only)
