### PR TITLE
fix: P1 Validation: LFortran API drop-in differential lane for direct (fixes #160)

### DIFF
--- a/tools/lfortran_mass/test_report_selection.py
+++ b/tools/lfortran_mass/test_report_selection.py
@@ -38,6 +38,48 @@ class ReportSelectionSummaryTests(unittest.TestCase):
         self.assertEqual(summary["skipped_reason_counts"]["duplicate_case"], 1)
         self.assertEqual(summary["skipped_by_corpus_reason"]["tests_toml:expected_failure"], 1)
 
+    def test_differential_mismatch_buckets(self) -> None:
+        processed = [
+            {
+                "case_id": "a",
+                "classification": "mismatch",
+                "corpus": "integration_cmake",
+                "differential_ok": True,
+                "differential_match": False,
+                "differential_rc_match": False,
+                "differential_stdout_match": True,
+                "differential_stderr_match": True,
+            },
+            {
+                "case_id": "b",
+                "classification": "mismatch",
+                "corpus": "integration_cmake",
+                "differential_ok": True,
+                "differential_match": False,
+                "differential_rc_match": True,
+                "differential_stdout_match": False,
+                "differential_stderr_match": False,
+            },
+            {
+                "case_id": "c",
+                "classification": "mismatch",
+                "corpus": "integration_cmake",
+                "differential_ok": False,
+                "differential_match": False,
+            },
+        ]
+        summary = report.summarize(
+            manifest_total=3,
+            processed=processed,
+            baseline=[],
+            selection_rows=[],
+        )
+
+        self.assertEqual(summary["differential_mismatch_total"], 3)
+        self.assertEqual(summary["differential_mismatch_buckets"]["rc"], 1)
+        self.assertEqual(summary["differential_mismatch_buckets"]["stdout_stderr"], 1)
+        self.assertEqual(summary["differential_mismatch_buckets"]["unknown"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Added strict API corpus mode to `tools/lfortran_mass/run_mass.py` via `--compat-api-list`, so validation can run against deterministic `compat_api*.txt` selection and fail fast if listed entries are missing.
- Added differential mismatch bucket aggregation (`rc`, `stdout`, `stderr` combinations + `unknown`) in `tools/lfortran_mass/report.py` for actionable mismatch taxonomy.
- Added machine-readable summary artifact output (`summary.json`) alongside existing `summary.md`.
- Added unit tests for compat-list parsing/selection and mismatch bucket accounting.

## Verification
- `python3 -m unittest discover -s tools/lfortran_mass -p 'test_*.py' 2>&1 | tee /tmp/test.log`
  - Output excerpt:
    - `Ran 26 tests in 0.004s`
    - `OK`
- `rg -n "FAILED|ERROR|Traceback" /tmp/test.log || true`
  - Output excerpt: no matches

## Artifacts
- Test log: `/tmp/test.log`
- New validation summary artifact path (when running mass harness): `/tmp/liric_lfortran_mass/summary.json`
- Existing validation artifacts: `/tmp/liric_lfortran_mass/summary.md`, `/tmp/liric_lfortran_mass/results.jsonl`, `/tmp/liric_lfortran_mass/selection_decisions.jsonl`
