### PR TITLE
fix: parse packed struct constant aggregates instead of dropping as undef

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -50,6 +50,8 @@ int test_parser_decl_with_modern_param_attrs(void);
 int test_parser_store_with_const_gep_operand(void);
 int test_parser_call_arg_with_align_attr(void);
 int test_parser_store_with_struct_constant(void);
+int test_parser_store_packed_struct_float_pair(void);
+int test_parser_store_packed_struct_double_pair(void);
 int test_parser_urem_instruction(void);
 int test_parser_canonical_phi_pairs(void);
 int test_parser_select_with_ptr_operands(void);
@@ -105,6 +107,8 @@ int test_jit_fptrunc_f64_f32(void);
 int test_jit_fcmp_oeq(void);
 int test_jit_fp_arithmetic_chain(void);
 int test_jit_insert_extractvalue_struct_fields(void);
+int test_jit_packed_struct_float_constant(void);
+int test_jit_packed_struct_double_constant(void);
 int test_e2e_ret_42(void);
 int test_e2e_add_i32(void);
 int test_e2e_branch(void);
@@ -163,6 +167,8 @@ int main(void) {
     RUN_TEST(test_parser_store_with_const_gep_operand);
     RUN_TEST(test_parser_call_arg_with_align_attr);
     RUN_TEST(test_parser_store_with_struct_constant);
+    RUN_TEST(test_parser_store_packed_struct_float_pair);
+    RUN_TEST(test_parser_store_packed_struct_double_pair);
     RUN_TEST(test_parser_urem_instruction);
     RUN_TEST(test_parser_canonical_phi_pairs);
     RUN_TEST(test_parser_select_with_ptr_operands);
@@ -224,6 +230,8 @@ int main(void) {
     RUN_TEST(test_jit_fcmp_oeq);
     RUN_TEST(test_jit_fp_arithmetic_chain);
     RUN_TEST(test_jit_insert_extractvalue_struct_fields);
+    RUN_TEST(test_jit_packed_struct_float_constant);
+    RUN_TEST(test_jit_packed_struct_double_constant);
 
     fprintf(stderr, "\nE2E tests:\n");
     RUN_TEST(test_e2e_ret_42);


### PR DESCRIPTION
## Summary
- Parse struct/packed-struct constant values (e.g. `<{ float 1.0, float 2.0 }>`) instead of discarding them as `undef`
- For structs <= 8 bytes: pack field bits into `LR_VAL_IMM_I64`
- For structs > 8 bytes: lower store into per-field GEP + scalar store sequences
- Add 4 new tests (2 parser, 2 JIT E2E)

Fixes #77

## Why
The parser was converting all aggregate constant literals to `undef`, which the backend treated as zero. This broke all complex number initializations in lfortran-generated .ll files (~117 tests use packed struct constants for complex numbers).

## Verification

### Fails on main
```
$ git checkout main
$ ./build/liric --dump-ir /tmp/functions_21.ll 2>&1 | grep 'store.*v32'
  store { float, float } undef, ptr %v32
```
Complex constant `<{ float 0x405EDA3D80000000, float 0xC05F233340000000 }>` parsed as `undef`.

### Passes after fix
```
$ git checkout fix/issue-77-packed-struct-constants
$ ./build/liric --dump-ir /tmp/functions_21.ll 2>&1 | grep 'store.*v32'
  store { float, float } -4397455410811448852, ptr %v32
```
Packed i64 value matches: `{123.41f, -124.55f}` bit-packed correctly.

### Unit tests
```
$ ctest --test-dir build --output-on-failure
105 tests: 105 passed, 0 failed
```