### PR TITLE
fix: c-string backslash escape and global i1 true/false initializers

### DIFF
--- a/src/ll_parser.c
+++ b/src/ll_parser.c
@@ -1765,18 +1765,25 @@ static void parse_global(lr_parser_t *p) {
             uint8_t *buf = lr_arena_array(p->arena, uint8_t, slen + 1);
             size_t out = 0;
             for (size_t i = 0; i < slen; i++) {
-                if (s[i] == '\\' && i + 2 < slen) {
-                    int hi = 0, lo = 0;
-                    char c1 = s[i + 1], c2 = s[i + 2];
-                    hi = (c1 >= '0' && c1 <= '9') ? c1 - '0' :
-                         (c1 >= 'a' && c1 <= 'f') ? c1 - 'a' + 10 :
-                         (c1 >= 'A' && c1 <= 'F') ? c1 - 'A' + 10 : -1;
-                    lo = (c2 >= '0' && c2 <= '9') ? c2 - '0' :
-                         (c2 >= 'a' && c2 <= 'f') ? c2 - 'a' + 10 :
-                         (c2 >= 'A' && c2 <= 'F') ? c2 - 'A' + 10 : -1;
-                    if (hi >= 0 && lo >= 0) {
-                        buf[out++] = (uint8_t)(hi * 16 + lo);
-                        i += 2;
+                if (s[i] == '\\' && i + 1 < slen) {
+                    if (i + 2 < slen) {
+                        int hi = 0, lo = 0;
+                        char c1 = s[i + 1], c2 = s[i + 2];
+                        hi = (c1 >= '0' && c1 <= '9') ? c1 - '0' :
+                             (c1 >= 'a' && c1 <= 'f') ? c1 - 'a' + 10 :
+                             (c1 >= 'A' && c1 <= 'F') ? c1 - 'A' + 10 : -1;
+                        lo = (c2 >= '0' && c2 <= '9') ? c2 - '0' :
+                             (c2 >= 'a' && c2 <= 'f') ? c2 - 'a' + 10 :
+                             (c2 >= 'A' && c2 <= 'F') ? c2 - 'A' + 10 : -1;
+                        if (hi >= 0 && lo >= 0) {
+                            buf[out++] = (uint8_t)(hi * 16 + lo);
+                            i += 2;
+                            continue;
+                        }
+                    }
+                    if (s[i + 1] == '\\') {
+                        buf[out++] = '\\';
+                        i++;
                         continue;
                     }
                 }
@@ -1835,6 +1842,14 @@ static void parse_global(lr_parser_t *p) {
             }
         }
     } else if (check(p, LR_TOK_NULL)) {
+        next(p);
+    } else if (check(p, LR_TOK_TRUE)) {
+        uint8_t *buf = lr_arena_array(p->arena, uint8_t, 1);
+        buf[0] = 1;
+        g->init_data = buf;
+        g->init_size = 1;
+        next(p);
+    } else if (check(p, LR_TOK_FALSE)) {
         next(p);
     } else if (check(p, LR_TOK_GETELEMENTPTR)) {
         lr_operand_t gep = parse_const_gep_operand(p, p->module->type_ptr);


### PR DESCRIPTION
## Summary
- Fix `\\` escape in c-string constants: emit single backslash instead of copying both characters
- Parse `true`/`false` keywords in global variable initializers for `i1` type

Fixes #80 (partial)

## Changes

**C-string `\\` escape** (`ll_parser.c`): The c-string parser only handled `\XX` hex escapes.
When `\` was followed by another `\`, both were copied literally, producing a string one byte
too long. This caused wrong output in elemental_10/11/12 where Fortran backslash escapes are used.

**Global `i1 true`/`false`** (`ll_parser.c`): `parse_global()` handled int/float/zeroinitializer/null
but not `true`/`false` tokens. Globals like `@flag = internal global i1 true` were left
zero-initialized (false), skipping conditional output.

## Test results

Mass tests: exact matches 2156 -> 2169 (+13), mismatches 92 -> 88 (-4), JIT passes 2253 -> 2262 (+9), 0 regressions.

## Verification

### Test fails on main
```
$ echo 'c"a\\\\b\0A\00"' | # backslash escape
$ ./build/liric --jit /tmp/test_backslash.ll
a\\b    # two backslashes (wrong)

$ ./build/liric --jit /tmp/test_i1_true.ll
fail    # i1 true read as false
```

### Test passes after fix
```
$ ./build/liric --jit /tmp/test_backslash.ll
a\b     # single backslash (correct)

$ ./build/liric --jit /tmp/test_i1_true.ll
pass    # i1 true correctly initialized
```