### PR TITLE
fix: keep alloca result slots pointer-sized

### DIFF
--- a/src/target_common.c
+++ b/src/target_common.c
@@ -45,6 +45,9 @@ size_t lr_target_inst_result_slot_size(const lr_inst_t *inst, size_t min_size) {
     if (!lr_target_inst_has_result_slot(inst)) {
         return 0;
     }
+    if (inst->op == LR_OP_ALLOCA) {
+        return slot_size;
+    }
     if (inst->type) {
         size_t type_size = lr_type_size(inst->type);
         if (type_size > slot_size) {


### PR DESCRIPTION
## Summary
- keep `LR_OP_ALLOCA` result-slot size at pointer width instead of using pointee/aggregate byte size
- avoid inflating backend vreg stack slot allocation for alloca results

Refs #78

## Why
`alloca` returns a pointer value. Sizing its result slot using the allocated element type can over-allocate stack slots and distort frame layout pressure in both backends.

## Changes
- `src/target_common.c`: in `lr_target_inst_result_slot_size()`, return `min_size` for `LR_OP_ALLOCA`.

## Verification
```bash
cmake --build build -j$(nproc)
ctest --test-dir build --output-on-failure
```

Targeted crash repros are still open (tracked in #78):
```bash
build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/arrays_elemental_15.ll   # rc=139
build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/character_19.ll         # rc=139
build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/dict_test_07_.ll         # rc=139
build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/dict_test_13_.ll         # rc=139
```
