### PR TITLE
refactor: share target-lowering decision helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(liric STATIC
     src/wasm_decode.c
     src/wasm_to_ir.c
     src/target_registry.c
+    src/target_common.c
     src/target_x86_64.c
     src/target_aarch64.c
     src/jit.c

--- a/src/target_common.c
+++ b/src/target_common.c
@@ -1,0 +1,91 @@
+#include "target_common.h"
+
+bool lr_target_alloca_uses_static_storage(const lr_inst_t *inst) {
+    if (!inst || inst->op != LR_OP_ALLOCA) {
+        return false;
+    }
+    if (inst->num_operands == 0) {
+        return true;
+    }
+    return inst->operands[0].kind == LR_VAL_IMM_I64 &&
+           inst->operands[0].imm_i64 == 1;
+}
+
+size_t lr_target_alloca_elem_size(const lr_inst_t *inst, size_t min_size) {
+    size_t elem_size = 0;
+    if (inst && inst->type) {
+        elem_size = lr_type_size(inst->type);
+    }
+    if (elem_size < min_size) {
+        elem_size = min_size;
+    }
+    return elem_size;
+}
+
+bool lr_target_inst_has_result_slot(const lr_inst_t *inst) {
+    if (!inst) {
+        return false;
+    }
+    switch (inst->op) {
+    case LR_OP_STORE:
+    case LR_OP_BR:
+    case LR_OP_CONDBR:
+    case LR_OP_RET:
+    case LR_OP_RET_VOID:
+    case LR_OP_UNREACHABLE:
+        return false;
+    default:
+        break;
+    }
+    return inst->type && inst->type->kind != LR_TYPE_VOID;
+}
+
+size_t lr_target_inst_result_slot_size(const lr_inst_t *inst, size_t min_size) {
+    size_t slot_size = min_size;
+    if (!lr_target_inst_has_result_slot(inst)) {
+        return 0;
+    }
+    if (inst->op == LR_OP_LOAD && inst->type) {
+        size_t load_size = lr_type_size(inst->type);
+        if (load_size > slot_size) {
+            slot_size = load_size;
+        }
+    }
+    return slot_size;
+}
+
+uint8_t lr_target_cc_from_icmp(lr_icmp_pred_t pred) {
+    switch (pred) {
+    case LR_ICMP_EQ:  return LR_CC_EQ;
+    case LR_ICMP_NE:  return LR_CC_NE;
+    case LR_ICMP_SGT: return LR_CC_SGT;
+    case LR_ICMP_SGE: return LR_CC_SGE;
+    case LR_ICMP_SLT: return LR_CC_SLT;
+    case LR_ICMP_SLE: return LR_CC_SLE;
+    case LR_ICMP_UGT: return LR_CC_UGT;
+    case LR_ICMP_UGE: return LR_CC_UGE;
+    case LR_ICMP_ULT: return LR_CC_ULT;
+    case LR_ICMP_ULE: return LR_CC_ULE;
+    default:          return LR_CC_EQ;
+    }
+}
+
+uint8_t lr_target_cc_from_fcmp(lr_fcmp_pred_t pred) {
+    switch (pred) {
+    case LR_FCMP_OEQ: return LR_CC_FP_OEQ;
+    case LR_FCMP_ONE: return LR_CC_FP_ONE;
+    case LR_FCMP_OGT: return LR_CC_FP_OGT;
+    case LR_FCMP_OGE: return LR_CC_FP_OGE;
+    case LR_FCMP_OLT: return LR_CC_FP_OLT;
+    case LR_FCMP_OLE: return LR_CC_FP_OLE;
+    case LR_FCMP_ORD: return LR_CC_FP_ORD;
+    case LR_FCMP_UNO: return LR_CC_FP_UNO;
+    case LR_FCMP_UEQ: return LR_CC_FP_UEQ;
+    case LR_FCMP_UNE: return LR_CC_FP_UNE;
+    case LR_FCMP_UGT: return LR_CC_FP_UGT;
+    case LR_FCMP_UGE: return LR_CC_FP_UGE;
+    case LR_FCMP_ULT: return LR_CC_FP_ULT;
+    case LR_FCMP_ULE: return LR_CC_FP_ULE;
+    default:          return LR_CC_FP_OEQ;
+    }
+}

--- a/src/target_common.h
+++ b/src/target_common.h
@@ -1,0 +1,15 @@
+#ifndef LIRIC_TARGET_COMMON_H
+#define LIRIC_TARGET_COMMON_H
+
+#include "target.h"
+
+bool lr_target_alloca_uses_static_storage(const lr_inst_t *inst);
+size_t lr_target_alloca_elem_size(const lr_inst_t *inst, size_t min_size);
+
+bool lr_target_inst_has_result_slot(const lr_inst_t *inst);
+size_t lr_target_inst_result_slot_size(const lr_inst_t *inst, size_t min_size);
+
+uint8_t lr_target_cc_from_icmp(lr_icmp_pred_t pred);
+uint8_t lr_target_cc_from_fcmp(lr_fcmp_pred_t pred);
+
+#endif


### PR DESCRIPTION
Refactor-only duplication cleanup for shared lowering decisions between x86_64 and aarch64.