### PR TITLE
JIT: fix const-GEP global offsets and late vtable function relocs

### DIFF
--- a/src/builder.c
+++ b/src/builder.c
@@ -30,6 +30,7 @@ enum {
 
 static lr_operand_t desc_to_op(lr_operand_desc_t d) {
     lr_operand_t op;
+    memset(&op, 0, sizeof(op));
     op.kind = (lr_operand_kind_t)d.kind;
     op.type = d.type;
     switch (d.kind) {

--- a/src/ir.c
+++ b/src/ir.c
@@ -182,27 +182,37 @@ lr_global_t *lr_global_create(lr_module_t *m, const char *name, lr_type_t *type,
 }
 
 lr_operand_t lr_op_vreg(uint32_t vreg, lr_type_t *type) {
-    return (lr_operand_t){ .kind = LR_VAL_VREG, .vreg = vreg, .type = type };
+    return (lr_operand_t){
+        .kind = LR_VAL_VREG, .vreg = vreg, .type = type, .global_offset = 0
+    };
 }
 
 lr_operand_t lr_op_imm_i64(int64_t val, lr_type_t *type) {
-    return (lr_operand_t){ .kind = LR_VAL_IMM_I64, .imm_i64 = val, .type = type };
+    return (lr_operand_t){
+        .kind = LR_VAL_IMM_I64, .imm_i64 = val, .type = type, .global_offset = 0
+    };
 }
 
 lr_operand_t lr_op_imm_f64(double val, lr_type_t *type) {
-    return (lr_operand_t){ .kind = LR_VAL_IMM_F64, .imm_f64 = val, .type = type };
+    return (lr_operand_t){
+        .kind = LR_VAL_IMM_F64, .imm_f64 = val, .type = type, .global_offset = 0
+    };
 }
 
 lr_operand_t lr_op_block(uint32_t id) {
-    return (lr_operand_t){ .kind = LR_VAL_BLOCK, .block_id = id };
+    return (lr_operand_t){
+        .kind = LR_VAL_BLOCK, .block_id = id, .global_offset = 0
+    };
 }
 
 lr_operand_t lr_op_global(uint32_t id, lr_type_t *type) {
-    return (lr_operand_t){ .kind = LR_VAL_GLOBAL, .global_id = id, .type = type };
+    return (lr_operand_t){
+        .kind = LR_VAL_GLOBAL, .global_id = id, .type = type, .global_offset = 0
+    };
 }
 
 lr_operand_t lr_op_null(lr_type_t *type) {
-    return (lr_operand_t){ .kind = LR_VAL_NULL, .type = type };
+    return (lr_operand_t){ .kind = LR_VAL_NULL, .type = type, .global_offset = 0 };
 }
 
 uint32_t lr_module_intern_symbol(lr_module_t *m, const char *name) {
@@ -368,6 +378,10 @@ static void print_operand(const lr_operand_t *op, const lr_module_t *m,
         const char *name = lr_module_symbol_name(m, op->global_id);
         if (name) fprintf(out, "@%s", name);
         else fprintf(out, "@g%u", op->global_id);
+        if (op->global_offset > 0)
+            fprintf(out, "+%ld", (long)op->global_offset);
+        else if (op->global_offset < 0)
+            fprintf(out, "%ld", (long)op->global_offset);
         break;
     }
     case LR_VAL_NULL:    fprintf(out, "null"); break;

--- a/src/ir.h
+++ b/src/ir.h
@@ -100,6 +100,7 @@ typedef enum lr_operand_kind {
 typedef struct lr_operand {
     lr_operand_kind_t kind;
     lr_type_t *type;
+    int64_t global_offset;
     union {
         uint32_t vreg;
         int64_t imm_i64;
@@ -150,6 +151,7 @@ typedef struct lr_func {
 
 typedef struct lr_reloc {
     size_t offset;
+    int64_t addend;
     char *symbol_name;
     struct lr_reloc *next;
 } lr_reloc_t;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -81,6 +81,7 @@ int test_jit_internal_global_address_relocation(void);
 int test_jit_external_call_abs(void);
 int test_jit_varargs_printf_call(void);
 int test_jit_varargs_printf_double_call(void);
+int test_jit_const_gep_vtable_function_ptr(void);
 int test_jit_llvm_intrinsic_fabs_f32(void);
 int test_jit_llvm_intrinsic_memcpy_memset(void);
 int test_jit_gep_struct_field(void);
@@ -193,6 +194,7 @@ int main(void) {
     RUN_TEST(test_jit_external_call_abs);
     RUN_TEST(test_jit_varargs_printf_call);
     RUN_TEST(test_jit_varargs_printf_double_call);
+    RUN_TEST(test_jit_const_gep_vtable_function_ptr);
     RUN_TEST(test_jit_llvm_intrinsic_fabs_f32);
     RUN_TEST(test_jit_llvm_intrinsic_memcpy_memset);
     RUN_TEST(test_jit_gep_struct_field);


### PR DESCRIPTION
## Summary
- preserve const-GEP byte offsets on global operands in the LLVM IR parser
- carry global offsets through JIT global symbol resolution
- re-apply global relocations after function compilation so globals/vtables pointing to module-defined functions are patched correctly
- add regression test for const-GEP vtable-style indirect function call

Refs #78

## Why
A major remaining SIGSEGV class came from globals/vtables containing function pointers that were still null at call time. The root cause was relocation timing and dropped const-GEP addends.

## Changes
- `src/ir.h`: add `global_offset` on operands and `addend` on global reloc entries
- `src/ir.c`: initialize/print `global_offset` in operands
- `src/ll_parser.c`: compute and preserve constant GEP byte offsets for global operands; store relocation addends
- `src/jit.c`: apply global relocation addends and re-apply global relocs after compiled function symbols are available
- `src/target_x86_64.c`: honor global operand offsets in object-path address loads
- `src/builder.c`: zero-initialize converted operands for struct field safety
- `tests/test_jit.c`, `tests/test_main.c`: new regression `test_jit_const_gep_vtable_function_ptr`

## Verification
```bash
$ cmake --build build -j$(nproc)
$ ctest --test-dir build --output-on-failure
100% tests passed, 0 tests failed out of 1
```

Targeted repro:
- `class_01` changed from SIGSEGV to `rc=0` with matching output.

Segfault-cluster retest (class bucket previously failing):
- total: 37
- now passing: 33
- still segfault: 4 (`class_04`, `class_38`, `class_39`, `class_40`)

Latest bounded compatibility run (limit 400):
- `liric_match`: 337
- `both_match`: 333
- `liric rc=-11`: 10

#78 remains open for the remaining crash buckets.
