### PR TITLE
fix: pre-populate miss cache for module-defined functions in JIT

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -527,6 +527,15 @@ int lr_jit_add_module(lr_jit_t *j, lr_module_t *m) {
             funcs[fi++] = f;
     }
 
+    for (uint32_t i = 0; i < nfuncs; i++) {
+        const char *name = funcs[i]->name;
+        if (name && name[0]) {
+            uint32_t hash = symbol_hash(name);
+            if (!find_symbol_entry(j, name, hash))
+                miss_cache_add(j, name, hash);
+        }
+    }
+
     /* Resolve function declarations eagerly — these are external symbols
        that will be needed during compilation (e.g., runtime functions). */
     for (lr_func_t *f = m->first_func; f; f = f->next) {


### PR DESCRIPTION
## Summary
- Pre-populate JIT miss cache for module-defined function names before the compile loop
- Prevents `dlsym` from shadowing module-defined functions with libc namesakes (e.g. Fortran's `isdigit` vs libc's `isdigit`)

Refs #78

## Why
When `main` referenced module-defined `isdigit` (takes `%string_descriptor*`, returns `i1`), `lookup_symbol` fell through to `dlsym(RTLD_DEFAULT, "isdigit")` which found libc's `isdigit(int)`. The wrong function pointer was baked into the compiled code, causing SIGSEGV when called with a pointer argument.

## Changes
- [`src/jit.c`](src/jit.c): After building the `funcs[]` array, add miss cache entries for all module-defined function names. This forces `lookup_symbol` to return NULL (triggering the compile loop's retry mechanism) instead of falling through to dlsym.

## Verification

### Test fails on main
```
$ git checkout main
$ cmake --build build -j$(nproc) && build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/character_19.ll; echo "rc=$?"
rc=139  (SIGSEGV)
```

### Test passes after fix
```
$ git checkout fix/issue-78-jit-symbol-shadowing
$ cmake --build build -j$(nproc) && build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/character_19.ll; echo "rc=$?"
rc=0
```