### PR TITLE
perf: phase 1 API-path caches and arena uninit fast path

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ Keep these separate from primary API KPIs:
 - Lexer hotspot share (callgrind): `lr_lexer_next ~46%`
 - Parser hotspots (callgrind): `parse_function_def ~4%`, `parse_type ~3%`
 
+### Next Major Speedup: Direct API JIT (No Object Files)
+
+Current API flow still pays object/link overhead. The next first-class path should remove file/object creation:
+
+1. LFortran emits module IR directly to liric C API (in-memory).
+2. Liric JIT materializes code directly (`lr_jit_add_module`), no `.o` and no system linker.
+3. Runtime symbols come from one of:
+   - preloaded runtime shared library (`dlsym` path), or
+   - runtime LLVM IR/bitcode module compiled once and registered in the same JIT instance.
+
+Primary KPIs for this path:
+
+- API build time (frontend -> liric IR)
+- JIT materialization time (no object/link phases)
+- Time-to-first-result
+
+Validation target:
+
+- Add a dedicated API fast-path benchmark mode against LFortran API workloads.
+- Keep LL-file benchmark and lexer/parser metrics as separate diagnostics.
+- Tracking: issues `#156` (direct API JIT path) and `#157` (stable 100-case API corpus).
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -50,45 +50,54 @@ Artifacts go to `/tmp/liric_bench/`.
 | lli matches LLVM output | 2165 | 95.5 |
 | Both liric and lli match | 2004 | 88.4 |
 
-## API-First Performance Metrics
+## Performance Metrics (API First)
 
-If your real workload uses the API (not `.ll` parsing), track these 3 metrics first:
+Primary KPIs for API-heavy workloads:
 
-1. **API build time**  
-Time spent in `lc_*` / builder calls to construct IR.
+1. API wall-clock (`lfortran+liric` vs `lfortran+LLVM`)
+2. Compile phase time (`compile+link` vs `compile+JIT`)
+3. Run phase time (first execution)
 
-2. **JIT materialization time**  
-Time in `lr_jit_add_module()` until function pointers are ready.
+`bench_api` now uses blocking `waitpid` + `SIGALRM` timeout handling (no 10ms polling quantization).
 
-3. **Time-to-first-result**  
-`API build time + JIT materialization time + first function call`.
+### 100-case API Mode Snapshot (2026-02-09)
 
-### Why these metrics
+Command:
 
-- They map directly to API user latency.
-- Parser/lexer numbers are secondary diagnostics for API-heavy usage.
-- `bench_api` wall-clock is coarse-grained (10ms polling), so use it for broad trends, not micro-latency.
+```bash
+./build/bench_api --iters 3 --bench-dir /tmp/liric_bench_100_api
+```
 
-### Simple Baseline vs `lli` (reference)
+Attempted 100 tests, completed 15 on this machine (others skipped due runtime errors).
+Medians on completed tests:
 
-From `./build/bench_ll --iters 1` (1963 tests, February 2026):
+- Wall: `liric 28.270 ms` vs `llvm 38.655 ms` -> **1.36x faster**
+- Compile: `liric 27.770 ms` vs `llvm 38.066 ms` -> **1.36x faster**
+- Run: `liric 0.537 ms` vs `llvm 0.597 ms` -> **1.09x faster**
 
-- Wall-clock median: `liric 10.064 ms` vs `lli 20.119 ms` -> **2.00x faster**
-- JIT materialization median (fair internal): `liric 0.528 ms` vs `lli 5.100 ms` -> **9.88x faster**
-- Liric internal split median: parse `0.476 ms`, compile `0.054 ms`, lookup `0.0001 ms`
+### 100-case LL Mode Snapshot (2026-02-09)
 
-Use this as a sanity baseline. For API product work, optimize and report the 3 API-first metrics above.
+Command:
 
-### Secondary Diagnostics (Lexer/Parser, Not First-Class)
+```bash
+./build/bench_ll --iters 3 --bench-dir /tmp/liric_bench_100_ll
+```
 
-Keep lexer/parser metrics separate and tracked, but treat them as second-order for API-first workloads.
+Attempted 100 tests, completed 94.
+Medians:
 
