### PR TITLE
parser: enforce canonical i64 runtime GEP indices

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -45,6 +45,7 @@ int test_parser_add(void);
 int test_parser_typed_call_and_dot_label(void);
 int test_parser_named_type_operand(void);
 int test_parser_forward_named_type_by_value(void);
+int test_parser_gep_runtime_index_canonicalized_i64(void);
 int test_parser_decl_with_modern_param_attrs(void);
 int test_parser_store_with_const_gep_operand(void);
 int test_parser_call_arg_with_align_attr(void);
@@ -155,6 +156,7 @@ int main(void) {
     RUN_TEST(test_parser_typed_call_and_dot_label);
     RUN_TEST(test_parser_named_type_operand);
     RUN_TEST(test_parser_forward_named_type_by_value);
+    RUN_TEST(test_parser_gep_runtime_index_canonicalized_i64);
     RUN_TEST(test_parser_decl_with_modern_param_attrs);
     RUN_TEST(test_parser_store_with_const_gep_operand);
     RUN_TEST(test_parser_call_arg_with_align_attr);


### PR DESCRIPTION
## Summary
- enforce a stricter IR contract for GEP at parse/build time:
  - runtime integer indices are canonicalized to explicit `i64`
  - non-`i64` runtime indices now get explicit `sext ... to i64` inserted before GEP
  - integer immediates used as GEP indices are normalized to `i64` typed operands
- add parser regression test for canonicalized runtime GEP index behavior

## Why
Backends should not infer GEP index signedness/width ad hoc. Making this explicit during IR construction keeps the IR contract tighter and reduces backend semantic branching, while preserving `.ll` compatibility.

## Changes
- `src/ll_parser.c`
  - add GEP index canonicalization helper in parser path
  - thread `func` context into `parse_instruction()` so parser can emit explicit cast instructions
- `tests/test_parser.c`
  - add `test_parser_gep_runtime_index_canonicalized_i64`
- `tests/test_main.c`
  - register the new parser test

## Verification
```bash
cmake --build build -j$(nproc)
./build/test_liric
# 99 tests: 99 passed, 0 failed
```
