### PR TITLE
fix: GEP result slots pointer-sized + stack probing for large frames

### DIFF
--- a/src/target_common.c
+++ b/src/target_common.c
@@ -45,7 +45,7 @@ size_t lr_target_inst_result_slot_size(const lr_inst_t *inst, size_t min_size) {
     if (!lr_target_inst_has_result_slot(inst)) {
         return 0;
     }
-    if (inst->op == LR_OP_ALLOCA) {
+    if (inst->op == LR_OP_ALLOCA || inst->op == LR_OP_GEP) {
         return slot_size;
     }
     if (inst->type) {


### PR DESCRIPTION
## Summary
- Keep GEP result slot size at pointer width (same pattern as alloca fix in #136)
- Add page-by-page stack probing in x86_64 and aarch64 prologues when stack_size > 4096

Refs #78

## Why
GEP instructions have `inst->type` set to the base element type (e.g. `[262144 x double]`) for offset computation, but `lr_target_inst_result_slot_size` used this to size the result slot. Since GEP returns a pointer, this inflated stack frames dramatically - `elemental_sin` went from 4MB (correct) to 16MB (wrong), exceeding the 8MB OS stack limit.

The stack probing is defense-in-depth for remaining large-frame cases: when stack_size > 4096, the prologue now touches each 4KB page to properly extend the kernel stack guard.

## Changes
- `src/target_common.c`: Return `min_size` for `LR_OP_GEP` in `lr_target_inst_result_slot_size()`
- `src/target_x86_64.c`: Probing loop in `emit_prologue()` using `mov ecx, pages; sub rsp, 4096; test [rsp], eax; dec rcx; jnz`
- `src/target_aarch64.c`: Probing in prologue using chunked `sub sp, 4095; str xzr, [sp]` pairs

## Verification

### Test fails on main
```
$ git checkout main
$ cmake --build build -j$(nproc)
$ build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/arrays_elemental_15.ll; echo "rc=$?"
rc=139  (SIGSEGV)
```

### Test passes after fix (no longer segfaults)
```
$ git checkout fix/issue-78-stack-probing
$ cmake --build build -j$(nproc)
$ build/liric_probe_runner --sig i32_argc_argv --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so /tmp/liric_bench/ll/arrays_elemental_15.ll; echo "rc=$?"
ERROR STOP
rc=1  (correctness mismatch - not a segfault, tracked separately in #80)
```

Note: arrays_elemental_15 still has an ERROR STOP (rc=1) vs LLVM's rc=0, but this is a correctness mismatch tracked in #80, not a segfault.