### PR TITLE
fix: dynamic block_offsets/fixups and larger parser block caps

### DIFF
--- a/src/ll_parser.c
+++ b/src/ll_parser.c
@@ -5,13 +5,13 @@
 #include <stdlib.h>
 
 #define VREG_MAP_CAP 16384u
-#define BLOCK_MAP_CAP 1024u
+#define BLOCK_MAP_CAP 4096u
 #define GLOBAL_MAP_CAP 4096u
 #define FUNC_MAP_CAP 1024u
 #define TYPE_MAP_CAP 256u
 
 #define VREG_INDEX_CAP 32768u
-#define BLOCK_INDEX_CAP 2048u
+#define BLOCK_INDEX_CAP 8192u
 #define GLOBAL_INDEX_CAP 8192u
 
 typedef struct lr_parser {


### PR DESCRIPTION
## Summary
- Replace static `block_offsets[1024]` and `fixups[4096]` arrays with arena-allocated arrays sized from `func->num_blocks` in both x86_64 and aarch64 backends
- Increase parser `BLOCK_MAP_CAP` from 1024 to 4096 and `BLOCK_INDEX_CAP` from 2048 to 8192

Refs #78

## Why
Functions with >1024 blocks (e.g. `fill_smalltocapital` in dict_test_07_ with 2823 blocks) overflowed three static limits:
1. Parser `block_map[1024]` - duplicate blocks created, corrupting IR CFG
2. Backend `block_offsets[1024]` - stack buffer overflow corrupting compiler state
3. Backend `fixups[4096]` - branch fixups silently dropped, leaving 0-displacement jumps

## Changes
- `src/ll_parser.c`: `BLOCK_MAP_CAP` 1024->4096, `BLOCK_INDEX_CAP` 2048->8192
- `src/target_x86_64.c`: `block_offsets` and `fixups` arena-allocated from `func->num_blocks`; new `x86_fixup_t` typedef
- `src/target_aarch64.c`: Same pattern with `a64_fixup_t` typedef

## Verification

### Tests fail on main
```
$ git checkout main
$ cmake --build build -j$(nproc)
$ build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/dict_test_07_.ll; echo "rc=$?"
rc=139  (SIGSEGV)
$ build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/dict_test_13_.ll; echo "rc=$?"
rc=139  (SIGSEGV)
```

### Tests pass after fix
```
$ git checkout fix/issue-78-capacity-overflows
$ cmake --build build -j$(nproc)
$ build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/dict_test_07_.ll; echo "rc=$?"
rc=0
$ build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/dict_test_13_.ll; echo "rc=$?"
rc=0
```