### PR TITLE
fix: P3 (Secondary) LL parser optimization for large text modules (fixes #144)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -60,6 +60,8 @@ int test_parser_function_pointer_type(void);
 int test_parser_quoted_label_names(void);
 int test_parser_boolean_literals(void);
 int test_parser_named_params_no_collision(void);
+int test_parser_unnamed_params_numeric_alias(void);
+int test_parser_high_numeric_vregs(void);
 int test_parser_cast_expr_in_aggregate_init(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
@@ -193,6 +195,8 @@ int main(void) {
     RUN_TEST(test_parser_quoted_label_names);
     RUN_TEST(test_parser_boolean_literals);
     RUN_TEST(test_parser_named_params_no_collision);
+    RUN_TEST(test_parser_unnamed_params_numeric_alias);
+    RUN_TEST(test_parser_high_numeric_vregs);
     RUN_TEST(test_parser_cast_expr_in_aggregate_init);
 
     fprintf(stderr, "\nCodegen tests:\n");


### PR DESCRIPTION
## Summary
- add a numeric local-ID fast path in `ll_parser` so `%N` vreg lookups bypass hash probing on the hot path
- track/reset numeric `%N` mappings per function with used-slot reset, preserving hash-map fallback for non-numeric and high numeric names
- reuse numeric registration for unnamed parameter aliases
- add parser coverage for unnamed numeric parameter aliases and high-numbered vregs beyond fast-path capacity

## Verification
- `cmake -S . -B build -G Ninja && cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
  - `100% tests passed, 0 tests failed out of 6`
  - `Total Test time (real) =   0.15 sec`
- `./build/bench_corpus --single functions_30 --iters 3 2>&1 | tee /tmp/bench.log`
  - `functions_30                                        8800        2456      11256         74`
  - `Passed: 1/1`
  - `Parse:      8.8 ms (78%)`

Artifacts:
- `/tmp/test.log`
- `/tmp/bench.log`
