### PR TITLE
fix: Batch W^X transitions across multiple lr_jit_add_module calls (fixes #100)

### DIFF
--- a/include/liric/liric.h
+++ b/include/liric/liric.h
@@ -206,7 +206,9 @@ const char *lr_jit_host_target_name(void);
 const char *lr_jit_target_name(const lr_jit_t *j);
 void lr_jit_add_symbol(lr_jit_t *j, const char *name, void *addr);
 int lr_jit_load_library(lr_jit_t *j, const char *path);
+void lr_jit_begin_update(lr_jit_t *j);
 int lr_jit_add_module(lr_jit_t *j, lr_module_t *m);
+void lr_jit_end_update(lr_jit_t *j);
 void *lr_jit_get_function(lr_jit_t *j, const char *name);
 void lr_jit_destroy(lr_jit_t *j);
 

--- a/src/jit.h
+++ b/src/jit.h
@@ -27,9 +27,12 @@ typedef struct lr_sym_miss_entry {
 typedef struct lr_jit {
     const lr_target_t *target;
     bool map_jit_enabled;
+    bool update_active;
+    bool update_dirty;
     uint8_t *code_buf;
     size_t code_size;
     size_t code_cap;
+    size_t update_begin_code_size;
     uint8_t *data_buf;
     size_t data_size;
     size_t data_cap;
@@ -48,7 +51,9 @@ const char *lr_jit_host_target_name(void);
 const char *lr_jit_target_name(const lr_jit_t *j);
 void lr_jit_add_symbol(lr_jit_t *j, const char *name, void *addr);
 int lr_jit_load_library(lr_jit_t *j, const char *path);
+void lr_jit_begin_update(lr_jit_t *j);
 int lr_jit_add_module(lr_jit_t *j, lr_module_t *m);
+void lr_jit_end_update(lr_jit_t *j);
 void *lr_jit_get_function(lr_jit_t *j, const char *name);
 void lr_jit_destroy(lr_jit_t *j);
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -84,6 +84,7 @@ int test_jit_alloca_load_store(void);
 int test_jit_alloca_many_static_slots(void);
 int test_jit_forward_typed_call(void);
 int test_jit_forward_call_chain(void);
+int test_jit_batched_module_updates(void);
 int test_jit_self_recursive_call(void);
 int test_jit_self_recursive_call_ignores_prebound_symbol(void);
 int test_jit_fadd_double_bits(void);
@@ -221,6 +222,7 @@ int main(void) {
     RUN_TEST(test_jit_alloca_many_static_slots);
     RUN_TEST(test_jit_forward_typed_call);
     RUN_TEST(test_jit_forward_call_chain);
+    RUN_TEST(test_jit_batched_module_updates);
     RUN_TEST(test_jit_self_recursive_call);
     RUN_TEST(test_jit_self_recursive_call_ignores_prebound_symbol);
     RUN_TEST(test_jit_fadd_double_bits);


### PR DESCRIPTION
## Summary
- add explicit batched update APIs: `lr_jit_begin_update()` / `lr_jit_end_update()`
- teach `lr_jit_add_module()` to skip per-module W^X flips during an active batch
- use a range-aware cache flush helper so batched mode clears icache once for newly emitted code
- add JIT regression coverage for batched multi-module ingestion (including declaration-only module path)

## Verification
- `cmake --build build -j$(nproc) 2>&1 | tee /tmp/test.log`
- `ctest --test-dir build --output-on-failure 2>&1 | tee -a /tmp/test.log`
- `rg -n "FAIL|ERROR|failed|warning:" /tmp/test.log || true`

Output excerpts:
- `100% tests passed, 0 tests failed out of 6`
- `1/6 Test #1: liric_tests ...........................   Passed`

Artifacts:
- `/tmp/test.log`
