### PR TITLE
fix: Peephole and JIT-time optimizations for direct-emission backends (fixes #42)

### DIFF
--- a/tests/test_codegen.c
+++ b/tests/test_codegen.c
@@ -98,6 +98,25 @@ static int count_rax_store_to_rbp(const uint8_t *code, size_t code_len) {
     return count;
 }
 
+static int has_xor_eax_eax(const uint8_t *code, size_t code_len) {
+    for (size_t i = 0; i + 1 < code_len; i++) {
+        if (code[i + 0] == 0x31 && code[i + 1] == 0xC0)
+            return 1;
+    }
+    return 0;
+}
+
+static int has_mov_imm_zero_rax(const uint8_t *code, size_t code_len) {
+    for (size_t i = 0; i + 6 < code_len; i++) {
+        if (code[i + 0] == 0x48 && code[i + 1] == 0xC7 && code[i + 2] == 0xC0 &&
+            code[i + 3] == 0x00 && code[i + 4] == 0x00 &&
+            code[i + 5] == 0x00 && code[i + 6] == 0x00) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 int test_codegen_skip_redundant_immediate_reload(void) {
     const char *src =
         "define i64 @f(i64 %a, i64 %b, i64 %c) {\n"
@@ -161,6 +180,71 @@ int test_codegen_keep_store_for_next_inst_multiuse_vreg(void) {
     TEST_ASSERT(code_len > 0, "generated some code");
     TEST_ASSERT(count_rax_store_to_rbp(code, code_len) >= 1,
                 "multi-use temporaries keep required stack spill");
+
+    lr_arena_destroy(arena);
+    return 0;
+}
+
+int test_codegen_zero_immediate_uses_xor_when_flags_dead(void) {
+    const char *src =
+        "define i64 @f() {\n"
+        "entry:\n"
+        "  ret i64 0\n"
+        "}\n";
+    lr_arena_t *arena = lr_arena_create(0);
+    char err[256] = {0};
+
+    lr_module_t *m = lr_parse_ll_text(src, strlen(src), arena, err, sizeof(err));
+    TEST_ASSERT(m != NULL, err);
+
+    const lr_target_t *target = lr_target_host();
+    TEST_ASSERT(target != NULL, "host target exists");
+    if (strcmp(target->name, "x86_64") != 0) {
+        lr_arena_destroy(arena);
+        return 0;
+    }
+
+    uint8_t code[4096];
+    size_t code_len = 0;
+    int rc = target->compile_func(m->first_func, m, code, sizeof(code), &code_len, arena);
+    TEST_ASSERT_EQ(rc, 0, "compile succeeds");
+    TEST_ASSERT(code_len > 0, "generated some code");
+    TEST_ASSERT(has_xor_eax_eax(code, code_len), "ret i64 0 uses xor zeroing");
+    TEST_ASSERT(!has_mov_imm_zero_rax(code, code_len),
+                "ret i64 0 avoids mov imm zero in dead-flags context");
+
+    lr_arena_destroy(arena);
+    return 0;
+}
+
+int test_codegen_select_zero_keeps_mov_for_flags(void) {
+    const char *src =
+        "define i64 @f(i64 %x) {\n"
+        "entry:\n"
+        "  %cond = icmp ne i64 %x, 0\n"
+        "  %r = select i1 %cond, i64 7, i64 0\n"
+        "  ret i64 %r\n"
+        "}\n";
+    lr_arena_t *arena = lr_arena_create(0);
+    char err[256] = {0};
+
+    lr_module_t *m = lr_parse_ll_text(src, strlen(src), arena, err, sizeof(err));
+    TEST_ASSERT(m != NULL, err);
+
+    const lr_target_t *target = lr_target_host();
+    TEST_ASSERT(target != NULL, "host target exists");
+    if (strcmp(target->name, "x86_64") != 0) {
+        lr_arena_destroy(arena);
+        return 0;
+    }
+
+    uint8_t code[4096];
+    size_t code_len = 0;
+    int rc = target->compile_func(m->first_func, m, code, sizeof(code), &code_len, arena);
+    TEST_ASSERT_EQ(rc, 0, "compile succeeds");
+    TEST_ASSERT(code_len > 0, "generated some code");
+    TEST_ASSERT(has_mov_imm_zero_rax(code, code_len),
+                "select keeps mov imm zero so condition flags stay intact");
 
     lr_arena_destroy(arena);
     return 0;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -67,6 +67,8 @@ int test_codegen_ret_42(void);
 int test_codegen_add(void);
 int test_codegen_skip_redundant_immediate_reload(void);
 int test_codegen_keep_store_for_next_inst_multiuse_vreg(void);
+int test_codegen_zero_immediate_uses_xor_when_flags_dead(void);
+int test_codegen_select_zero_keeps_mov_for_flags(void);
 int test_host_target_name(void);
 int test_create_host_target(void);
 int test_create_unknown_target_fails(void);
@@ -85,6 +87,7 @@ int test_jit_ret_42(void);
 int test_jit_add_args(void);
 int test_jit_arithmetic(void);
 int test_jit_icmp(void);
+int test_jit_select_immediate_zero(void);
 int test_jit_branch(void);
 int test_jit_loop(void);
 int test_jit_alloca_load_store(void);
@@ -208,6 +211,8 @@ int main(void) {
     RUN_TEST(test_codegen_add);
     RUN_TEST(test_codegen_skip_redundant_immediate_reload);
     RUN_TEST(test_codegen_keep_store_for_next_inst_multiuse_vreg);
+    RUN_TEST(test_codegen_zero_immediate_uses_xor_when_flags_dead);
+    RUN_TEST(test_codegen_select_zero_keeps_mov_for_flags);
 
     fprintf(stderr, "\nTarget tests:\n");
     RUN_TEST(test_host_target_name);
@@ -230,6 +235,7 @@ int main(void) {
     RUN_TEST(test_jit_add_args);
     RUN_TEST(test_jit_arithmetic);
     RUN_TEST(test_jit_icmp);
+    RUN_TEST(test_jit_select_immediate_zero);
     RUN_TEST(test_jit_branch);
     RUN_TEST(test_jit_loop);
     RUN_TEST(test_jit_alloca_load_store);


### PR DESCRIPTION
## Summary
- add a safe x86_64 peephole for zero immediates: emit `xor reg, reg` instead of `mov reg, 0` when flags are not live
- keep `mov` in flag-sensitive `select` lowering so condition flags used by `cmov` remain intact
- add focused codegen/JIT regression coverage for both optimized and flag-preserving paths

## Verification
- Command:
  - `cmake -S . -B build -G Ninja && cmake --build build -j$(nproc) && ./build/test_liric 2>&1 | tee /tmp/test.log`
- Output excerpts:
  - `test_codegen_zero_immediate_uses_xor_when_flags_dead... ok`
  - `test_codegen_select_zero_keeps_mov_for_flags... ok`
  - `test_jit_select_immediate_zero... ok`
  - `130 tests: 130 passed, 0 failed`
- Artifact path:
  - `/tmp/test.log`
