### PR TITLE
Fix LLVM-compat state tracking and recover API object-mode execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,17 @@ Coverage: `270` completed tests, `3` iterations each.
 
 | Metric | liric | lli | Speedup |
 |---|---:|---:|---:|
-| Wall median | `10.064 ms` | `20.119 ms` | **2.00x** |
-| Wall aggregate | `2777.65 ms` | `6936.12 ms` | **2.50x** |
-| Materialization median (`parse+compile+lookup` vs `parse+jit+lookup`) | `0.518 ms` | `4.365 ms` | **8.43x** |
-| Materialization aggregate | `215.79 ms` | `2873.72 ms` | **13.32x** |
+| Wall median | `10.084 ms` | `30.176 ms` | **2.99x** |
+| Wall aggregate | `2803.50 ms` | `8963.53 ms` | **3.20x** |
+| Materialization median (`parse+compile+lookup` vs `parse+jit+lookup`) | `0.713 ms` | `6.088 ms` | **9.14x** |
+| Materialization aggregate | `267.20 ms` | `3834.94 ms` | **14.35x** |
 
 Phase split medians:
-- liric: parse `0.476 ms`, compile `0.045 ms`, lookup `0.0001 ms`
-- lli: parse `0.252 ms`, jit `0.0029 ms`, lookup `4.070 ms`
+- liric: parse `0.656 ms`, compile `0.059 ms`, lookup `0.0001 ms`
+- lli: parse `0.378 ms`, jit `0.0041 ms`, lookup `5.717 ms`
 
 Faster-case counts:
-- wall: `267/270`
+- wall: `269/270`
 - materialization: `270/270`
 
 ### API JIT Mode (Primary, `bench_api_jit`)
@@ -104,34 +104,43 @@ Coverage: `100` attempted, `100` completed, `0` skipped.
 
 | Metric | liric | LLVM baseline | Speedup |
 |---|---:|---:|---:|
-| Frontend median (shared LFortran emit) | `11.148 ms` | `11.148 ms` | `1.00x` |
-| Wall median (frontend + materialization + first call) | `11.864 ms` | `17.595 ms` | **1.48x** |
-| Wall aggregate | `1556.97 ms` | `2777.17 ms` | **1.78x** |
-| JIT materialization median | `0.584 ms` | `6.392 ms` | **10.95x** |
-| JIT materialization aggregate | `86.41 ms` | `1330.53 ms` | **15.40x** |
-| Execution median (entry call only) | `0.017 ms` | `0.020 ms` | **1.19x** |
+| Frontend median (shared LFortran emit) | `10.887 ms` | `10.887 ms` | `1.00x` |
+| Wall median (frontend + materialization + first call) | `11.537 ms` | `18.069 ms` | **1.54x** |
+| Wall aggregate | `1543 ms` | `2794 ms` | **1.81x** |
+| JIT materialization median | `0.619 ms` | `6.755 ms` | **11.97x** |
+| JIT materialization aggregate | `87 ms` | `1346 ms` | **15.43x** |
+| Execution median (entry call only) | `0.017 ms` | `0.021 ms` | **1.22x** |
 
 Faster-case counts:
 - wall: `99/100`
 - materialization: `100/100`
-- execution: `78/100`
+- execution: `80/100`
 
 ### API Object Mode (Legacy, `bench_api`)
 
-The object/link/run benchmark is still available, but it is currently blocked by runtime hangs in `lfortran` `WITH_LIRIC` binaries.
-
-Smoke command:
+Command:
 
 ```bash
-./build/bench_api --iters 1 --timeout 5 --bench-dir /tmp/liric_bench \
-  --compat-list /tmp/liric_bench/compat_api_smoke10.txt \
-  --options-jsonl /tmp/liric_bench/compat_api_smoke10_options.jsonl \
-  --min-completed 0
+./build/bench_api --iters 3 --bench-dir /tmp/liric_bench --min-completed 1
 ```
 
-Result: `10` attempted, `0` completed, `10` skipped (`liric_run_timeout`).
+Coverage: `100` attempted, `18` completed, `82` skipped (`liric_run_failed`).
 
-Interpretation: object-mode numbers are not used for current API performance KPIs; API performance tracking is based on `bench_api_jit`.
+| Metric | lfortran+`WITH_LIRIC` | lfortran+LLVM | Speedup |
+|---|---:|---:|---:|
+| Wall median (compile+run) | `29.086 ms` | `39.514 ms` | **1.39x** |
+| Wall aggregate | `522 ms` | `736 ms` | **1.41x** |
+| Compile median | `28.532 ms` | `38.877 ms` | **1.39x** |
+| Compile aggregate | `512 ms` | `726 ms` | **1.42x** |
+| Run median | `0.541 ms` | `0.556 ms` | **1.01x** |
+| Run aggregate | `10 ms` | `10 ms` | **1.03x** |
+
+Faster-case counts (completed set only):
+- wall: `18/18`
+- compile: `18/18`
+- run: `11/18`
+
+Interpretation: object-mode is no longer fully blocked, but coverage is still partial (`82` run failures). Primary API KPIs remain based on `bench_api_jit`.
 
 ## License
 

--- a/include/llvm/IR/BasicBlock.h
+++ b/include/llvm/IR/BasicBlock.h
@@ -1,6 +1,7 @@
 #ifndef LLVM_IR_BASICBLOCK_H
 #define LLVM_IR_BASICBLOCK_H
 
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Value.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -33,7 +34,9 @@ public:
                               Function *Parent = nullptr,
                               BasicBlock *InsertBefore = nullptr);
 
