### PR TITLE
fix: P0 Perf: Direct API JIT path (no object files, no system linker) (fixes #156)

### DIFF
--- a/include/liric/liric_compat.h
+++ b/include/liric/liric_compat.h
@@ -3,6 +3,7 @@
 
 #include <liric/liric.h>
 #include <liric/liric_types.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -406,6 +407,9 @@ void lc_create_memset(lc_module_compat_t *mod, lr_block_t *b, lr_func_t *f,
                       lc_value_t *dst, lc_value_t *val, lc_value_t *size);
 void lc_create_memmove(lc_module_compat_t *mod, lr_block_t *b, lr_func_t *f,
                        lc_value_t *dst, lc_value_t *src, lc_value_t *size);
+
+/* ---- Direct JIT materialization ---- */
+int lc_module_add_to_jit(lc_module_compat_t *mod, lr_jit_t *jit);
 
 /* ---- Object file emission ---- */
 int lc_module_emit_object(lc_module_compat_t *mod, const char *filename);

--- a/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h
+++ b/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h
@@ -49,9 +49,8 @@ inline llvm::Error llvm::orc::IRCompileLayer::add(
     (void)JD;
     Module *M = TSM.getModuleUnlocked();
     if (!M) return make_error("Null module");
-    lc_module_finalize_phis(M->getCompat());
-    int rc = lr_jit_add_module(ES.getJIT(), M->getIR());
-    if (rc != 0) return make_error("lr_jit_add_module failed");
+    int rc = lc_module_add_to_jit(M->getCompat(), ES.getJIT());
+    if (rc != 0) return make_error("lc_module_add_to_jit failed");
     return Error::success();
 }
 

--- a/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -2,6 +2,7 @@
 #define LLVM_EXECUTIONENGINE_ORC_LLJIT_H
 
 #include <liric/liric.h>
+#include <liric/liric_compat.h>
 #include "llvm/ADT/StringRef.h"
 
 namespace llvm {
@@ -48,8 +49,7 @@ public:
 #include "llvm/IR/Module.h"
 
 inline int llvm::orc::LLJIT::addModule(llvm::Module &M) {
-    lc_module_finalize_phis(M.getCompat());
-    return lr_jit_add_module(jit_, M.getIR());
+    return lc_module_add_to_jit(M.getCompat(), jit_);
 }
 
 #endif

--- a/src/liric_compat.c
+++ b/src/liric_compat.c
@@ -1,5 +1,6 @@
 #include "ir.h"
 #include "arena.h"
+#include "jit.h"
 #include "objfile.h"
 #include <stdlib.h>
 #include <string.h>
@@ -1809,6 +1810,12 @@ void lc_create_memmove(lc_module_compat_t *mod, lr_block_t *b, lr_func_t *f,
                                        m->type_ptr, lr_vreg_new(f),
                                        ops, nops);
     lr_block_append(b, inst2);
+}
+
+int lc_module_add_to_jit(lc_module_compat_t *mod, lr_jit_t *jit) {
+    if (!mod || !jit) return -1;
+    lc_module_finalize_phis(mod);
+    return lr_jit_add_module(jit, mod->mod);
 }
 
 int lc_module_emit_object_to_file(lc_module_compat_t *mod, FILE *out) {

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -141,6 +141,8 @@ int test_builder_gep_runtime_index_canonicalized_i64(void);
 int test_builder_call(void);
 int test_builder_select(void);
 int test_builder_roundtrip(void);
+int test_builder_compat_add_to_jit(void);
+int test_builder_compat_add_to_jit_null_args(void);
 #if !defined(__APPLE__)
 int test_objfile_elf_header(void);
 int test_objfile_elf_symbols(void);
@@ -281,6 +283,8 @@ int main(void) {
     RUN_TEST(test_builder_call);
     RUN_TEST(test_builder_select);
     RUN_TEST(test_builder_roundtrip);
+    RUN_TEST(test_builder_compat_add_to_jit);
+    RUN_TEST(test_builder_compat_add_to_jit_null_args);
 
     fprintf(stderr, "\nObject file tests:\n");
 #if !defined(__APPLE__)


### PR DESCRIPTION
## Summary
- add `lc_module_add_to_jit()` to the compat C API to finalize deferred PHIs and materialize a compat module directly into an existing `lr_jit_t`
- route ORC wrapper module-add paths through the compat API (`LLJIT::addModule`, `IRCompileLayer::add`)
- add C test coverage for direct compat materialization and null-argument rejection
- make `include/liric/liric_compat.h` self-contained by including `<stdio.h>` for `FILE`

## Verification
Commands:
```bash
set -o pipefail; (cmake -S . -B build -G Ninja && cmake --build build -j"$(nproc)" && ctest --test-dir build --output-on-failure) 2>&1 | tee /tmp/test.log
rg -n "FAIL|FAILED|error:|Error" /tmp/test.log || true
```

Output excerpts:
- `100% tests passed, 0 tests failed out of 4`
- `rg` found no matches

Artifacts:
- `/tmp/test.log`
