### PR TITLE
fix: Flatten IR linked lists to arrays for cache-friendly backend tra (fixes #96)

### DIFF
--- a/include/liric/liric_types.h
+++ b/include/liric/liric_types.h
@@ -52,6 +52,8 @@ struct lr_block {
     uint32_t id;
     struct lr_inst *first;
     struct lr_inst *last;
+    struct lr_inst **inst_array;
+    uint32_t num_insts;
     struct lr_block *next;
 };
 
@@ -66,6 +68,7 @@ struct lr_func {
     bool is_decl;
     lr_block_t *first_block;
     lr_block_t *last_block;
+    lr_block_t **block_array;
     uint32_t num_blocks;
     uint32_t next_vreg;
     struct lr_func *next;

--- a/src/ir.h
+++ b/src/ir.h
@@ -146,6 +146,8 @@ typedef struct lr_block {
     uint32_t id;
     lr_inst_t *first;
     lr_inst_t *last;
+    lr_inst_t **inst_array;
+    uint32_t num_insts;
     struct lr_block *next;
 } lr_block_t;
 
@@ -160,6 +162,7 @@ typedef struct lr_func {
     bool is_decl;
     lr_block_t *first_block;
     lr_block_t *last_block;
+    lr_block_t **block_array;
     uint32_t num_blocks;
     uint32_t next_vreg;
     struct lr_func *next;
@@ -224,6 +227,7 @@ uint32_t lr_vreg_new(lr_func_t *f);
 lr_inst_t *lr_inst_create(lr_arena_t *a, lr_opcode_t op, lr_type_t *type,
                            uint32_t dest, lr_operand_t *ops, uint32_t nops);
 void lr_block_append(lr_block_t *b, lr_inst_t *inst);
+int lr_func_finalize(lr_func_t *f, lr_arena_t *a);
 lr_global_t *lr_global_create(lr_module_t *m, const char *name, lr_type_t *type,
                                bool is_const);
 

--- a/src/target_shared.c
+++ b/src/target_shared.c
@@ -44,15 +44,22 @@ void lr_target_set_static_alloca_offset(lr_arena_t *arena,
     *num_offsets = cap;
 }
 
-void lr_target_prescan_static_alloca_offsets(const lr_func_t *func,
+void lr_target_prescan_static_alloca_offsets(lr_func_t *func,
+                                             lr_arena_t *arena,
                                              void *ctx,
                                              lr_target_static_alloca_ensure_fn ensure) {
-    if (!func || !ensure) {
+    if (!func || !arena || !ensure) {
         return;
     }
 
-    for (const lr_block_t *b = func->first_block; b; b = b->next) {
-        for (const lr_inst_t *inst = b->first; inst; inst = inst->next) {
+    if (lr_func_finalize(func, arena) != 0) {
+        return;
+    }
+
+    for (uint32_t bi = 0; bi < func->num_blocks; bi++) {
+        const lr_block_t *b = func->block_array[bi];
+        for (uint32_t ii = 0; ii < b->num_insts; ii++) {
+            const lr_inst_t *inst = b->inst_array[ii];
             if (inst->op != LR_OP_ALLOCA) {
                 continue;
             }

--- a/src/target_shared.h
+++ b/src/target_shared.h
@@ -14,7 +14,8 @@ void lr_target_set_static_alloca_offset(lr_arena_t *arena,
                                         uint32_t *num_offsets,
                                         uint32_t vreg,
                                         int32_t offset);
-void lr_target_prescan_static_alloca_offsets(const lr_func_t *func,
+void lr_target_prescan_static_alloca_offsets(lr_func_t *func,
+                                             lr_arena_t *arena,
                                              void *ctx,
                                              lr_target_static_alloca_ensure_fn ensure);
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -70,6 +70,7 @@ int test_non_host_target_fails(void);
 int test_load_missing_runtime_library_fails(void);
 int test_target_shared_static_alloca_table(void);
 int test_target_shared_prescan_filters_dynamic_alloca(void);
+int test_ir_finalize_builds_dense_arrays(void);
 int test_jit_ret_42(void);
 int test_jit_add_args(void);
 int test_jit_arithmetic(void);
@@ -201,6 +202,7 @@ int main(void) {
     RUN_TEST(test_load_missing_runtime_library_fails);
     RUN_TEST(test_target_shared_static_alloca_table);
     RUN_TEST(test_target_shared_prescan_filters_dynamic_alloca);
+    RUN_TEST(test_ir_finalize_builds_dense_arrays);
 
     fprintf(stderr, "\nJIT tests:\n");
     RUN_TEST(test_jit_ret_42);

--- a/tests/test_target_shared.c
+++ b/tests/test_target_shared.c
@@ -89,12 +89,68 @@ int test_target_shared_prescan_filters_dynamic_alloca(void) {
     lr_block_append(next, lr_inst_create(arena, LR_OP_ALLOCA, mod->type_i64,
                                          static_dest2, &one, 1));
 
-    lr_target_prescan_static_alloca_offsets(func, &capture, capture_static_alloca);
+    lr_target_prescan_static_alloca_offsets(func, arena, &capture, capture_static_alloca);
 
     TEST_ASSERT_EQ(capture.count, 3, "only static allocas are prescanned");
     TEST_ASSERT_EQ(capture.dests[0], static_dest0, "first static alloca visited");
     TEST_ASSERT_EQ(capture.dests[1], static_dest1, "second static alloca visited");
     TEST_ASSERT_EQ(capture.dests[2], static_dest2, "third static alloca visited");
+
+    lr_arena_destroy(arena);
+    return 0;
+}
+
+int test_ir_finalize_builds_dense_arrays(void) {
+    lr_arena_t *arena = lr_arena_create(0);
+    lr_module_t *mod = lr_module_create(arena);
+    lr_func_t *func = lr_func_create(mod, "f", mod->type_i32, NULL, 0, false);
+    lr_block_t *entry = lr_block_create(func, arena, "entry");
+    lr_block_t *exit = lr_block_create(func, arena, "exit");
+
+    lr_operand_t add_ops[2] = {
+        lr_op_imm_i64(4, mod->type_i32),
+        lr_op_imm_i64(5, mod->type_i32)
+    };
+    uint32_t sum_vreg = lr_vreg_new(func);
+    lr_inst_t *add_inst = lr_inst_create(arena, LR_OP_ADD, mod->type_i32, sum_vreg,
+                                         add_ops, 2);
+    lr_operand_t br_ops[1] = { lr_op_block(exit->id) };
+    lr_inst_t *br_inst = lr_inst_create(arena, LR_OP_BR, mod->type_void, 0, br_ops, 1);
+    lr_operand_t ret_ops[1] = { lr_op_vreg(sum_vreg, mod->type_i32) };
+    lr_inst_t *ret_inst = lr_inst_create(arena, LR_OP_RET, mod->type_i32, 0, ret_ops, 1);
+
+    TEST_ASSERT(func->block_array == NULL, "block array starts null");
+    TEST_ASSERT(entry->inst_array == NULL, "inst array starts null");
+
+    lr_block_append(entry, add_inst);
+    lr_block_append(entry, br_inst);
+    lr_block_append(exit, ret_inst);
+
+    TEST_ASSERT_EQ(lr_func_finalize(func, arena), 0, "finalize succeeds");
+    TEST_ASSERT(func->block_array != NULL, "block array populated");
+    TEST_ASSERT(func->block_array[entry->id] == entry, "entry indexed by block id");
+    TEST_ASSERT(func->block_array[exit->id] == exit, "exit indexed by block id");
+    TEST_ASSERT_EQ(entry->num_insts, 2, "entry has two instructions");
+    TEST_ASSERT(entry->inst_array[0] == add_inst, "entry[0] points to first inst");
+    TEST_ASSERT(entry->inst_array[1] == br_inst, "entry[1] points to second inst");
+    TEST_ASSERT_EQ(exit->num_insts, 1, "exit has one instruction");
+    TEST_ASSERT(exit->inst_array[0] == ret_inst, "exit[0] points to ret inst");
+
+    lr_operand_t tail_ops[1] = { lr_op_imm_i64(0, mod->type_i32) };
+    lr_inst_t *tail_ret = lr_inst_create(arena, LR_OP_RET, mod->type_i32, 0, tail_ops, 1);
+    lr_block_append(exit, tail_ret);
+    TEST_ASSERT(exit->inst_array == NULL, "append invalidates inst array");
+    TEST_ASSERT_EQ(exit->num_insts, 0, "append resets cached inst count");
+
+    TEST_ASSERT_EQ(lr_func_finalize(func, arena), 0, "re-finalize succeeds");
+    TEST_ASSERT_EQ(exit->num_insts, 2, "re-finalize updates instruction count");
+    TEST_ASSERT(exit->inst_array[1] == tail_ret, "new instruction appears in rebuilt cache");
+
+    (void)lr_block_create(func, arena, "tail");
+    TEST_ASSERT(func->block_array == NULL, "new block invalidates block array");
+    TEST_ASSERT_EQ(lr_func_finalize(func, arena), 0, "finalize rebuilds block array");
+    TEST_ASSERT(func->block_array != NULL, "rebuilt block array is present");
+    TEST_ASSERT_EQ(func->num_blocks, 3, "function now has three blocks");
 
     lr_arena_destroy(arena);
     return 0;


### PR DESCRIPTION
## Summary
- added `lr_func_finalize()` to materialize per-function dense block and instruction arrays while preserving existing linked-list construction
- switched backend emission/prescan and JIT dependency/symbol-resolution scans to iterate finalized arrays instead of chasing `next` pointers
- invalidated/rebuilt caches on IR mutation (`lr_block_create` / `lr_block_append`) and exposed new layout fields in public type mirror headers
- added regression coverage for finalize/invalidation behavior in `test_ir_finalize_builds_dense_arrays`

## Verification
Commands:
```bash
cmake --build build -j$(nproc) 2>&1 | tee /tmp/test.log
ctest --test-dir build --output-on-failure 2>&1 | tee -a /tmp/test.log
grep -E "(error|ERROR|fail|FAIL)" /tmp/test.log | tail -n 20 || true
```

Output excerpt:
- `100% tests passed, 0 tests failed out of 6`

Artifacts:
- `/tmp/test.log`