### PR TITLE
fix: redirect child stdin to /dev/null in benchmark harnesses

### DIFF
--- a/tools/bench_api.c
+++ b/tools/bench_api.c
@@ -216,6 +216,13 @@ static cmd_result_t run_cmd(char *const argv[], int timeout_sec, const char *env
             setenv("DYLD_LIBRARY_PATH", env_lib_dir, 1);
             setenv("LD_LIBRARY_PATH", env_lib_dir, 1);
         }
+        {
+            int devnull = open("/dev/null", O_RDONLY);
+            if (devnull >= 0) {
+                dup2(devnull, STDIN_FILENO);
+                close(devnull);
+            }
+        }
         if (dup2(out_fd, STDOUT_FILENO) < 0) _exit(127);
         if (dup2(err_fd, STDERR_FILENO) < 0) _exit(127);
         close(out_fd);
@@ -524,7 +531,11 @@ static cfg_t parse_args(int argc, char **argv) {
 
 int main(int argc, char **argv) {
     cfg_t cfg = parse_args(argc, argv);
-    char *compat_path = path_join2(cfg.bench_dir, "compat_api.txt");
+    char *compat_path;
+
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
+    compat_path = path_join2(cfg.bench_dir, "compat_api.txt");
     char *opts_path = path_join2(cfg.bench_dir, "compat_api_options.jsonl");
     char *api_bin_dir = path_join2(cfg.bench_dir, "api_bin");
     char *jsonl_path = path_join2(cfg.bench_dir, "bench_api.jsonl");

--- a/tools/bench_compat_check.c
+++ b/tools/bench_compat_check.c
@@ -341,6 +341,13 @@ static cmd_result_t run_cmd(char *const argv[], int timeout_sec, const char *std
         }
         fderr = err_fd;
 
+        {
+            int devnull = open("/dev/null", O_RDONLY);
+            if (devnull >= 0) {
+                dup2(devnull, STDIN_FILENO);
+                close(devnull);
+            }
+        }
         if (dup2(fdout, STDOUT_FILENO) < 0) _exit(127);
         if (dup2(fderr, STDERR_FILENO) < 0) _exit(127);
 

--- a/tools/bench_ll.c
+++ b/tools/bench_ll.c
@@ -214,6 +214,13 @@ static cmd_result_t run_cmd(char *const argv[], int timeout_sec, const char *env
             setenv("DYLD_LIBRARY_PATH", env_lib_dir, 1);
             setenv("LD_LIBRARY_PATH", env_lib_dir, 1);
         }
+        {
+            int devnull = open("/dev/null", O_RDONLY);
+            if (devnull >= 0) {
+                dup2(devnull, STDIN_FILENO);
+                close(devnull);
+            }
+        }
         if (dup2(out_fd, STDOUT_FILENO) < 0) _exit(127);
         if (dup2(err_fd, STDERR_FILENO) < 0) _exit(127);
         close(out_fd);


### PR DESCRIPTION
## Summary
- Redirect stdin to /dev/null for all child processes in bench_api, bench_ll, and bench_compat_check
- Set line-buffered stdout in bench_api for visible progress when output is captured

## Why
Child processes inherited stdin from the parent. Fortran tests that read from stdin
(e.g. namelist input) would block indefinitely, hanging the entire benchmark run.
bench_api hung at different test numbers depending on timeout settings because the
blocking test varied.

## Verification

### Hangs on main
```
$ git checkout main
$ timeout 120 ./build/bench_api --iters 1 --timeout 5
  [71/2051] array_bound_4    <-- hangs here, no more output
```

### Passes after fix
```
$ git checkout fix/bench-api-hang
$ timeout 120 ./build/bench_api --iters 1 --timeout 5
  [71/2051] array_bound_4: wall 40.2ms vs 50.4ms (1.25x)
  [72/2051] array_bound_5: skipped (runtime error)
  ...continues through all 2051 tests...
```