### PR TITLE
x86_64: fix aggregate load/store spill handling (78 progress)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -90,6 +90,7 @@ int test_jit_gep_array_index(void);
 int test_jit_global_string_constant(void);
 int test_jit_global_struct_ptr_relocation(void);
 int test_jit_global_struct_integer_init(void);
+int test_jit_aggregate_load_store_copy(void);
 int test_jit_call_stack_args(void);
 int test_jit_call_many_stack_args(void);
 int test_jit_fsub_double(void);
@@ -204,6 +205,7 @@ int main(void) {
     RUN_TEST(test_jit_global_string_constant);
     RUN_TEST(test_jit_global_struct_ptr_relocation);
     RUN_TEST(test_jit_global_struct_integer_init);
+    RUN_TEST(test_jit_aggregate_load_store_copy);
     RUN_TEST(test_jit_call_stack_args);
     RUN_TEST(test_jit_call_many_stack_args);
     RUN_TEST(test_jit_fsub_double);


### PR DESCRIPTION
## Summary
- make x86_64 aggregate value handling explicit for `load`/`store` values larger than 8 bytes
- add safe byte-copy and zero-fill paths for aggregate memory transfers
- add a JIT regression test for aggregate load/store copy behavior

## Why
Remaining #78 segfaults were dominated by runtime paths that move packed descriptors (`{ptr,i64}`) through aggregate loads/stores. The previous backend treated most vreg traffic as scalar 8-byte values, which could corrupt aggregate payloads and crash runtime formatting paths.

## What changed
- `src/target_x86_64.c`
  - add aggregate-aware mem copy helpers
  - teach `LR_OP_LOAD` to copy full aggregate payloads into vreg spill slots when `type_size > 8`
  - teach `LR_OP_STORE` to copy aggregate payloads from spill slots, with safe partial-copy + zero-fill fallback
  - keep scalar paths unchanged for <=8-byte values
- `tests/test_jit.c`
  - add `test_jit_aggregate_load_store_copy`
- `tests/test_main.c`
  - register the new JIT test

## Validation
- `cmake --build build -j$(nproc)`
- `./build/test_liric` (97/97 passed)
- `./build/bench_compat_check --timeout 15`

## Compatibility impact (`bench_compat_check`)
- before (main baseline):
  - `liric_match`: 1777
  - LLVM-comparable segfaults (`liric_rc=-11 && llvm_rc=0`): 81
- after (this branch):
  - `liric_match`: 1888
  - LLVM-comparable segfaults: 10

Refs #78
