### PR TITLE
fix: OpenMP tests need libgomp linkage (fixes #82)

### DIFF
--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -34,6 +34,10 @@ Defaults are:
 - Runtime library preload: auto-detected when available:
   - `<detected-lfortran-bin>/../runtime/liblfortran_runtime.so`
   - env override: `$LFORTRAN_RUNTIME_LIBRARY_DIR/liblfortran_runtime.so`
+- OpenMP runtime preload: auto-detected when selected tests use OpenMP
+  (`--openmp` / `llvm_omp`), searching common `libgomp`/`libomp` locations
+  - env override (explicit file): `$LFORTRAN_OPENMP_LIBRARY`
+  - env override (directory): `$LFORTRAN_OPENMP_LIBRARY_DIR`
 
 ## Build Prerequisites
 ```bash
@@ -62,6 +66,7 @@ Useful options:
 - `--include-expected-fail`: include expected-failure/error-handling tests
 - `--load-lib <path>`: preload runtime libraries into liric JIT (repeatable)
 - `--no-auto-runtime-lib`: disable automatic preload of `liblfortran_runtime`
+- `--no-auto-openmp-lib`: disable automatic preload of OpenMP runtime (`libgomp`/`libomp`)
 - `--diag-fail-logs`: write failing-stage stdout/stderr/meta under `cache/<case_id>/diag/`
 - `--diag-jit-coredump`: on JIT signal failures, capture `coredumpctl info` and `eu-stack` output when available
 


### PR DESCRIPTION
## Summary
- auto-detect and preload an OpenMP runtime (`libgomp`/`libomp`) in `run_mass.py` when selected entries require OpenMP (`--openmp` / `llvm_omp`)
- add env overrides for OpenMP runtime discovery: `LFORTRAN_OPENMP_LIBRARY` (explicit file) and `LFORTRAN_OPENMP_LIBRARY_DIR` (search directory)
- add `--no-auto-openmp-lib` opt-out flag and emit `auto_openmp_lib` in run summary output
- add helper unit tests for OpenMP detection/resolution and update mass-testing docs

## Verification
- `python3 -m unittest tools.lfortran_mass.test_run_mass_helpers tools.lfortran_mass.test_classify 2>&1 | tee /tmp/test.log`
  - excerpt: `Ran 22 tests in 0.004s`
  - excerpt: `OK`
- `rg -n "FAILED|ERROR|Traceback|FAIL:" /tmp/test.log || true`
  - no matches

## Artifacts
- `/tmp/test.log`
