### PR TITLE
cli: make object emission explicit opt-in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,36 @@ target_link_libraries(test_liric PRIVATE liric ${LIRIC_PLATFORM_LIBS})
 target_include_directories(test_liric PRIVATE src)
 add_test(NAME liric_tests COMMAND test_liric)
 
+add_test(
+    NAME liric_cli_emit_obj_opt_in
+    COMMAND ${CMAKE_COMMAND}
+        -DCLI=$<TARGET_FILE:liric_bin>
+        -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/ret_42.ll
+        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/liric_cli_emit_obj_test.o
+        -DMODE=emit
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_obj_mode.cmake
+)
+
+add_test(
+    NAME liric_cli_obj_disabled_by_default
+    COMMAND ${CMAKE_COMMAND}
+        -DCLI=$<TARGET_FILE:liric_bin>
+        -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/ret_42.ll
+        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/liric_cli_default_should_not_emit.o
+        -DMODE=default
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_obj_mode.cmake
+)
+
+add_test(
+    NAME liric_cli_emit_obj_jit_conflict
+    COMMAND ${CMAKE_COMMAND}
+        -DCLI=$<TARGET_FILE:liric_bin>
+        -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/ret_42.ll
+        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/liric_cli_emit_obj_conflict.o
+        -DMODE=conflict
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_obj_mode.cmake
+)
+
 include(GNUInstallDirs)
 install(TARGETS liric ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY include/liric DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@ ctest --test-dir build --output-on-failure
 ```bash
 ./build/liric --jit file.ll
 ./build/liric --dump-ir file.ll
+./build/liric --emit-obj out.o file.ll
 ./build/liric --jit file.wasm --func add --args 2 3
 ```
 
 For programmatic IR construction, use the C API in `include/liric/liric.h`.
+
+`--emit-obj` is an explicit opt-in compatibility mode. The primary/first-class path is direct JIT for low-latency compilation.
 
 ## Benchmarks
 

--- a/tests/cmake/test_liric_cli_obj_mode.cmake
+++ b/tests/cmake/test_liric_cli_obj_mode.cmake
@@ -1,0 +1,49 @@
+if(NOT DEFINED CLI OR NOT DEFINED INPUT OR NOT DEFINED OUT OR NOT DEFINED MODE)
+    message(FATAL_ERROR "CLI, INPUT, OUT, and MODE are required")
+endif()
+
+file(REMOVE "${OUT}")
+
+if(MODE STREQUAL "emit")
+    execute_process(
+        COMMAND "${CLI}" --emit-obj "${OUT}" "${INPUT}"
+        RESULT_VARIABLE rc
+        OUTPUT_VARIABLE out
+        ERROR_VARIABLE err
+    )
+    if(NOT rc EQUAL 0)
+        message(FATAL_ERROR "emit mode failed rc=${rc}\nstdout:\n${out}\nstderr:\n${err}")
+    endif()
+    if(NOT EXISTS "${OUT}")
+        message(FATAL_ERROR "emit mode did not create object file: ${OUT}")
+    endif()
+    file(SIZE "${OUT}" obj_size)
+    if(obj_size LESS 64)
+        message(FATAL_ERROR "emitted object looks too small (${obj_size} bytes)")
+    endif()
+elseif(MODE STREQUAL "default")
+    execute_process(
+        COMMAND "${CLI}" "${INPUT}"
+        RESULT_VARIABLE rc
+        OUTPUT_VARIABLE out
+        ERROR_VARIABLE err
+    )
+    if(NOT rc EQUAL 0)
+        message(FATAL_ERROR "default mode failed rc=${rc}\nstdout:\n${out}\nstderr:\n${err}")
+    endif()
+    if(EXISTS "${OUT}")
+        message(FATAL_ERROR "default mode unexpectedly emitted object file: ${OUT}")
+    endif()
+elseif(MODE STREQUAL "conflict")
+    execute_process(
+        COMMAND "${CLI}" --emit-obj "${OUT}" --jit "${INPUT}"
+        RESULT_VARIABLE rc
+        OUTPUT_VARIABLE out
+        ERROR_VARIABLE err
+    )
+    if(rc EQUAL 0)
+        message(FATAL_ERROR "conflict mode should fail but succeeded\nstdout:\n${out}\nstderr:\n${err}")
+    endif()
+else()
+    message(FATAL_ERROR "Unknown MODE=${MODE}")
+endif()


### PR DESCRIPTION
## Summary
- add explicit `--emit-obj <path>` mode to `liric` CLI
- keep object emission disabled by default unless this flag is provided
- enforce mode clarity: `--emit-obj` and `--jit` are mutually exclusive
- add CLI CTest coverage for:
  - opt-in object emission success
  - default mode does not emit object files
  - conflict mode fails as expected
- document object emission as second-class compatibility mode in README

## Why
Object emission is a compatibility feature. Primary first-class path remains direct JIT for low-latency compilation.

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`

All tests passed, including new CLI object-mode tests.
