### PR TITLE
refactor: share target semantics for x86_64 and aarch64

### DIFF
--- a/src/ir.h
+++ b/src/ir.h
@@ -125,6 +125,20 @@ typedef struct lr_inst {
     struct lr_inst *next;
 } lr_inst_t;
 
+typedef struct lr_phi_copy {
+    uint32_t dest_vreg;
+    lr_operand_t src_op;
+    struct lr_phi_copy *next;
+} lr_phi_copy_t;
+
+typedef struct lr_gep_step {
+    bool is_const;
+    int64_t const_byte_offset;
+    size_t runtime_elem_size;
+    uint8_t runtime_signext_bytes;
+    const lr_type_t *next_type;
+} lr_gep_step_t;
+
 typedef struct lr_block {
     char *name;
     uint32_t id;
@@ -222,6 +236,11 @@ const char *lr_module_symbol_name(const lr_module_t *m, uint32_t id);
 
 size_t lr_type_size(const lr_type_t *t);
 size_t lr_type_align(const lr_type_t *t);
+size_t lr_struct_field_offset(const lr_type_t *st, uint32_t field_idx);
+lr_phi_copy_t **lr_build_phi_copies(lr_arena_t *arena, lr_func_t *func);
+uint8_t lr_gep_index_signext_bytes(const lr_operand_t *idx_op);
+bool lr_gep_analyze_step(const lr_type_t *cur_ty, bool first_index,
+                         const lr_operand_t *idx_op, lr_gep_step_t *out);
 
 void lr_module_dump(lr_module_t *m, FILE *out);
 


### PR DESCRIPTION
## Summary
- extract target-neutral semantic helpers into `ir.c` / `ir.h`
- remove duplicated PHI-copy construction, struct field offset math, and GEP semantic walking from both backends
- keep ISA emission local in `target_x86_64.c` and `target_aarch64.c`

Fixes #127

## What changed
- `src/ir.h`
  - add `lr_phi_copy_t` and `lr_gep_step_t`
  - add shared helper APIs:
    - `lr_build_phi_copies()`
    - `lr_struct_field_offset()`
    - `lr_gep_index_signext_bytes()`
    - `lr_gep_analyze_step()`
- `src/ir.c`
  - implement the shared helpers above
- `src/target_x86_64.c`
  - switch PHI-copy construction to `lr_build_phi_copies()`
  - switch GEP semantic analysis to `lr_gep_analyze_step()`
- `src/target_aarch64.c`
  - switch PHI-copy construction to `lr_build_phi_copies()`
  - switch GEP semantic analysis to `lr_gep_analyze_step()`
  - keep arm64 sign-extension emission local via short helper (`emit_signext_index_reg`)
- `src/ll_parser.c`
  - remove local `struct_field_offset` duplicate and use `lr_struct_field_offset()`

## Why this shape
- semantic policy is now centralized once
- backend files keep only architecture-specific emission
- no MIR and no extra compile-stage pass added

## Verification
```bash
cmake --build build -j$(nproc)
./build/test_liric
# 98 tests: 98 passed, 0 failed
```
