### PR TITLE
fix: P3 (Secondary) IR construction allocation reductions for LL inge (fixes #145)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -73,6 +73,7 @@ int test_load_missing_runtime_library_fails(void);
 int test_target_shared_static_alloca_table(void);
 int test_target_shared_prescan_filters_dynamic_alloca(void);
 int test_ir_finalize_builds_dense_arrays(void);
+int test_ir_inst_create_packs_operands_in_single_allocation(void);
 int test_ir_phi_copies_flat_arrays_preserve_emission_order(void);
 int test_jit_ret_42(void);
 int test_jit_add_args(void);
@@ -209,6 +210,7 @@ int main(void) {
     RUN_TEST(test_target_shared_static_alloca_table);
     RUN_TEST(test_target_shared_prescan_filters_dynamic_alloca);
     RUN_TEST(test_ir_finalize_builds_dense_arrays);
+    RUN_TEST(test_ir_inst_create_packs_operands_in_single_allocation);
     RUN_TEST(test_ir_phi_copies_flat_arrays_preserve_emission_order);
 
     fprintf(stderr, "\nJIT tests:\n");


### PR DESCRIPTION
## Summary
- reduce IR instruction construction churn by allocating `lr_inst_t` header and operand storage in a single arena allocation
- preserve existing `lr_inst_create(...)` API and operand-copy semantics
- add regression coverage that validates operand copy behavior and packed operand layout

## Verification
- `cmake -S . -B build -G Ninja && cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
  - excerpt: `100% tests passed, 0 tests failed out of 6`
  - artifact: `/tmp/test.log`
- `./build/bench_corpus --single functions_30 --iters 3 2>&1 | tee /tmp/bench_145.log`
  - excerpt: `functions_30 Parse(us) 8767 Compile(us) 2444 JIT(us) 11211`
  - artifact: `/tmp/bench_145.log`
