### PR TITLE
compat: implement parseAssemblyString/parseAssemblyFile via liric parser

### DIFF
--- a/include/llvm/AsmParser/Parser.h
+++ b/include/llvm/AsmParser/Parser.h
@@ -3,27 +3,52 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Support/SourceMgr.h"
 #include <memory>
+#include <string>
+#include <fstream>
 
 namespace llvm {
 
-class Module;
-
 inline std::unique_ptr<Module> parseAssemblyString(
     StringRef AsmString, SMDiagnostic &Err, LLVMContext &Context) {
-    (void)AsmString;
-    (void)Context;
-    Err = SMDiagnostic("parseAssemblyString not yet implemented in liric");
-    return nullptr;
+    char parse_err[512] = {0};
+    lr_module_t *parsed = lr_parse_ll(AsmString.data(), AsmString.size(),
+                                      parse_err, sizeof(parse_err));
+    if (!parsed) {
+        Err = SMDiagnostic(parse_err[0] ? parse_err
+                                        : "parseAssemblyString failed in liric");
+        return nullptr;
+    }
+
+    std::unique_ptr<Module> M = std::make_unique<Module>("asm", Context);
+    lc_module_compat_t *compat = M->getCompat();
+    if (!compat) {
+        lr_module_free(parsed);
+        Err = SMDiagnostic("failed to create compat module wrapper");
+        return nullptr;
+    }
+
+    if (compat->mod) {
+        lr_module_free(compat->mod);
+    }
+    compat->mod = parsed;
+    if (compat->ctx) compat->ctx->mod = parsed;
+    Module::setCurrentModule(compat);
+    return M;
 }
 
 inline std::unique_ptr<Module> parseAssemblyFile(
     StringRef Filename, SMDiagnostic &Err, LLVMContext &Context) {
-    (void)Filename;
-    (void)Context;
-    Err = SMDiagnostic("parseAssemblyFile not yet implemented in liric");
-    return nullptr;
+    std::ifstream in(Filename.str(), std::ios::in | std::ios::binary);
+    if (!in) {
+        Err = SMDiagnostic("failed to open LLVM assembly file: " + Filename.str());
+        return nullptr;
+    }
+    std::string src((std::istreambuf_iterator<char>(in)),
+                    std::istreambuf_iterator<char>());
+    return parseAssemblyString(StringRef(src), Err, Context);
 }
 
 } // namespace llvm


### PR DESCRIPTION
## Summary
- implement `parseAssemblyString` by parsing LLVM IR text with `lr_parse_ll`
- create a compat `Module` wrapper and replace its IR module with parsed IR
- implement `parseAssemblyFile` by loading file contents and delegating to `parseAssemblyString`

Fixes #105

## Validation
```bash
ctest --test-dir build --output-on-failure
```
- `ctest`: 1/1 passed

Reproducer (`/tmp/repro105.cpp`):
```cpp
#include "llvm/IR/LLVMContext.h"
#include "llvm/IR/Module.h"
#include "llvm/AsmParser/Parser.h"
```

### Fails on main
```bash
g++ -std=c++17 -I/tmp/liric-main-clean/include /tmp/repro105.cpp build/libliric.a -ldl -lm -pthread -o /tmp/repro105_main_clean
/tmp/repro105_main_clean
# parse failed: parseAssemblyString not yet implemented in liric
# rc=2
```

### Passes on this branch
```bash
g++ -std=c++17 -Iinclude /tmp/repro105.cpp build/libliric.a -ldl -lm -pthread -o /tmp/repro105
/tmp/repro105
# len=42
# rc=0
```
