### PR TITLE
fix: Replace linked-list PHI copies with flat arrays (fixes #98)

### DIFF
--- a/src/ir.h
+++ b/src/ir.h
@@ -130,8 +130,12 @@ typedef struct lr_inst {
 typedef struct lr_phi_copy {
     uint32_t dest_vreg;
     lr_operand_t src_op;
-    struct lr_phi_copy *next;
 } lr_phi_copy_t;
+
+typedef struct lr_block_phi_copies {
+    lr_phi_copy_t *copies;
+    uint32_t count;
+} lr_block_phi_copies_t;
 
 typedef struct lr_gep_step {
     bool is_const;
@@ -246,7 +250,7 @@ size_t lr_struct_field_offset(const lr_type_t *st, uint32_t field_idx);
 bool lr_aggregate_index_path(const lr_type_t *base, const uint32_t *indices,
                              uint32_t num_indices, size_t *byte_offset_out,
                              const lr_type_t **leaf_type_out);
-lr_phi_copy_t **lr_build_phi_copies(lr_arena_t *arena, lr_func_t *func);
+lr_block_phi_copies_t *lr_build_phi_copies(lr_arena_t *arena, lr_func_t *func);
 uint8_t lr_gep_index_signext_bytes(const lr_operand_t *idx_op);
 bool lr_gep_analyze_step(const lr_type_t *cur_ty, bool first_index,
                          const lr_operand_t *idx_op, lr_gep_step_t *out);

--- a/src/target_aarch64.c
+++ b/src/target_aarch64.c
@@ -90,7 +90,7 @@ static void count_vreg_use(uint32_t *counts, uint32_t num_counts,
 }
 
 static uint32_t *build_vreg_use_counts(lr_arena_t *arena, lr_func_t *func,
-                                       lr_phi_copy_t **phi_copies) {
+                                       lr_block_phi_copies_t *phi_copies) {
     if (!arena || !func || func->next_vreg == 0)
         return NULL;
 
@@ -111,8 +111,9 @@ static uint32_t *build_vreg_use_counts(lr_arena_t *arena, lr_func_t *func,
 
     if (phi_copies) {
         for (uint32_t bi = 0; bi < func->num_blocks; bi++) {
-            for (lr_phi_copy_t *pc = phi_copies[bi]; pc; pc = pc->next)
-                count_vreg_use(counts, func->next_vreg, &pc->src_op);
+            for (uint32_t ci = 0; ci < phi_copies[bi].count; ci++)
+                count_vreg_use(counts, func->next_vreg,
+                               &phi_copies[bi].copies[ci].src_op);
         }
     }
 
@@ -718,10 +719,10 @@ static void emit_jcc_a64(a64_compile_ctx_t *ctx, uint8_t cc, uint32_t target_blo
     emit_u32(ctx->buf, &ctx->pos, ctx->buflen, 0x54000000u);
 }
 
-static void emit_phi_copies(a64_compile_ctx_t *ctx, lr_phi_copy_t *copies) {
-    for (lr_phi_copy_t *pc = copies; pc; pc = pc->next) {
-        emit_load_operand(ctx, &pc->src_op, A64_X9);
-        emit_store_slot(ctx, pc->dest_vreg, A64_X9);
+static void emit_phi_copies(a64_compile_ctx_t *ctx, const lr_block_phi_copies_t *copies) {
+    for (uint32_t i = 0; i < copies->count; i++) {
+        emit_load_operand(ctx, &copies->copies[i].src_op, A64_X9);
+        emit_store_slot(ctx, copies->copies[i].dest_vreg, A64_X9);
     }
 }
 
@@ -836,11 +837,11 @@ static int32_t ensure_static_alloca_offset_cb(void *ctx, const lr_inst_t *inst) 
     return ensure_static_alloca_offset((a64_compile_ctx_t *)ctx, inst);
 }
 
-static void reserve_phi_dest_slots(a64_compile_ctx_t *ctx, lr_phi_copy_t **phi_copies,
+static void reserve_phi_dest_slots(a64_compile_ctx_t *ctx, lr_block_phi_copies_t *phi_copies,
                                    uint32_t num_blocks) {
     for (uint32_t bi = 0; bi < num_blocks; bi++) {
-        for (lr_phi_copy_t *pc = phi_copies[bi]; pc; pc = pc->next)
-            alloc_slot(ctx, pc->dest_vreg, 8);
+        for (uint32_t ci = 0; ci < phi_copies[bi].count; ci++)
+            alloc_slot(ctx, phi_copies[bi].copies[ci].dest_vreg, 8);
     }
 }
 
@@ -910,7 +911,7 @@ static int aarch64_compile_func(lr_func_t *func, lr_module_t *mod,
 
     attach_obj_symbol_defined_cache(&ctx);
 
-    lr_phi_copy_t **phi_copies = lr_build_phi_copies(ctx.arena, func);
+    lr_block_phi_copies_t *phi_copies = lr_build_phi_copies(ctx.arena, func);
     if (!phi_copies)
         return -1;
     ctx.vreg_use_counts = build_vreg_use_counts(ctx.arena, func, phi_copies);
@@ -946,14 +947,14 @@ static int aarch64_compile_func(lr_func_t *func, lr_module_t *mod,
             ctx.current_inst_index = ii;
             switch (inst->op) {
             case LR_OP_RET: {
-                emit_phi_copies(&ctx, phi_copies[bi]);
+                emit_phi_copies(&ctx, &phi_copies[bi]);
                 emit_load_operand(&ctx, &inst->operands[0], A64_X9);
                 emit_mov_reg(ctx.buf, &ctx.pos, ctx.buflen, A64_X0, A64_X9, true);
                 emit_epilogue_a64(&ctx);
                 break;
             }
             case LR_OP_RET_VOID: {
-                emit_phi_copies(&ctx, phi_copies[bi]);
+                emit_phi_copies(&ctx, &phi_copies[bi]);
                 emit_epilogue_a64(&ctx);
                 break;
             }
@@ -1096,12 +1097,12 @@ static int aarch64_compile_func(lr_func_t *func, lr_module_t *mod,
                 break;
             }
             case LR_OP_BR: {
-                emit_phi_copies(&ctx, phi_copies[bi]);
+                emit_phi_copies(&ctx, &phi_copies[bi]);
                 emit_jmp_a64(&ctx, inst->operands[0].block_id);
                 break;
             }
             case LR_OP_CONDBR: {
-                emit_phi_copies(&ctx, phi_copies[bi]);
+                emit_phi_copies(&ctx, &phi_copies[bi]);
                 emit_load_operand(&ctx, &inst->operands[0], A64_X9);
                 emit_u32(ctx.buf, &ctx.pos, ctx.buflen,
                          enc_ands_reg(false, A64_X9, A64_X9));

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -73,6 +73,7 @@ int test_load_missing_runtime_library_fails(void);
 int test_target_shared_static_alloca_table(void);
 int test_target_shared_prescan_filters_dynamic_alloca(void);
 int test_ir_finalize_builds_dense_arrays(void);
+int test_ir_phi_copies_flat_arrays_preserve_emission_order(void);
 int test_jit_ret_42(void);
 int test_jit_add_args(void);
 int test_jit_arithmetic(void);
@@ -207,6 +208,7 @@ int main(void) {
     RUN_TEST(test_target_shared_static_alloca_table);
     RUN_TEST(test_target_shared_prescan_filters_dynamic_alloca);
     RUN_TEST(test_ir_finalize_builds_dense_arrays);
+    RUN_TEST(test_ir_phi_copies_flat_arrays_preserve_emission_order);
 
     fprintf(stderr, "\nJIT tests:\n");
     RUN_TEST(test_jit_ret_42);


### PR DESCRIPTION
## Summary
- replace linked-list PHI copy chains with per-block flat arrays (`lr_block_phi_copies_t`) built in two passes
- preserve previous emission order semantics by filling arrays in reverse encounter order
- switch x86_64 and aarch64 emission/use-count/slot-reservation paths to indexed PHI-copy traversal
- add a focused unit test covering PHI-copy count, data, and order stability

## Verification
- Command:
  - `cmake -S . -B build -G Ninja && cmake --build build -j"$(nproc)" && ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/liric_issue98_test.log`
- Output excerpt:
  - `100% tests passed, 0 tests failed out of 6`
- Artifact:
  - `/tmp/liric_issue98_test.log`
