### PR TITLE
fix: Triage: split catch-all mismatch/unsupported buckets into stable (fixes #116)

### DIFF
--- a/docs/lfortran_failure_taxonomy.md
+++ b/docs/lfortran_failure_taxonomy.md
@@ -1,0 +1,65 @@
+# LFortran Mass Failure Taxonomy
+
+This document defines the stable root-cause taxonomy used by
+`tools/lfortran_mass/report.py` summary artifacts.
+
+## Taxonomy Dimensions
+
+Each non-pass result is mapped to one node:
+
+`<stage>|<symptom>|<feature_family>`
+
+### Stage
+- `parse`: LLVM IR parse/IR construction failures.
+- `codegen`: LFortran emit failures before liric parse/JIT.
+- `jit-link`: entrypoint/signature/symbol resolution failures.
+- `runtime`: JIT execution failures after symbol/link setup.
+- `output-format`: differential run completed but outputs differ.
+
+### Symptom
+- `segfault`
+- `unresolved-symbol`
+- `wrong-stdout`
+- `wrong-stderr`
+- `wrong-stdout+stderr`
+- `rc-mismatch`
+- `unsupported-feature`
+- `unsupported-abi`
+- `compiler-error`
+- `infra-fail`
+- `unknown`
+
+### Feature Family
+- `intrinsics`
+- `complex`
+- `openmp`
+- `multi-file`
+- `runtime-api`
+- `general`
+
+## Bucket Mapping For Umbrella Issues
+
+This maps historical bucket issues to concrete child issues.
+
+### Differential mismatch bucket (`#80`, closed)
+
+- `output-format|wrong-stdout|general` -> `#54`
+- `output-format|wrong-stderr|general` -> `#55`
+- `output-format|rc-mismatch|general` -> `#16`
+- `output-format|wrong-stdout+stderr|general` -> `#16`
+
+### Unsupported bucket (`#81`, open)
+
+- `jit-link|unresolved-symbol|runtime-api` -> `#79`
+- `runtime|segfault|general` -> `#78`
+- `runtime|unsupported-feature|intrinsics` -> `#76`, `#75`
+- `runtime|unsupported-feature|complex` -> `#77`
+- `runtime|unsupported-feature|openmp` -> `#82`
+- `parse|unsupported-feature|general` -> `#50`, `#51`, `#53`, `#74`
+
+## Reporting
+
+`summary.json` and `summary.md` now include:
+- `taxonomy_counts`: all non-pass nodes.
+- `mismatch_taxonomy_counts`: only `mismatch` rows (`#80` lineage).
+- `unsupported_taxonomy_counts`: only `unsupported_feature`/`unsupported_abi` rows (`#81` lineage).

--- a/docs/lfortran_mass_testing.md
+++ b/docs/lfortran_mass_testing.md
@@ -7,6 +7,8 @@ source of unit test cases, plus integration metadata from
 evaluate compatibility in liric parse/JIT/runtime lanes.
 
 Roadmap and scorecard are tracked in `docs/lfortran_mass_tracker.md`.
+Stable mismatch/unsupported root-cause taxonomy is defined in
+`docs/lfortran_failure_taxonomy.md`.
 
 ## Design Principles
 - Reuse LFortran test configuration directly from `tests.toml`.
@@ -91,6 +93,7 @@ All artifacts are written under `/tmp/liric_lfortran_mass/`:
 - Skip reason histogram and skip reasons by corpus
 - Supported processed/passed counts
 - Unsupported histogram
+- Taxonomy counts per root-cause node (`stage|symptom|feature_family`)
 - Mismatch count
 - New supported regressions vs baseline
 - Gate decision

--- a/tools/lfortran_mass/classify.py
+++ b/tools/lfortran_mass/classify.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import re
-from typing import Dict
+from typing import Dict, Iterable, Mapping, Optional, Set
 
 PASS = "pass"
 MISMATCH = "mismatch"
@@ -14,6 +14,31 @@ LIRIC_JIT_FAIL = "liric_jit_fail"
 UNSUPPORTED_FEATURE = "unsupported_feature"
 UNSUPPORTED_ABI = "unsupported_abi"
 INFRA_FAIL = "infra_fail"
+
+TAXON_STAGE_PARSE = "parse"
+TAXON_STAGE_CODEGEN = "codegen"
+TAXON_STAGE_JIT_LINK = "jit-link"
+TAXON_STAGE_RUNTIME = "runtime"
+TAXON_STAGE_OUTPUT_FORMAT = "output-format"
+
+TAXON_SYMPTOM_SEGFAULT = "segfault"
+TAXON_SYMPTOM_UNRESOLVED_SYMBOL = "unresolved-symbol"
+TAXON_SYMPTOM_WRONG_STDOUT = "wrong-stdout"
+TAXON_SYMPTOM_WRONG_STDERR = "wrong-stderr"
+TAXON_SYMPTOM_WRONG_STDOUT_STDERR = "wrong-stdout+stderr"
+TAXON_SYMPTOM_RC_MISMATCH = "rc-mismatch"
+TAXON_SYMPTOM_UNSUPPORTED_FEATURE = "unsupported-feature"
+TAXON_SYMPTOM_UNSUPPORTED_ABI = "unsupported-abi"
+TAXON_SYMPTOM_COMPILER_ERROR = "compiler-error"
+TAXON_SYMPTOM_INFRA_FAIL = "infra-fail"
+TAXON_SYMPTOM_UNKNOWN = "unknown"
+
+TAXON_FAMILY_INTRINSICS = "intrinsics"
+TAXON_FAMILY_COMPLEX = "complex"
+TAXON_FAMILY_OPENMP = "openmp"
+TAXON_FAMILY_MULTI_FILE = "multi-file"
+TAXON_FAMILY_RUNTIME_API = "runtime-api"
+TAXON_FAMILY_GENERAL = "general"
 
 UNSUPPORTED_FEATURE_PATTERNS = [
     r"\bfcmp\b",
@@ -92,4 +117,117 @@ def counts(rows: list[Dict[str, str]]) -> Dict[str, int]:
     for row in rows:
         key = row.get("classification", INFRA_FAIL)
         out[key] = out.get(key, 0) + 1
+    return out
+
+
+def _row_text(row: Mapping[str, object]) -> str:
+    parts = [
+        str(row.get("reason", "")),
+        str(row.get("stage", "")),
+        str(row.get("source_path", "")),
+        str(row.get("filename", "")),
+        str(row.get("case_id", "")),
+        str(row.get("classification", "")),
+    ]
+    return " ".join(parts).lower()
+
+
+def _taxonomy_stage(classification: str, stage: str, text: str) -> str:
+    if classification == MISMATCH or stage == "differential":
+        return TAXON_STAGE_OUTPUT_FORMAT
+    if stage == "parse":
+        return TAXON_STAGE_PARSE
+    if stage in {"emit", "emit_prep"}:
+        return TAXON_STAGE_CODEGEN
+    if stage in {"entrypoint", "differential_prepare"}:
+        return TAXON_STAGE_JIT_LINK
+    if stage == "jit":
+        if "unresolved symbol" in text or "undefined symbol" in text:
+            return TAXON_STAGE_JIT_LINK
+        if " not found" in text:
+            return TAXON_STAGE_JIT_LINK
+        return TAXON_STAGE_RUNTIME
+    return TAXON_STAGE_RUNTIME
+
+
+def _taxonomy_mismatch_symptom(row: Mapping[str, object]) -> str:
+    rc_match = row.get("differential_rc_match")
+    stdout_match = row.get("differential_stdout_match")
+    stderr_match = row.get("differential_stderr_match")
+    if rc_match is False:
+        return TAXON_SYMPTOM_RC_MISMATCH
+    if stdout_match is False and stderr_match is False:
+        return TAXON_SYMPTOM_WRONG_STDOUT_STDERR
+    if stdout_match is False:
+        return TAXON_SYMPTOM_WRONG_STDOUT
+    if stderr_match is False:
+        return TAXON_SYMPTOM_WRONG_STDERR
+    return TAXON_SYMPTOM_UNKNOWN
+
+
+def _taxonomy_symptom(classification: str, row: Mapping[str, object], text: str) -> str:
+    if classification == MISMATCH:
+        return _taxonomy_mismatch_symptom(row)
+    if "segmentation fault" in text or "sigsegv" in text:
+        return TAXON_SYMPTOM_SEGFAULT
+    if "unresolved symbol" in text or "undefined symbol" in text:
+        return TAXON_SYMPTOM_UNRESOLVED_SYMBOL
+    if " not found" in text and "function" in text:
+        return TAXON_SYMPTOM_UNRESOLVED_SYMBOL
+    if classification == UNSUPPORTED_FEATURE:
+        return TAXON_SYMPTOM_UNSUPPORTED_FEATURE
+    if classification == UNSUPPORTED_ABI:
+        return TAXON_SYMPTOM_UNSUPPORTED_ABI
+    if classification in {LIRIC_PARSE_FAIL, LFORTRAN_EMIT_FAIL, LIRIC_JIT_FAIL}:
+        return TAXON_SYMPTOM_COMPILER_ERROR
+    if classification == INFRA_FAIL:
+        return TAXON_SYMPTOM_INFRA_FAIL
+    return TAXON_SYMPTOM_UNKNOWN
+
+
+def _taxonomy_feature_family(text: str) -> str:
+    if "openmp" in text or "libgomp" in text or "omp_" in text:
+        return TAXON_FAMILY_OPENMP
+    if "complex" in text:
+        return TAXON_FAMILY_COMPLEX
+    if "llvm." in text or "intrinsic" in text:
+        return TAXON_FAMILY_INTRINSICS
+    if "extrafile" in text or "multi-file" in text:
+        return TAXON_FAMILY_MULTI_FILE
+    if "lfortran_runtime" in text or "_lfortran_" in text:
+        return TAXON_FAMILY_RUNTIME_API
+    if "entry signature" in text or "unsupported signature" in text:
+        return TAXON_FAMILY_RUNTIME_API
+    return TAXON_FAMILY_GENERAL
+
+
+def taxonomy_node(row: Mapping[str, object]) -> Dict[str, str]:
+    classification = str(row.get("classification", INFRA_FAIL))
+    stage = str(row.get("stage", "")).lower()
+    text = _row_text(row)
+    out_stage = _taxonomy_stage(classification, stage, text)
+    out_symptom = _taxonomy_symptom(classification, row, text)
+    out_feature_family = _taxonomy_feature_family(text)
+    return {
+        "stage": out_stage,
+        "symptom": out_symptom,
+        "feature_family": out_feature_family,
+        "node": f"{out_stage}|{out_symptom}|{out_feature_family}",
+    }
+
+
+def taxonomy_counts(
+    rows: Iterable[Mapping[str, object]],
+    include_classifications: Optional[Set[str]] = None,
+    exclude_pass: bool = False,
+) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    for row in rows:
+        classification = str(row.get("classification", INFRA_FAIL))
+        if exclude_pass and classification == PASS:
+            continue
+        if include_classifications is not None and classification not in include_classifications:
+            continue
+        node = taxonomy_node(row)["node"]
+        out[node] = out.get(node, 0) + 1
     return out

--- a/tools/lfortran_mass/report.py
+++ b/tools/lfortran_mass/report.py
@@ -47,6 +47,14 @@ def summarize(
     selection_rows: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
     counts = classify.counts(processed)
+    taxonomy_counts = classify.taxonomy_counts(processed, exclude_pass=True)
+    mismatch_taxonomy_counts = classify.taxonomy_counts(
+        processed, include_classifications={classify.MISMATCH}
+    )
+    unsupported_taxonomy_counts = classify.taxonomy_counts(
+        processed,
+        include_classifications={classify.UNSUPPORTED_FEATURE, classify.UNSUPPORTED_ABI},
+    )
     mismatch_count = counts.get(classify.MISMATCH, 0)
     corpus_counts: Dict[str, int] = {}
     for row in processed:
@@ -139,6 +147,9 @@ def summarize(
         "differential_mismatch_total": diff_mismatch_total,
         "differential_mismatch_buckets": diff_mismatch_buckets,
         "classification_counts": counts,
+        "taxonomy_counts": taxonomy_counts,
+        "mismatch_taxonomy_counts": mismatch_taxonomy_counts,
+        "unsupported_taxonomy_counts": unsupported_taxonomy_counts,
         "corpus_counts": corpus_counts,
         "selected_by_corpus": selected_by_corpus,
         "skipped_by_corpus": skipped_by_corpus,
@@ -218,6 +229,27 @@ def write_summary_md(path: Path, summary: Dict[str, Any]) -> None:
     counts: Dict[str, int] = summary.get("classification_counts", {})
     for key in sorted(counts.keys()):
         lines.append(f"- {key}: {counts[key]}")
+
+    lines.append("")
+    lines.append("## Taxonomy Counts")
+    lines.append("")
+    tax_counts: Dict[str, int] = summary.get("taxonomy_counts", {})
+    for key in sorted(tax_counts.keys()):
+        lines.append(f"- {key}: {tax_counts[key]}")
+
+    lines.append("")
+    lines.append("## Taxonomy Counts (Mismatch)")
+    lines.append("")
+    mismatch_tax: Dict[str, int] = summary.get("mismatch_taxonomy_counts", {})
+    for key in sorted(mismatch_tax.keys()):
+        lines.append(f"- {key}: {mismatch_tax[key]}")
+
+    lines.append("")
+    lines.append("## Taxonomy Counts (Unsupported)")
+    lines.append("")
+    unsupported_tax: Dict[str, int] = summary.get("unsupported_taxonomy_counts", {})
+    for key in sorted(unsupported_tax.keys()):
+        lines.append(f"- {key}: {unsupported_tax[key]}")
 
     lines.append("")
     lines.append("## Differential Mismatch Buckets")

--- a/tools/lfortran_mass/test_report_selection.py
+++ b/tools/lfortran_mass/test_report_selection.py
@@ -80,6 +80,54 @@ class ReportSelectionSummaryTests(unittest.TestCase):
         self.assertEqual(summary["differential_mismatch_buckets"]["stdout_stderr"], 1)
         self.assertEqual(summary["differential_mismatch_buckets"]["unknown"], 1)
 
+    def test_taxonomy_histograms_are_reported(self) -> None:
+        processed = [
+            {
+                "case_id": "mismatch_stdout",
+                "classification": "mismatch",
+                "stage": "differential",
+                "differential_ok": True,
+                "differential_match": False,
+                "differential_rc_match": True,
+                "differential_stdout_match": False,
+                "differential_stderr_match": True,
+            },
+            {
+                "case_id": "unsupported_runtime",
+                "classification": "unsupported_abi",
+                "stage": "jit",
+                "reason": "unresolved symbol: _lfortran_abort",
+            },
+            {
+                "case_id": "pass_case",
+                "classification": "pass",
+                "stage": "differential",
+            },
+        ]
+        summary = report.summarize(
+            manifest_total=3,
+            processed=processed,
+            baseline=[],
+            selection_rows=[],
+        )
+
+        self.assertEqual(
+            summary["taxonomy_counts"]["output-format|wrong-stdout|general"], 1
+        )
+        self.assertEqual(
+            summary["taxonomy_counts"]["jit-link|unresolved-symbol|runtime-api"], 1
+        )
+        self.assertEqual(len(summary["taxonomy_counts"]), 2)
+        self.assertEqual(
+            summary["mismatch_taxonomy_counts"]["output-format|wrong-stdout|general"], 1
+        )
+        self.assertEqual(
+            summary["unsupported_taxonomy_counts"][
+                "jit-link|unresolved-symbol|runtime-api"
+            ],
+            1,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add stable taxonomy extraction in mass classification (`stage|symptom|feature_family`)
- add taxonomy node histograms to mass summary JSON/Markdown for all non-pass rows, mismatch-only rows, and unsupported-only rows
- document taxonomy and explicit `#80`/`#81` bucket-to-child-issue mapping in-repo
- extend unit tests to cover taxonomy mapping and report aggregation

## Verification
- `python3 -m unittest tools.lfortran_mass.test_classify tools.lfortran_mass.test_report_selection 2>&1 | tee /tmp/test.log`
  - excerpt: `Ran 12 tests in 0.001s` and `OK`
- `grep -nE "FAILED|ERROR|Traceback" /tmp/test.log || true`
  - no matches

## Artifacts
- test log: `/tmp/test.log`
- taxonomy doc: `docs/lfortran_failure_taxonomy.md`
