### PR TITLE
fix: perf(jit): eliminate repeated function finalization in materiali (fixes #194)

### DIFF
--- a/src/ir.h
+++ b/src/ir.h
@@ -236,6 +236,7 @@ lr_inst_t *lr_inst_create(lr_arena_t *a, lr_opcode_t op, lr_type_t *type,
                            uint32_t dest, lr_operand_t *ops, uint32_t nops);
 void lr_block_append(lr_block_t *b, lr_inst_t *inst);
 int lr_func_finalize(lr_func_t *f, lr_arena_t *a);
+bool lr_func_is_finalized(const lr_func_t *f);
 lr_global_t *lr_global_create(lr_module_t *m, const char *name, lr_type_t *type,
                                bool is_const);
 

--- a/src/target_aarch64.c
+++ b/src/target_aarch64.c
@@ -892,8 +892,6 @@ static int aarch64_compile_func(lr_func_t *func, lr_module_t *mod,
                                  uint8_t *buf, size_t buflen, size_t *out_len,
                                  lr_arena_t *arena) {
     lr_arena_t *layout_arena = (mod && mod->arena) ? mod->arena : arena;
-    if (lr_func_finalize(func, layout_arena) != 0)
-        return -1;
 
     uint32_t nb = func->num_blocks > 0 ? func->num_blocks : 1;
     uint32_t fc = nb * 2;

--- a/src/target_shared.c
+++ b/src/target_shared.c
@@ -52,7 +52,7 @@ void lr_target_prescan_static_alloca_offsets(lr_func_t *func,
         return;
     }
 
-    if (lr_func_finalize(func, arena) != 0) {
+    if (!lr_func_is_finalized(func) && lr_func_finalize(func, arena) != 0) {
         return;
     }
 

--- a/src/target_x86_64.c
+++ b/src/target_x86_64.c
@@ -1030,8 +1030,6 @@ static int x86_64_compile_func(lr_func_t *func, lr_module_t *mod,
                                 uint8_t *buf, size_t buflen, size_t *out_len,
                                 lr_arena_t *arena) {
     lr_arena_t *layout_arena = (mod && mod->arena) ? mod->arena : arena;
-    if (lr_func_finalize(func, layout_arena) != 0)
-        return -1;
 
     uint32_t nb = func->num_blocks > 0 ? func->num_blocks : 1;
     uint32_t fc = nb * 2;

--- a/tests/test_target_shared.c
+++ b/tests/test_target_shared.c
@@ -123,12 +123,14 @@ int test_ir_finalize_builds_dense_arrays(void) {
     TEST_ASSERT(func->linear_inst_array == NULL, "linear inst array starts null");
     TEST_ASSERT(func->block_inst_offsets == NULL, "block offsets start null");
     TEST_ASSERT(entry->inst_array == NULL, "inst array starts null");
+    TEST_ASSERT(!lr_func_is_finalized(func), "fresh function is not finalized");
 
     lr_block_append(entry, add_inst);
     lr_block_append(entry, br_inst);
     lr_block_append(exit, ret_inst);
 
     TEST_ASSERT_EQ(lr_func_finalize(func, arena), 0, "finalize succeeds");
+    TEST_ASSERT(lr_func_is_finalized(func), "function reports finalized after finalize");
     TEST_ASSERT(func->block_array != NULL, "block array populated");
     TEST_ASSERT(func->block_array[entry->id] == entry, "entry indexed by block id");
     TEST_ASSERT(func->block_array[exit->id] == exit, "exit indexed by block id");
@@ -155,8 +157,10 @@ int test_ir_finalize_builds_dense_arrays(void) {
     TEST_ASSERT(func->linear_inst_array == NULL, "append invalidates linear inst array");
     TEST_ASSERT(func->block_inst_offsets == NULL, "append invalidates block offsets");
     TEST_ASSERT_EQ(func->num_linear_insts, 0, "append resets linear inst count");
+    TEST_ASSERT(!lr_func_is_finalized(func), "append invalidates finalized state");
 
     TEST_ASSERT_EQ(lr_func_finalize(func, arena), 0, "re-finalize succeeds");
+    TEST_ASSERT(lr_func_is_finalized(func), "re-finalize restores finalized state");
     TEST_ASSERT_EQ(exit->num_insts, 2, "re-finalize updates instruction count");
     TEST_ASSERT(exit->inst_array[1] == tail_ret, "new instruction appears in rebuilt cache");
     TEST_ASSERT_EQ(func->num_linear_insts, 4, "re-finalize updates linear inst count");
@@ -168,7 +172,9 @@ int test_ir_finalize_builds_dense_arrays(void) {
     TEST_ASSERT(func->block_array == NULL, "new block invalidates block array");
     TEST_ASSERT(func->linear_inst_array == NULL, "new block invalidates linear inst array");
     TEST_ASSERT(func->block_inst_offsets == NULL, "new block invalidates block offsets");
+    TEST_ASSERT(!lr_func_is_finalized(func), "new block invalidates finalized state");
     TEST_ASSERT_EQ(lr_func_finalize(func, arena), 0, "finalize rebuilds block array");
+    TEST_ASSERT(lr_func_is_finalized(func), "function is finalized after rebuild");
     TEST_ASSERT(func->block_array != NULL, "rebuilt block array is present");
     TEST_ASSERT_EQ(func->num_blocks, 3, "function now has three blocks");
     TEST_ASSERT_EQ(func->num_linear_insts, 4, "empty block does not change linear inst count");


### PR DESCRIPTION
## Summary
- finalize all non-declaration functions once in `lr_jit_add_module()` before compile-order and symbol-resolution passes
- remove redundant finalize calls from JIT compile-order/resolve flow and backend compile entrypoints (`x86_64`, `aarch64`)
- add `lr_func_is_finalized()` and use it in shared fallback helpers (`lr_build_phi_copies`, static-alloca prescan) so non-JIT paths remain safe
- extend IR finalize tests to assert finalized-state invalidation/rebuild behavior

## Verification
- `./tools/arch_regen.sh`
- `cmake -S . -B build -G Ninja && cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
- `grep -Ein "error|fail|failed" /tmp/test.log || true`
- `./build/bench_ll --iters 1 --timeout 15 2>&1 | tee /tmp/bench_ll.log`
- Baseline comparison in temporary `origin/main` worktree:
  - `./build/bench_ll --iters 1 --timeout 15 --runtime-lib /home/ert/code/lfortran-dev/lfortran/build/src/runtime/liblfortran_runtime.so --bench-dir /tmp/liric_bench_baseline 2>&1 | tee /tmp/bench_ll_baseline.log`
- Targeted timing artifacts:
  - `./build/liric_probe_runner --ignore-retcode --timing --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so --func main --sig i32_argc_argv /tmp/liric_bench/ll/functions_30.ll 2>&1 | tee /tmp/probe_functions_30.log`
  - `./build/liric_probe_runner --ignore-retcode --timing --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so --func main --sig i32_argc_argv /tmp/liric_bench/ll/arrays_30.ll 2>&1 | tee /tmp/probe_arrays_30.log`
  - `./build/liric_probe_runner --ignore-retcode --timing --load-lib ../lfortran/build/src/runtime/liblfortran_runtime.so --func main --sig i32_argc_argv /tmp/liric_bench/ll/print_arr_08.ll 2>&1 | tee /tmp/probe_print_arr_08.log`

### Output excerpts
- Tests: `100% tests passed, 0 tests failed out of 8`
- `bench_ll` materialization median (`liric`):
  - branch: `0.465300 ms` (`/tmp/liric_bench/bench_ll_summary.json`)
  - baseline (`origin/main`): `0.470500 ms` (`/tmp/liric_bench_baseline/bench_ll_summary.json`)
- Large-case materialization (`liric_parse_compile_lookup_median_ms`, branch vs baseline):
  - `functions_30`: `12.8201 ms` vs `13.1945 ms` (delta `-0.3744 ms`)
  - `arrays_30`: `6.7970 ms` vs `7.2085 ms` (delta `-0.4115 ms`)
  - `print_arr_08`: `7.1906 ms` vs `8.3798 ms` (delta `-1.1892 ms`)
- Targeted probe timing logs:
  - `/tmp/probe_functions_30.log`: `compile_us=3054.4`
  - `/tmp/probe_arrays_30.log`: `compile_us=1823.0`
  - `/tmp/probe_print_arr_08.log`: `compile_us=1808.6`

### Artifacts
- `/tmp/test.log`
- `/tmp/bench_ll.log`
- `/tmp/bench_ll_baseline.log`
- `/tmp/liric_bench/bench_ll.jsonl`
- `/tmp/liric_bench/bench_ll_summary.json`
- `/tmp/liric_bench_baseline/bench_ll.jsonl`
- `/tmp/liric_bench_baseline/bench_ll_summary.json`
- `/tmp/probe_functions_30.log`
- `/tmp/probe_arrays_30.log`
- `/tmp/probe_print_arr_08.log`
