### PR TITLE
fix: perf(jit): add lazy on-demand function materialization (avoid ea (fixes #196)

### DIFF
--- a/src/jit.h
+++ b/src/jit.h
@@ -24,6 +24,8 @@ typedef struct lr_sym_miss_entry {
     struct lr_sym_miss_entry *bucket_next;
 } lr_sym_miss_entry_t;
 
+typedef struct lr_lazy_func_entry lr_lazy_func_entry_t;
+
 struct lr_jit;
 typedef void *(*lr_symbol_provider_resolve_fn)(struct lr_jit *jit, const char *name);
 
@@ -52,6 +54,10 @@ typedef struct lr_jit {
     uint32_t sym_bucket_count;
     lr_sym_miss_entry_t **miss_buckets;
     uint32_t miss_bucket_count;
+    lr_lazy_func_entry_t *lazy_funcs;
+    lr_lazy_func_entry_t **lazy_func_buckets;
+    uint32_t lazy_func_bucket_count;
+    uint32_t materialize_depth;
     lr_lib_entry_t *libs;
     lr_symbol_provider_t *symbol_providers;
     lr_symbol_provider_t *symbol_providers_tail;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -100,6 +100,7 @@ int test_jit_batched_module_updates(void);
 int test_jit_self_recursive_call(void);
 int test_jit_self_recursive_call_ignores_prebound_symbol(void);
 int test_jit_unresolved_symbol_fails(void);
+int test_jit_lazy_materializes_reachable_functions_only(void);
 int test_jit_fadd_double_bits(void);
 int test_jit_fmul_float_bits(void);
 int test_jit_phi_select_nested(void);
@@ -253,6 +254,7 @@ int main(void) {
     RUN_TEST(test_jit_self_recursive_call);
     RUN_TEST(test_jit_self_recursive_call_ignores_prebound_symbol);
     RUN_TEST(test_jit_unresolved_symbol_fails);
+    RUN_TEST(test_jit_lazy_materializes_reachable_functions_only);
     RUN_TEST(test_jit_fadd_double_bits);
     RUN_TEST(test_jit_fmul_float_bits);
     RUN_TEST(test_jit_phi_select_nested);


### PR DESCRIPTION
## Summary
- implement lazy function materialization in the JIT: `lr_jit_add_module()` now registers/finalizes module functions and defers codegen until first use
- compile transitive lazy dependencies during relocation patching, with cycle-safe in-progress tracking and nested W^X transition handling
- allow module-global relocations to trigger lazy function materialization for function-pointer globals (for example vtables)
- update JIT tests for lazy unresolved-symbol behavior and add a reachable-only lazy materialization test

## Verification
- `./tools/arch_regen.sh`
  - excerpt: `Architecture regeneration complete`
  - artifact: `/tmp/arch_regen.log`
- `./build/test_liric`
  - excerpt: `136 tests: 136 passed, 0 failed`
  - artifact: `/tmp/test_liric_single.log`
- `ctest --test-dir build --output-on-failure -E '^liric_tests$'`
  - excerpt: `100% tests passed, 0 tests failed out of 7`
  - artifact: `/tmp/test_extra.log`