-- LL parse median (`bench_ll` internal split): `0.476 ms`
+- Wall (`liric_probe_runner` vs `lli`): `liric 10.065 ms` vs `lli 20.120 ms` -> **2.00x faster**
+- Internal materialization (fair split): `liric 0.486 ms` vs `lli 4.819 ms` -> **10.10x faster**
+- Liric split: parse `0.439 ms`, compile `0.051 ms`, lookup `0.0001 ms`
+
+### Secondary Diagnostics (Lexer/Parser)
+
+Keep these separate from primary API KPIs:
+
+- LL parse median (`bench_ll`, 100-case): `0.439 ms`
 - Corpus parse share (`bench_corpus`): `~84%` of JIT time
-- Lexer hotspot share (callgrind profile): `lr_lexer_next ~46%`
-- Parser hotspot shares (callgrind profile): `parse_function_def ~4%`, `parse_type ~3%`
-
-Use these to detect frontend regressions and guide LL-text ingestion work, not as primary API latency KPIs.
+- Lexer hotspot share (callgrind): `lr_lexer_next ~46%`
+- Parser hotspots (callgrind): `parse_function_def ~4%`, `parse_type ~3%`
 
 ## License
 

--- a/include/liric/liric_types.h
+++ b/include/liric/liric_types.h
@@ -112,6 +112,7 @@ struct lr_arena;
 typedef struct lr_arena lr_arena_t;
 
 void *lr_arena_alloc(lr_arena_t *a, size_t size, size_t align);
