### PR TITLE
fix: Eliminate prescan pass: patch prologue + on-demand stack slots (fixes #94)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -107,6 +107,7 @@ int test_jit_fptrunc_f64_f32(void);
 int test_jit_fcmp_oeq(void);
 int test_jit_fp_arithmetic_chain(void);
 int test_jit_insert_extractvalue_struct_fields(void);
+int test_jit_late_frame_patch_and_phi_slots(void);
 int test_jit_packed_struct_float_constant(void);
 int test_jit_packed_struct_double_constant(void);
 int test_e2e_ret_42(void);
@@ -230,6 +231,7 @@ int main(void) {
     RUN_TEST(test_jit_fcmp_oeq);
     RUN_TEST(test_jit_fp_arithmetic_chain);
     RUN_TEST(test_jit_insert_extractvalue_struct_fields);
+    RUN_TEST(test_jit_late_frame_patch_and_phi_slots);
     RUN_TEST(test_jit_packed_struct_float_constant);
     RUN_TEST(test_jit_packed_struct_double_constant);
 


### PR DESCRIPTION
## Summary
- remove the backend pre-scan pass in both x86_64 and aarch64 compile paths
- allocate stack slots lazily and patch prologue stack adjustment after emission
- keep static `alloca` offsets correct with lazy frame growth and reserve PHI destination slots from PHI copy data
- switch aarch64 epilogue to restore `sp` from `fp`, avoiding stale stack-size immediates on early returns
- add `test_jit_late_frame_patch_and_phi_slots` to cover early-return frame patching and PHI with a late predecessor block

## Verification
- `set -o pipefail; { cmake -S . -B build -G Ninja && cmake --build build -j"$(nproc)" && ctest --test-dir build --output-on-failure; } 2>&1 | tee /tmp/test.log`
  - excerpt: `100% tests passed, 0 tests failed out of 4`
  - excerpt: `Total Test time (real) =   0.04 sec`
- `nm build/test_liric | rg "test_jit_late_frame_patch_and_phi_slots"`
  - excerpt: `0000000000011b20 T test_jit_late_frame_patch_and_phi_slots`

## Artifacts
- `/tmp/test.log`
