### PR TITLE
fix: Flatten IR linked lists to arrays for cache-friendly backend tra (fixes #96)

### DIFF
--- a/include/liric/liric_types.h
+++ b/include/liric/liric_types.h
@@ -54,6 +54,7 @@ struct lr_block {
     struct lr_inst *last;
     struct lr_inst **inst_array;
     uint32_t num_insts;
+    struct lr_func *func;
     struct lr_block *next;
 };
 
@@ -69,6 +70,9 @@ struct lr_func {
     lr_block_t *first_block;
     lr_block_t *last_block;
     lr_block_t **block_array;
+    struct lr_inst **linear_inst_array;
+    uint32_t *block_inst_offsets;
+    uint32_t num_linear_insts;
     uint32_t num_blocks;
     uint32_t next_vreg;
     struct lr_func *next;

--- a/src/ir.h
+++ b/src/ir.h
@@ -152,6 +152,7 @@ typedef struct lr_block {
     lr_inst_t *last;
     lr_inst_t **inst_array;
     uint32_t num_insts;
+    struct lr_func *func;
     struct lr_block *next;
 } lr_block_t;
 
@@ -167,6 +168,9 @@ typedef struct lr_func {
     lr_block_t *first_block;
     lr_block_t *last_block;
     lr_block_t **block_array;
+    lr_inst_t **linear_inst_array;
+    uint32_t *block_inst_offsets;
+    uint32_t num_linear_insts;
     uint32_t num_blocks;
     uint32_t next_vreg;
     struct lr_func *next;

--- a/src/target_aarch64.c
+++ b/src/target_aarch64.c
@@ -98,15 +98,10 @@ static uint32_t *build_vreg_use_counts(lr_arena_t *arena, lr_func_t *func,
     for (uint32_t i = 0; i < func->next_vreg; i++)
         counts[i] = 0;
 
-    for (uint32_t bi = 0; bi < func->num_blocks; bi++) {
-        lr_block_t *b = func->block_array[bi];
-        if (!b)
-            continue;
-        for (uint32_t ii = 0; ii < b->num_insts; ii++) {
-            lr_inst_t *inst = b->inst_array[ii];
-            for (uint32_t oi = 0; oi < inst->num_operands; oi++)
-                count_vreg_use(counts, func->next_vreg, &inst->operands[oi]);
-        }
+    for (uint32_t ii = 0; ii < func->num_linear_insts; ii++) {
+        lr_inst_t *inst = func->linear_inst_array[ii];
+        for (uint32_t oi = 0; oi < inst->num_operands; oi++)
+            count_vreg_use(counts, func->next_vreg, &inst->operands[oi]);
     }
 
     if (phi_copies) {

--- a/src/target_shared.c
+++ b/src/target_shared.c
@@ -56,17 +56,14 @@ void lr_target_prescan_static_alloca_offsets(lr_func_t *func,
         return;
     }
 
-    for (uint32_t bi = 0; bi < func->num_blocks; bi++) {
-        const lr_block_t *b = func->block_array[bi];
-        for (uint32_t ii = 0; ii < b->num_insts; ii++) {
-            const lr_inst_t *inst = b->inst_array[ii];
-            if (inst->op != LR_OP_ALLOCA) {
-                continue;
-            }
-            if (!lr_target_alloca_uses_static_storage(inst)) {
-                continue;
-            }
-            (void)ensure(ctx, inst);
+    for (uint32_t ii = 0; ii < func->num_linear_insts; ii++) {
+        const lr_inst_t *inst = func->linear_inst_array[ii];
+        if (inst->op != LR_OP_ALLOCA) {
+            continue;
         }
+        if (!lr_target_alloca_uses_static_storage(inst)) {
+            continue;
+        }
+        (void)ensure(ctx, inst);
     }
 }

--- a/src/target_x86_64.c
+++ b/src/target_x86_64.c
@@ -99,15 +99,10 @@ static uint32_t *build_vreg_use_counts(lr_arena_t *arena, lr_func_t *func,
     for (uint32_t i = 0; i < func->next_vreg; i++)
         counts[i] = 0;
 
-    for (uint32_t bi = 0; bi < func->num_blocks; bi++) {
-        lr_block_t *b = func->block_array[bi];
-        if (!b)
-            continue;
-        for (uint32_t ii = 0; ii < b->num_insts; ii++) {
-            lr_inst_t *inst = b->inst_array[ii];
-            for (uint32_t oi = 0; oi < inst->num_operands; oi++)
-                count_vreg_use(counts, func->next_vreg, &inst->operands[oi]);
-        }
+    for (uint32_t ii = 0; ii < func->num_linear_insts; ii++) {
+        lr_inst_t *inst = func->linear_inst_array[ii];
+        for (uint32_t oi = 0; oi < inst->num_operands; oi++)
+            count_vreg_use(counts, func->next_vreg, &inst->operands[oi]);
     }
 
     if (phi_copies) {


### PR DESCRIPTION
## Summary
- add function-level finalized linear instruction caches (`linear_inst_array` and `block_inst_offsets`) while keeping linked-list construction APIs unchanged
- invalidate/rebuild linear caches on IR mutation (`lr_block_create`, `lr_block_append`)
- switch backend shared prescan and vreg-use counting helpers to traverse the linear cache
- make `lr_build_phi_copies()` always finalize first so partially stale per-block caches cannot be observed
- extend `tests/test_target_shared.c` to verify linear cache build/invalidation/rebuild and phi-copy rebuild after mutation

## Verification
- `./tools/arch_regen.sh`
  - `Architecture regeneration complete`
- `cmake -S . -B build -G Ninja && cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
  - `100% tests passed, 0 tests failed out of 7`
- `grep -nE "(FAIL|Error|FAILED|Assertion|Segmentation fault)" /tmp/test.log || true`
  - no matches

Artifacts:
- `/tmp/test.log`
