### PR TITLE
parser: resolve forward named by-value types (fix class segfaults)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -44,6 +44,7 @@ int test_parser_typed_pointer_decl_params(void);
 int test_parser_add(void);
 int test_parser_typed_call_and_dot_label(void);
 int test_parser_named_type_operand(void);
+int test_parser_forward_named_type_by_value(void);
 int test_parser_decl_with_modern_param_attrs(void);
 int test_parser_store_with_const_gep_operand(void);
 int test_parser_call_arg_with_align_attr(void);
@@ -151,6 +152,7 @@ int main(void) {
     RUN_TEST(test_parser_add);
     RUN_TEST(test_parser_typed_call_and_dot_label);
     RUN_TEST(test_parser_named_type_operand);
+    RUN_TEST(test_parser_forward_named_type_by_value);
     RUN_TEST(test_parser_decl_with_modern_param_attrs);
     RUN_TEST(test_parser_store_with_const_gep_operand);
     RUN_TEST(test_parser_call_arg_with_align_attr);


### PR DESCRIPTION
## Summary
- add forward named-type placeholders in the LLVM IR parser instead of collapsing unresolved `%name` to `ptr`
- backfill placeholders when the real type alias is parsed, so by-value layouts/sizes become correct
- add parser regression test for forward by-value named types (`%A = { %B }`, `%B = { i64, i64 }`)

## Why
Class segfaults were caused by incorrect struct sizes when a named type was referenced by value before its definition. That produced undersized stack allocas and overlapping locals at JIT runtime.

## Verification
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`
- Repro probes (all now `rc=0`):
  - `class_04`
  - `class_38`
  - `class_39`
  - `class_40`
- LFortran native outputs for the same 4 tests match the new liric outputs.

## Notes
- This is a focused incremental fix toward issue #78; it removes one concrete SIGSEGV root cause in class-heavy cases.
