### PR TITLE
fix: Last-value caching: skip redundant loads for scratch registers (fixes #170)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -63,6 +63,7 @@ int test_parser_named_params_no_collision(void);
 int test_parser_cast_expr_in_aggregate_init(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
+int test_codegen_skip_redundant_immediate_reload(void);
 int test_host_target_name(void);
 int test_create_host_target(void);
 int test_create_unknown_target_fails(void);
@@ -193,6 +194,7 @@ int main(void) {
     fprintf(stderr, "\nCodegen tests:\n");
     RUN_TEST(test_codegen_ret_42);
     RUN_TEST(test_codegen_add);
+    RUN_TEST(test_codegen_skip_redundant_immediate_reload);
 
     fprintf(stderr, "\nTarget tests:\n");
     RUN_TEST(test_host_target_name);


### PR DESCRIPTION
## Summary
- add last-value caching for scratch GPRs in x86_64 (`RAX`/`RCX`) and aarch64 (`X9`/`X10`) backends
- skip vreg reloads when the requested vreg is already resident in the target scratch register
- conservatively invalidate cache state at block boundaries and around clobber-heavy paths (calls/division/immediates)
- add regression coverage for immediate redundant store-then-reload pattern in codegen (`x86_64` host path)

## Verification
```bash
(cmake -S . -B build -G Ninja && cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure) 2>&1 | tee /tmp/test.log
grep -nEi "error:|\bFAIL\b|failed" /tmp/test.log || true
```

Output excerpts:
- `100% tests passed, 0 tests failed out of 6`
- `48:100% tests passed, 0 tests failed out of 6`

Artifacts:
- `/tmp/test.log`
