### PR TITLE
perf: remove per-char line/col tracking from lexer, inline int parsing

### DIFF
--- a/src/ll_lexer.h
+++ b/src/ll_lexer.h
@@ -157,20 +157,18 @@ typedef struct lr_token {
     size_t len;
     int64_t int_val;
     double float_val;
-    uint32_t line;
-    uint32_t col;
 } lr_token_t;
 
 typedef struct lr_lexer {
     const char *src;
     size_t src_len;
     size_t pos;
-    uint32_t line;
-    uint32_t col;
 } lr_lexer_t;
 
 void lr_lexer_init(lr_lexer_t *lex, const char *src, size_t len);
 lr_token_t lr_lexer_next(lr_lexer_t *lex);
 const char *lr_tok_name(lr_tok_t kind);
+void lr_lexer_compute_loc(const lr_lexer_t *lex, const char *pos,
+                          uint32_t *out_line, uint32_t *out_col);
 
 #endif


### PR DESCRIPTION
## Summary
- Remove `line`/`col` from `lr_token_t` and `lr_lexer_t`, add on-demand `lr_lexer_compute_loc()`
- Use `memchr` for comment scanning instead of byte-by-byte loop
- Inline integer parsing (replace `strtoll`) and hex parsing (replace `strtoull`)
- Fix parser error(), backtracking, and skip_line() to work without line/col fields

## Benchmark
100-case corpus (`bench_corpus --iters 5`):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| JIT total | 99ms | 92ms | -7% |
| Parse | 84ms | 77ms | -8% |
| Compile | 15ms | 15ms | unchanged |

Mass test: identical (2200 pass, 88 mismatch, 0 regressions).
Error messages still show correct line/col (verified manually).