+void *lr_arena_alloc_uninit(lr_arena_t *a, size_t size, size_t align);
 char *lr_arena_strdup(lr_arena_t *a, const char *s, size_t len);
 
 struct lr_module {

--- a/src/arena.c
+++ b/src/arena.c
@@ -11,6 +11,34 @@ static lr_arena_chunk_t *chunk_create(size_t data_size) {
     return c;
 }
 
+static void *arena_alloc_impl(lr_arena_t *a, size_t size, size_t align,
+                              int zero_init) {
+    if (!a) return NULL;
+    if (align == 0) align = 1;
+
+    lr_arena_chunk_t *c = a->head;
+    size_t offset = (c->used + align - 1) & ~(align - 1);
+    if (offset + size <= c->size) {
+        c->used = offset + size;
+        void *p = c->data + offset;
+        if (zero_init) memset(p, 0, size);
+        return p;
+    }
+
+    size_t need = size + align;
+    size_t chunk_size = need > a->default_chunk_size ? need : a->default_chunk_size;
+    lr_arena_chunk_t *nc = chunk_create(chunk_size);
+    if (!nc) return NULL;
+    nc->next = a->head;
+    a->head = nc;
+
+    size_t off2 = (nc->used + align - 1) & ~(align - 1);
+    nc->used = off2 + size;
+    void *p = nc->data + off2;
+    if (zero_init) memset(p, 0, size);
+    return p;
+}
+
 lr_arena_t *lr_arena_create(size_t default_chunk_size) {
     if (default_chunk_size == 0) default_chunk_size = 64 * 1024;
     lr_arena_t *a = malloc(sizeof(lr_arena_t));
@@ -22,29 +50,15 @@ lr_arena_t *lr_arena_create(size_t default_chunk_size) {
 }
 
 void *lr_arena_alloc(lr_arena_t *a, size_t size, size_t align) {
-    lr_arena_chunk_t *c = a->head;
-    size_t offset = (c->used + align - 1) & ~(align - 1);
-    if (offset + size <= c->size) {
-        c->used = offset + size;
-        void *p = c->data + offset;
-        memset(p, 0, size);
-        return p;
-    }
-    size_t need = size + align;
-    size_t chunk_size = need > a->default_chunk_size ? need : a->default_chunk_size;
-    lr_arena_chunk_t *nc = chunk_create(chunk_size);
-    if (!nc) return NULL;
-    nc->next = a->head;
-    a->head = nc;
-    size_t off2 = (nc->used + align - 1) & ~(align - 1);
-    nc->used = off2 + size;
-    void *p = nc->data + off2;
-    memset(p, 0, size);
-    return p;
+    return arena_alloc_impl(a, size, align, 1);
+}
+
+void *lr_arena_alloc_uninit(lr_arena_t *a, size_t size, size_t align) {
+    return arena_alloc_impl(a, size, align, 0);
 }
 
 char *lr_arena_strdup(lr_arena_t *a, const char *s, size_t len) {
-    char *p = lr_arena_alloc(a, len + 1, 1);
+    char *p = lr_arena_alloc_uninit(a, len + 1, 1);
     if (!p) return NULL;
     memcpy(p, s, len);
     p[len] = '\0';

--- a/src/arena.h
+++ b/src/arena.h
@@ -18,10 +18,14 @@ typedef struct lr_arena {
 
 lr_arena_t *lr_arena_create(size_t default_chunk_size);
 void *lr_arena_alloc(lr_arena_t *a, size_t size, size_t align);
+void *lr_arena_alloc_uninit(lr_arena_t *a, size_t size, size_t align);
 char *lr_arena_strdup(lr_arena_t *a, const char *s, size_t len);
 void lr_arena_destroy(lr_arena_t *a);
 
 #define lr_arena_new(a, T) ((T *)lr_arena_alloc((a), sizeof(T), _Alignof(T)))
 #define lr_arena_array(a, T, n) ((T *)lr_arena_alloc((a), sizeof(T) * (n), _Alignof(T)))
+#define lr_arena_new_uninit(a, T) ((T *)lr_arena_alloc_uninit((a), sizeof(T), _Alignof(T)))
+#define lr_arena_array_uninit(a, T, n) \
+    ((T *)lr_arena_alloc_uninit((a), sizeof(T) * (n), _Alignof(T)))
 
 #endif

--- a/src/objfile.h
+++ b/src/objfile.h
@@ -32,6 +32,7 @@ typedef struct lr_obj_reloc {
 
 typedef struct lr_obj_symbol {
     const char *name;
+    uint32_t hash;
     uint32_t offset;
     uint8_t section;
     bool is_defined;
@@ -44,6 +45,11 @@ typedef struct lr_objfile_ctx {
     lr_obj_symbol_t *symbols;
     uint32_t num_symbols;
     uint32_t symbol_cap;
+    uint32_t *symbol_index;
+    uint32_t symbol_index_cap;
+    uint8_t *module_sym_defined;
+    lr_func_t **module_sym_funcs;
+    uint32_t module_sym_count;
 } lr_objfile_ctx_t;
 
 /* Mapped relocation info returned by format-specific reloc mappers */


### PR DESCRIPTION
## Summary
This PR implements API-path performance Phase 1 with low-risk structural changes:

1. Arena fast path
- Added `lr_arena_alloc_uninit()` while preserving existing zeroing semantics in `lr_arena_alloc()`.
- Added `lr_arena_new_uninit` / `lr_arena_array_uninit` macros.
- Switched clear write-only hot allocations (`lr_arena_strdup`, selected backend growth buffers, compat global init copy) to uninitialized allocation.

2. Compat API symbol-id caches
- Added module-local caches keyed by symbol id for functions/globals in `src/liric_compat.c`.
- Replaced linear scans in:
  - `lc_global_lookup_or_create`
  - `lc_func_get_arg` fallback path
  - libc decl helper used by memcpy/memset/memmove builders
- Added cache ownership reset when the underlying `mod` pointer changes.

3. Backend symbol metadata cache (object path)
- Added object-context module symbol metadata (`defined` map + function map) built once in `lr_emit_object()`.
- x86_64/aarch64 object emission now uses this metadata instead of repeated linear module scans for symbol-defined checks and call metadata lookup.

4. Objfile symbol table indexing
- Replaced O(N^2) symbol lookup in `lr_obj_ensure_symbol()` with an open-addressed hash index.
- Preserved symbol table ordering/semantics.

## Validation
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`
- `./build/bench_corpus --top 5`
  - JIT total ~100.6 ms (parse 84.3 ms, compile 16.3 ms)
- `./build/bench_ll --iters 1`
  - liric internal compile median: **0.0539 ms**
  - liric materialized median: **0.5280 ms**

Note: `WITH_LLVM_COMPAT=ON` build currently fails due an unrelated pre-existing warning-as-error in `include/llvm/IR/Type.h` (`nonnull` compare on `this`), so compat ctest could not be executed in this environment.

## Issues
Closes #151
Closes #152
Closes #153
Closes #154