-    Function *getParent() const { return detail::current_function; }
+    Function *getParent() const {
+        return detail::lookup_block_parent(impl_block());
+    }
     Module *getModule() const { return nullptr; }
 
     bool empty() const {

--- a/include/llvm/IR/GlobalVariable.h
+++ b/include/llvm/IR/GlobalVariable.h
@@ -20,6 +20,9 @@ public:
     };
 
     GlobalVariable() = default;
+    ~GlobalVariable() {
+        detail::unregister_value_wrapper(this);
+    }
 
     GlobalVariable(Module &M, Type *Ty, bool isConstant,
                    LinkageTypes Linkage, Constant *Initializer = nullptr,

--- a/include/llvm/IR/LLVMContext.h
+++ b/include/llvm/IR/LLVMContext.h
@@ -2,6 +2,7 @@
 #define LLVM_IR_LLVMCONTEXT_H
 
 #include <liric/liric_compat.h>
+#include <unordered_map>
 
 namespace llvm {
 
@@ -10,6 +11,57 @@ class Function;
 namespace detail {
     inline thread_local lc_module_compat_t *fallback_module = nullptr;
     inline thread_local Function *current_function = nullptr;
+    inline thread_local std::unordered_map<const void *, lc_value_t *>
+        value_wrappers;
+    inline thread_local std::unordered_map<const lr_func_t *, Function *>
+        function_wrappers;
+    inline thread_local std::unordered_map<const lr_block_t *, Function *>
+        block_parents;
+
+    inline void register_value_wrapper(const void *obj, lc_value_t *v) {
+        if (obj && v) value_wrappers[obj] = v;
+    }
+
+    inline lc_value_t *lookup_value_wrapper(const void *obj) {
+        auto it = value_wrappers.find(obj);
+        return it == value_wrappers.end() ? nullptr : it->second;
+    }
+
+    inline void unregister_value_wrapper(const void *obj) {
+        if (obj) value_wrappers.erase(obj);
+    }
+
+    inline void register_function_wrapper(const lr_func_t *f, Function *fn) {
+        if (f && fn) function_wrappers[f] = fn;
+    }
+
+    inline Function *lookup_function_wrapper(const lr_func_t *f) {
+        auto it = function_wrappers.find(f);
+        return it == function_wrappers.end() ? nullptr : it->second;
+    }
+
+    inline void unregister_function_wrapper(const lr_func_t *f) {
+        if (f) function_wrappers.erase(f);
+    }
+
+    inline void register_block_parent(const lr_block_t *b, Function *fn) {
+        if (b && fn) block_parents[b] = fn;
+    }
+
+    inline Function *lookup_block_parent(const lr_block_t *b) {
+        auto it = block_parents.find(b);
+        return it == block_parents.end() ? nullptr : it->second;
+    }
+
+    inline void unregister_blocks_for_function(Function *fn) {
+        for (auto it = block_parents.begin(); it != block_parents.end();) {
+            if (it->second == fn) {
+                it = block_parents.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
 }
 
 class LLVMContext {

--- a/include/llvm/IR/Type.h
+++ b/include/llvm/IR/Type.h
@@ -43,7 +43,6 @@ public:
     };
 
     lr_type_t *impl() const {
-        if (!this) return nullptr;
         return const_cast<lr_type_t *>(
             reinterpret_cast<const lr_type_t *>(this));
     }

--- a/include/llvm/IR/Value.h
+++ b/include/llvm/IR/Value.h
@@ -13,6 +13,9 @@ class raw_ostream;
 class Value {
 public:
     lc_value_t *impl() const {
+        if (lc_value_t *wrapped = detail::lookup_value_wrapper(this)) {
+            return wrapped;
+        }
         return const_cast<lc_value_t *>(
             reinterpret_cast<const lc_value_t *>(this));
     }


### PR DESCRIPTION
## Summary
- fix LLVM-compat function/block tracking so declaration creation no longer corrupts active function state
- add wrapper-value mapping for object wrappers (`Function`, `GlobalVariable`) so `Value::impl()` resolves correct `lc_value_t`
- make `IRBuilder` resync module/function state from insertion blocks (including block-ref fallback)
- fix `CreateGlobalStringPtr()` to emit correctly typed NUL-terminated globals
- add LLVM-compat regressions for block-parent tracking and builder/module sync
- refresh README benchmark metrics for LL mode, API JIT mode, and API object mode

## Validation
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`
- local lfortran repro (`print *, 2+3`) with `build-liric` now runs successfully (was hanging/failing before)
- benchmark refresh:
  - `./build/bench_ll --iters 3 --timeout 20 --bench-dir /tmp/liric_bench`
  - `./build/bench_api_jit --iters 3 --bench-dir /tmp/liric_bench --min-completed 1`
  - `./build/bench_api --iters 3 --bench-dir /tmp/liric_bench --min-completed 1`

## Benchmark snapshot (2026-02-09)
- LL mode: wall median `2.99x` faster; materialization median `9.14x` faster
- API JIT mode: wall median `1.54x` faster; materialization median `11.97x` faster
- API object mode: no longer fully blocked; `18/100` completed (still `82` `liric_run_failed` skips)

## Issue linkage
- Progress toward: #102, #156
- No issue is fully closed by this PR (object mode remains partial coverage).
