### PR TITLE
compat: harden BasicBlock/IRBuilder null-paths for control-flow emission

### DIFF
--- a/include/llvm/IR/Instructions.h
+++ b/include/llvm/IR/Instructions.h
@@ -30,7 +30,7 @@ public:
 
     void addIncoming(Value *V, BasicBlock *BB) {
         lc_phi_node_t *phi = lc_value_get_phi_node(impl());
-        if (phi) {
+        if (phi && BB && BB->impl_block()) {
             lc_phi_add_incoming(phi, V->impl(), BB->impl_block());
         }
     }


### PR DESCRIPTION
## Summary
- harden `IRBuilder` insertion-point state so null insert points clear stale `block_/func_`
- make `CreateBr` / `CreateCondBr` null-safe to avoid null `BasicBlock*` cascades
- set/update `detail::current_function` in function creation and function-scoped insert-point setup
- make `BasicBlock::Create(..., InsertBefore)` recover parent IR function from `InsertBefore`
- guard PHI incoming edge insertion when block pointers are null

Fixes #103

## Why
#103 tracks null basic-block/function cascades that can lead to crashes during compat API lowering. This patch removes direct null-deref paths in branch emission and stabilizes current function context propagation.

## Validation
```bash
cmake --build build -j$(nproc)
ctest --test-dir build --output-on-failure
./build/bench_compat_check --timeout 15 --limit 200
```

Observed:
- `ctest`: 1/1 passed
- `bench_compat_check --limit 200` completed successfully and produced updated `/tmp/liric_bench/compat_check.jsonl`

