### PR TITLE
fix: perf(jit): add correctness-safe function materialization cache (fixes #197)

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -46,6 +46,8 @@ static double lr_jit_now_us(void) {
 #define SYM_BUCKET_COUNT 8192u
 #define MISS_BUCKET_COUNT 4096u
 #define LAZY_FUNC_BUCKET_COUNT 8192u
+#define MATERIALIZE_CACHE_BUCKET_COUNT 4096u
+#define MATERIALIZE_CACHE_SCHEMA_VERSION 1u
 
 typedef enum lr_lazy_func_state {
     LR_LAZY_FUNC_PENDING = 0,
@@ -58,11 +60,58 @@ struct lr_lazy_func_entry {
     uint32_t hash;
     lr_module_t *module;
     lr_func_t *func;
+    const uint8_t *module_sig;
+    size_t module_sig_len;
+    const uint8_t *func_sig;
+    size_t func_sig_len;
     void *pending_addr;
     lr_lazy_func_state_t state;
     lr_lazy_func_entry_t *next;
     lr_lazy_func_entry_t *bucket_next;
 };
+
+typedef struct lr_sig_buf {
+    uint8_t *data;
+    size_t len;
+    size_t cap;
+} lr_sig_buf_t;
+
+typedef struct lr_cached_reloc {
+    uint32_t offset;
+    uint8_t type;
+    const char *symbol_name;
+} lr_cached_reloc_t;
+
+typedef struct lr_mat_cache_entry {
+    uint64_t key_hash;
+    uint32_t epoch;
+    uint8_t target_ptr_size;
+    const char *target_name;
+    uint8_t *module_sig;
+    size_t module_sig_len;
+    uint8_t *func_sig;
+    size_t func_sig_len;
+    uint8_t *code;
+    size_t code_len;
+    lr_cached_reloc_t *relocs;
+    uint32_t num_relocs;
+    struct lr_mat_cache_entry *bucket_next;
+    struct lr_mat_cache_entry *next;
+} lr_mat_cache_entry_t;
+
+/*
+ * Cache correctness invariants:
+ * - Reuse requires exact module/function signature byte equality.
+ * - Reuse is scoped by target identity + ptr size + cache schema + epoch.
+ * - Stored code is pre-relocation bytes; stored reloc metadata is replayed.
+ * - Replay failures are hard failures (no silent compile fallback).
+ */
+static lr_mat_cache_entry_t *g_mat_cache_buckets[MATERIALIZE_CACHE_BUCKET_COUNT];
+static lr_mat_cache_entry_t *g_mat_cache_entries;
+static uint64_t g_mat_cache_hit_count;
+static uint64_t g_mat_cache_miss_count;
+static uint64_t g_mat_cache_entry_count;
+static uint32_t g_mat_cache_epoch = 1u;
 
 static void register_builtin_symbols(lr_jit_t *j);
 static int register_default_symbol_providers(lr_jit_t *j);
@@ -71,6 +120,7 @@ static void *resolve_symbol_from_loaded_libraries(lr_jit_t *j, const char *name)
 static void *resolve_symbol_from_process(lr_jit_t *j, const char *name);
 static lr_lazy_func_entry_t *find_lazy_func_entry(lr_jit_t *j, const char *name, uint32_t hash);
 static int materialize_lazy_function(lr_jit_t *j, lr_lazy_func_entry_t *entry);
+static int jit_ensure_module_symbols_interned(lr_module_t *m);
 
 static uint32_t symbol_hash(const char *name) {
     uint32_t h = 2166136261u;
@@ -79,6 +129,594 @@ static uint32_t symbol_hash(const char *name) {
         h *= 16777619u;
     }
     return h;
+}
+
+static uint64_t hash64_extend(uint64_t h, const void *data, size_t n) {
+    const uint8_t *p = (const uint8_t *)data;
+    for (size_t i = 0; i < n; i++) {
+        h ^= (uint64_t)p[i];
+        h *= 1099511628211ull;
+    }
+    return h;
+}
+
+static int sig_buf_reserve(lr_sig_buf_t *sb, size_t add) {
+    if (!sb)
+        return -1;
+    if (add > SIZE_MAX - sb->len)
+        return -1;
+    size_t need = sb->len + add;
+    if (need <= sb->cap)
+        return 0;
+    size_t new_cap = sb->cap ? sb->cap : 256u;
+    while (new_cap < need) {
+        if (new_cap > (SIZE_MAX / 2u)) {
+            new_cap = need;
+            break;
+        }
+        new_cap *= 2u;
+    }
+    uint8_t *new_data = (uint8_t *)realloc(sb->data, new_cap);
+    if (!new_data)
+        return -1;
+    sb->data = new_data;
+    sb->cap = new_cap;
+    return 0;
+}
+
+static int sig_buf_append(lr_sig_buf_t *sb, const void *data, size_t n) {
+    if (n == 0)
+        return 0;
+    if (sig_buf_reserve(sb, n) != 0)
+        return -1;
+    memcpy(sb->data + sb->len, data, n);
+    sb->len += n;
+    return 0;
+}
+
+static int sig_buf_u8(lr_sig_buf_t *sb, uint8_t v) {
+    return sig_buf_append(sb, &v, sizeof(v));
+}
+
+static int sig_buf_u32(lr_sig_buf_t *sb, uint32_t v) {
+    return sig_buf_append(sb, &v, sizeof(v));
+}
+
+static int sig_buf_u64(lr_sig_buf_t *sb, uint64_t v) {
+    return sig_buf_append(sb, &v, sizeof(v));
+}
+
+static int sig_buf_i64(lr_sig_buf_t *sb, int64_t v) {
+    return sig_buf_append(sb, &v, sizeof(v));
+}
+
+static int sig_buf_double_bits(lr_sig_buf_t *sb, double v) {
+    uint64_t bits = 0;
+    memcpy(&bits, &v, sizeof(bits));
+    return sig_buf_u64(sb, bits);
+}
+
+static int sig_buf_str(lr_sig_buf_t *sb, const char *s) {
+    uint32_t len = s ? (uint32_t)strlen(s) : 0u;
+    if (sig_buf_u32(sb, len) != 0)
+        return -1;
+    if (len == 0)
+        return 0;
+    return sig_buf_append(sb, s, len);
+}
+
+static int sig_serialize_type(lr_sig_buf_t *sb, const lr_type_t *t) {
+    if (!t)
+        return sig_buf_u8(sb, 0xFFu);
+
+    if (sig_buf_u8(sb, (uint8_t)t->kind) != 0)
+        return -1;
+
+    switch (t->kind) {
+    case LR_TYPE_ARRAY:
+        if (sig_buf_u64(sb, t->array.count) != 0)
+            return -1;
+        return sig_serialize_type(sb, t->array.elem);
+    case LR_TYPE_STRUCT:
+        if (sig_buf_u8(sb, t->struc.packed ? 1u : 0u) != 0)
+            return -1;
+        if (sig_buf_str(sb, t->struc.name) != 0)
+            return -1;
+        if (sig_buf_u32(sb, t->struc.num_fields) != 0)
+            return -1;
+        for (uint32_t i = 0; i < t->struc.num_fields; i++) {
+            if (sig_serialize_type(sb, t->struc.fields[i]) != 0)
+                return -1;
+        }
+        return 0;
+    case LR_TYPE_FUNC:
+        if (sig_serialize_type(sb, t->func.ret) != 0)
+            return -1;
+        if (sig_buf_u32(sb, t->func.num_params) != 0)
+            return -1;
+        if (sig_buf_u8(sb, t->func.vararg ? 1u : 0u) != 0)
+            return -1;
+        for (uint32_t i = 0; i < t->func.num_params; i++) {
+            if (sig_serialize_type(sb, t->func.params[i]) != 0)
+                return -1;
+        }
+        return 0;
+    default:
+        return 0;
+    }
+}
+
+static int sig_serialize_operand(lr_sig_buf_t *sb, const lr_operand_t *op,
+                                 const lr_module_t *m) {
+    if (!op)
+        return -1;
+    if (sig_buf_u8(sb, (uint8_t)op->kind) != 0)
+        return -1;
+    if (sig_serialize_type(sb, op->type) != 0)
+        return -1;
+    if (sig_buf_i64(sb, op->global_offset) != 0)
+        return -1;
+
+    switch (op->kind) {
+    case LR_VAL_VREG:
+        return sig_buf_u32(sb, op->vreg);
+    case LR_VAL_IMM_I64:
+        return sig_buf_i64(sb, op->imm_i64);
+    case LR_VAL_IMM_F64:
+        return sig_buf_double_bits(sb, op->imm_f64);
+    case LR_VAL_BLOCK:
+        return sig_buf_u32(sb, op->block_id);
+    case LR_VAL_GLOBAL: {
+        const char *sym_name = m ? lr_module_symbol_name(m, op->global_id) : NULL;
+        if (sig_buf_u32(sb, op->global_id) != 0)
+            return -1;
+        return sig_buf_str(sb, sym_name);
+    }
+    case LR_VAL_NULL:
+    case LR_VAL_UNDEF:
+        return 0;
+    default:
+        return -1;
+    }
+}
+
+static int sig_serialize_inst(lr_sig_buf_t *sb, const lr_inst_t *inst,
+                              const lr_module_t *m) {
+    if (!inst)
+        return -1;
+    if (sig_buf_u8(sb, (uint8_t)inst->op) != 0)
+        return -1;
+    if (sig_serialize_type(sb, inst->type) != 0)
+        return -1;
+    if (sig_buf_u32(sb, inst->dest) != 0)
+        return -1;
+    if (sig_buf_u32(sb, inst->num_operands) != 0)
+        return -1;
+    if (sig_buf_u32(sb, inst->num_indices) != 0)
+        return -1;
+    if (sig_buf_u8(sb, inst->call_external_abi ? 1u : 0u) != 0)
+        return -1;
+    if (sig_buf_u8(sb, inst->call_vararg ? 1u : 0u) != 0)
+        return -1;
+    if (sig_buf_u32(sb, (uint32_t)inst->icmp_pred) != 0)
+        return -1;
+    if (sig_buf_u32(sb, (uint32_t)inst->fcmp_pred) != 0)
+        return -1;
+
+    for (uint32_t i = 0; i < inst->num_operands; i++) {
+        if (sig_serialize_operand(sb, &inst->operands[i], m) != 0)
+            return -1;
+    }
+    for (uint32_t i = 0; i < inst->num_indices; i++) {
+        if (sig_buf_u32(sb, inst->indices ? inst->indices[i] : 0u) != 0)
+            return -1;
+    }
+    return 0;
+}
+
+static int sig_serialize_block(lr_sig_buf_t *sb, const lr_block_t *b,
+                               const lr_module_t *m) {
+    if (!b)
+        return -1;
+    if (sig_buf_u32(sb, b->id) != 0)
+        return -1;
+    if (sig_buf_str(sb, b->name) != 0)
+        return -1;
+
+    uint32_t num_insts = b->num_insts;
+    if (num_insts == 0) {
+        for (const lr_inst_t *inst = b->first; inst; inst = inst->next)
+            num_insts++;
+    }
+    if (sig_buf_u32(sb, num_insts) != 0)
+        return -1;
+
+    if (b->inst_array && b->num_insts == num_insts) {
+        for (uint32_t i = 0; i < num_insts; i++) {
+            if (sig_serialize_inst(sb, b->inst_array[i], m) != 0)
+                return -1;
+        }
+        return 0;
+    }
+
+    uint32_t seen = 0;
+    for (const lr_inst_t *inst = b->first; inst; inst = inst->next) {
+        if (sig_serialize_inst(sb, inst, m) != 0)
+            return -1;
+        seen++;
+    }
+    return seen == num_insts ? 0 : -1;
+}
+
+static int sig_serialize_function(lr_sig_buf_t *sb, const lr_module_t *m,
+                                  const lr_func_t *f) {
+    if (!f)
+        return -1;
+    if (sig_buf_str(sb, f->name) != 0)
+        return -1;
+    if (sig_buf_u8(sb, f->is_decl ? 1u : 0u) != 0)
+        return -1;
+    if (sig_buf_u8(sb, f->vararg ? 1u : 0u) != 0)
+        return -1;
+    if (sig_buf_u32(sb, f->num_params) != 0)
+        return -1;
+    if (sig_buf_u32(sb, f->next_vreg) != 0)
+        return -1;
+    if (sig_serialize_type(sb, f->ret_type) != 0)
+        return -1;
+    if (sig_serialize_type(sb, f->type) != 0)
+        return -1;
+    for (uint32_t i = 0; i < f->num_params; i++) {
+        if (sig_serialize_type(sb, f->param_types ? f->param_types[i] : NULL) != 0)
+            return -1;
+    }
+    for (uint32_t i = 0; i < f->num_params; i++) {
+        uint32_t vreg = f->param_vregs ? f->param_vregs[i] : 0u;
+        if (sig_buf_u32(sb, vreg) != 0)
+            return -1;
+    }
+
+    if (sig_buf_u32(sb, f->num_blocks) != 0)
+        return -1;
+    if (f->num_blocks == 0)
+        return 0;
+
+    if (f->block_array) {
+        for (uint32_t bi = 0; bi < f->num_blocks; bi++) {
+            if (sig_serialize_block(sb, f->block_array[bi], m) != 0)
+                return -1;
+        }
+        return 0;
+    }
+
+    uint32_t seen = 0;
+    for (const lr_block_t *b = f->first_block; b; b = b->next) {
+        if (sig_serialize_block(sb, b, m) != 0)
+            return -1;
+        seen++;
+    }
+    return seen == f->num_blocks ? 0 : -1;
+}
+
+static int sig_serialize_global(lr_sig_buf_t *sb, const lr_global_t *g) {
+    if (!g)
+        return -1;
+    if (sig_buf_str(sb, g->name) != 0)
+        return -1;
+    if (sig_serialize_type(sb, g->type) != 0)
+        return -1;
+    if (sig_buf_u8(sb, g->is_const ? 1u : 0u) != 0)
+        return -1;
+    if (sig_buf_u8(sb, g->is_external ? 1u : 0u) != 0)
+        return -1;
+    if (sig_buf_u32(sb, g->id) != 0)
+        return -1;
+
+    if (sig_buf_u64(sb, (uint64_t)g->init_size) != 0)
+        return -1;
+    if (g->init_size > 0 && sig_buf_append(sb, g->init_data, g->init_size) != 0)
+        return -1;
+
+    uint32_t reloc_count = 0;
+    for (const lr_reloc_t *r = g->relocs; r; r = r->next)
+        reloc_count++;
+    if (sig_buf_u32(sb, reloc_count) != 0)
+        return -1;
+    for (const lr_reloc_t *r = g->relocs; r; r = r->next) {
+        if (sig_buf_u64(sb, (uint64_t)r->offset) != 0)
+            return -1;
+        if (sig_buf_i64(sb, r->addend) != 0)
+            return -1;
+        if (sig_buf_str(sb, r->symbol_name) != 0)
+            return -1;
+    }
+    return 0;
+}
+
+static int sig_serialize_module(lr_sig_buf_t *sb, const lr_module_t *m) {
+    if (!m)
+        return -1;
+    if (sig_buf_u32(sb, m->num_symbols) != 0)
+        return -1;
+    for (uint32_t i = 0; i < m->num_symbols; i++) {
+        const char *sym_name = (m->symbol_names && i < m->num_symbols) ? m->symbol_names[i] : NULL;
+        uint32_t sym_hash = m->symbol_hashes ? m->symbol_hashes[i]
+                                             : (sym_name ? symbol_hash(sym_name) : 0u);
+        if (sig_buf_u32(sb, sym_hash) != 0)
+            return -1;
+        if (sig_buf_str(sb, sym_name) != 0)
+            return -1;
+    }
+
+    uint32_t nfuncs = 0;
+    for (const lr_func_t *f = m->first_func; f; f = f->next)
+        nfuncs++;
+    if (sig_buf_u32(sb, nfuncs) != 0)
+        return -1;
+    for (const lr_func_t *f = m->first_func; f; f = f->next) {
+        if (sig_serialize_function(sb, m, f) != 0)
+            return -1;
+    }
+
+    uint32_t nglobals = 0;
+    for (const lr_global_t *g = m->first_global; g; g = g->next)
+        nglobals++;
+    if (sig_buf_u32(sb, nglobals) != 0)
+        return -1;
+    for (const lr_global_t *g = m->first_global; g; g = g->next) {
+        if (sig_serialize_global(sb, g) != 0)
+            return -1;
+    }
+
+    return 0;
+}
+
+static int build_module_signature(const lr_module_t *m, uint8_t **out, size_t *out_len) {
+    lr_sig_buf_t sb = {0};
+    if (!out || !out_len)
+        return -1;
+    if (sig_serialize_module(&sb, m) != 0) {
+        free(sb.data);
+        return -1;
+    }
+    *out = sb.data;
+    *out_len = sb.len;
+    return 0;
+}
+
+static int build_function_signature(const lr_module_t *m, const lr_func_t *f,
+                                    uint8_t **out, size_t *out_len) {
+    lr_sig_buf_t sb = {0};
+    if (!out || !out_len)
+        return -1;
+    if (sig_serialize_function(&sb, m, f) != 0) {
+        free(sb.data);
+        return -1;
+    }
+    *out = sb.data;
+    *out_len = sb.len;
+    return 0;
+}
+
+static const uint8_t *arena_dup_bytes(lr_arena_t *arena, const uint8_t *src, size_t n) {
+    if (!arena || !src || n == 0)
+        return NULL;
+    uint8_t *dst = (uint8_t *)lr_arena_alloc_uninit(arena, n, _Alignof(uint8_t));
+    if (!dst)
+        return NULL;
+    memcpy(dst, src, n);
+    return dst;
+}
+
+static uint64_t materialize_key_hash(const lr_target_t *target,
+                                     const uint8_t *module_sig, size_t module_sig_len,
+                                     const uint8_t *func_sig, size_t func_sig_len,
+                                     uint32_t epoch) {
+    const uint64_t seed = 1469598103934665603ull;
+    const char *target_name = (target && target->name) ? target->name : "";
+    uint32_t schema = MATERIALIZE_CACHE_SCHEMA_VERSION;
+    uint32_t tname_len = (uint32_t)strlen(target_name);
+    uint8_t ptr_size = target ? target->ptr_size : 0u;
+    uint64_t h = seed;
+    h = hash64_extend(h, &schema, sizeof(schema));
+    h = hash64_extend(h, &epoch, sizeof(epoch));
+    h = hash64_extend(h, &ptr_size, sizeof(ptr_size));
+    h = hash64_extend(h, &tname_len, sizeof(tname_len));
+    h = hash64_extend(h, target_name, tname_len);
+    h = hash64_extend(h, &module_sig_len, sizeof(module_sig_len));
+    h = hash64_extend(h, module_sig, module_sig_len);
+    h = hash64_extend(h, &func_sig_len, sizeof(func_sig_len));
+    h = hash64_extend(h, func_sig, func_sig_len);
+    return h;
+}
+
+static void free_materialize_cache_entry(lr_mat_cache_entry_t *entry) {
+    if (!entry)
+        return;
+    free((char *)entry->target_name);
+    free(entry->module_sig);
+    free(entry->func_sig);
+    free(entry->code);
+    if (entry->relocs) {
+        for (uint32_t i = 0; i < entry->num_relocs; i++)
+            free((void *)entry->relocs[i].symbol_name);
+    }
+    free(entry->relocs);
+    free(entry);
+}
+
+static void clear_materialize_cache_entries(void) {
+    lr_mat_cache_entry_t *entry = g_mat_cache_entries;
+    while (entry) {
+        lr_mat_cache_entry_t *next = entry->next;
+        free_materialize_cache_entry(entry);
+        entry = next;
+    }
+    memset(g_mat_cache_buckets, 0, sizeof(g_mat_cache_buckets));
+    g_mat_cache_entries = NULL;
+    g_mat_cache_entry_count = 0;
+}
+
+static bool materialize_cache_key_matches(const lr_mat_cache_entry_t *entry,
+                                          const lr_target_t *target,
+                                          const uint8_t *module_sig, size_t module_sig_len,
+                                          const uint8_t *func_sig, size_t func_sig_len,
+                                          uint32_t epoch) {
+    const char *target_name = (target && target->name) ? target->name : "";
+    if (!entry || entry->epoch != epoch)
+        return false;
+    if (entry->target_ptr_size != (target ? target->ptr_size : 0u))
+        return false;
+    if (strcmp(entry->target_name ? entry->target_name : "", target_name) != 0)
+        return false;
+    if (entry->module_sig_len != module_sig_len || entry->func_sig_len != func_sig_len)
+        return false;
+    if (module_sig_len > 0 && memcmp(entry->module_sig, module_sig, module_sig_len) != 0)
+        return false;
+    if (func_sig_len > 0 && memcmp(entry->func_sig, func_sig, func_sig_len) != 0)
+        return false;
+    return true;
+}
+
+static const lr_mat_cache_entry_t *materialize_cache_lookup(const lr_target_t *target,
+                                                            const uint8_t *module_sig,
+                                                            size_t module_sig_len,
+                                                            const uint8_t *func_sig,
+                                                            size_t func_sig_len) {
+    if (!target || !module_sig || module_sig_len == 0 || !func_sig || func_sig_len == 0) {
+        g_mat_cache_miss_count++;
+        return NULL;
+    }
+
+    uint64_t key_hash = materialize_key_hash(target, module_sig, module_sig_len,
+                                             func_sig, func_sig_len, g_mat_cache_epoch);
+    uint32_t bucket = (uint32_t)(key_hash & (MATERIALIZE_CACHE_BUCKET_COUNT - 1u));
+    for (lr_mat_cache_entry_t *entry = g_mat_cache_buckets[bucket]; entry; entry = entry->bucket_next) {
+        if (entry->key_hash != key_hash)
+            continue;
+        if (materialize_cache_key_matches(entry, target, module_sig, module_sig_len,
+                                          func_sig, func_sig_len, g_mat_cache_epoch)) {
+            g_mat_cache_hit_count++;
+            return entry;
+        }
+    }
+    g_mat_cache_miss_count++;
+    return NULL;
+}
+
+static int materialize_cache_insert(const lr_target_t *target,
+                                    const uint8_t *module_sig, size_t module_sig_len,
+                                    const uint8_t *func_sig, size_t func_sig_len,
+                                    const uint8_t *code, size_t code_len,
+                                    const lr_cached_reloc_t *relocs,
+                                    uint32_t num_relocs) {
+    if (!target || !module_sig || module_sig_len == 0 || !func_sig || func_sig_len == 0 ||
+        !code || code_len == 0)
+        return -1;
+
+    uint64_t key_hash = materialize_key_hash(target, module_sig, module_sig_len,
+                                             func_sig, func_sig_len, g_mat_cache_epoch);
+    uint32_t bucket = (uint32_t)(key_hash & (MATERIALIZE_CACHE_BUCKET_COUNT - 1u));
+    for (lr_mat_cache_entry_t *entry = g_mat_cache_buckets[bucket]; entry; entry = entry->bucket_next) {
+        if (entry->key_hash != key_hash)
+            continue;
+        if (materialize_cache_key_matches(entry, target, module_sig, module_sig_len,
+                                          func_sig, func_sig_len, g_mat_cache_epoch))
+            return 0;
+    }
+
+    lr_mat_cache_entry_t *entry = (lr_mat_cache_entry_t *)calloc(1, sizeof(*entry));
+    if (!entry)
+        return -1;
+    entry->key_hash = key_hash;
+    entry->epoch = g_mat_cache_epoch;
+    entry->target_ptr_size = target->ptr_size;
+    entry->target_name = target->name ? strdup(target->name) : strdup("");
+    if (!entry->target_name)
+        goto fail;
+
+    entry->module_sig = (uint8_t *)malloc(module_sig_len);
+    entry->func_sig = (uint8_t *)malloc(func_sig_len);
+    entry->code = (uint8_t *)malloc(code_len);
+    if (!entry->module_sig || !entry->func_sig || !entry->code)
+        goto fail;
+    memcpy(entry->module_sig, module_sig, module_sig_len);
+    memcpy(entry->func_sig, func_sig, func_sig_len);
+    memcpy(entry->code, code, code_len);
+    entry->module_sig_len = module_sig_len;
+    entry->func_sig_len = func_sig_len;
+    entry->code_len = code_len;
+
+    if (num_relocs > 0) {
+        entry->relocs = (lr_cached_reloc_t *)calloc(num_relocs, sizeof(*entry->relocs));
+        if (!entry->relocs)
+            goto fail;
+        entry->num_relocs = num_relocs;
+        for (uint32_t i = 0; i < num_relocs; i++) {
+            entry->relocs[i].offset = relocs[i].offset;
+            entry->relocs[i].type = relocs[i].type;
+            entry->relocs[i].symbol_name = relocs[i].symbol_name
+                ? strdup(relocs[i].symbol_name)
+                : strdup("");
+            if (!entry->relocs[i].symbol_name)
+                goto fail;
+        }
+    }
+
+    entry->bucket_next = g_mat_cache_buckets[bucket];
+    g_mat_cache_buckets[bucket] = entry;
+    entry->next = g_mat_cache_entries;
+    g_mat_cache_entries = entry;
+    g_mat_cache_entry_count++;
+    return 0;
+
+fail:
+    free_materialize_cache_entry(entry);
+    return -1;
+}
+
+void lr_jit_materialize_cache_invalidate_all(void) {
+    clear_materialize_cache_entries();
+    g_mat_cache_epoch++;
+    if (g_mat_cache_epoch == 0u)
+        g_mat_cache_epoch = 1u;
+}
+
+uint32_t lr_jit_materialize_cache_epoch(void) {
+    return g_mat_cache_epoch;
+}
+
+void lr_jit_materialize_cache_reset_stats(void) {
+    g_mat_cache_hit_count = 0;
+    g_mat_cache_miss_count = 0;
+}
+
+uint64_t lr_jit_materialize_cache_hits(void) {
+    return g_mat_cache_hit_count;
+}
+
+uint64_t lr_jit_materialize_cache_misses(void) {
+    return g_mat_cache_miss_count;
+}
+
+uint64_t lr_jit_materialize_cache_entries(void) {
+    return g_mat_cache_entry_count;
+}
+
+static int jit_ensure_module_symbols_interned(lr_module_t *m) {
+    if (!m)
+        return -1;
+    for (lr_func_t *f = m->first_func; f; f = f->next) {
+        if (f->name && f->name[0] &&
+            lr_module_intern_symbol(m, f->name) == UINT32_MAX)
+            return -1;
+    }
+    for (lr_global_t *g = m->first_global; g; g = g->next) {
+        if (g->name && g->name[0] &&
+            lr_module_intern_symbol(m, g->name) == UINT32_MAX)
+            return -1;
+    }
+    return 0;
 }
 
 static float llvm_fabs_f32(float x) { return fabsf(x); }
@@ -315,7 +953,9 @@ static lr_lazy_func_entry_t *find_lazy_func_entry(lr_jit_t *j, const char *name,
     return NULL;
 }
 
-static lr_lazy_func_entry_t *upsert_lazy_func_entry(lr_jit_t *j, lr_module_t *m, lr_func_t *f) {
+static lr_lazy_func_entry_t *upsert_lazy_func_entry(lr_jit_t *j, lr_module_t *m, lr_func_t *f,
+                                                    const uint8_t *module_sig, size_t module_sig_len,
+                                                    const uint8_t *func_sig, size_t func_sig_len) {
     if (!j || !f || !f->name || !f->name[0] || !m)
         return NULL;
 
@@ -324,6 +964,10 @@ static lr_lazy_func_entry_t *upsert_lazy_func_entry(lr_jit_t *j, lr_module_t *m,
     if (existing) {
         existing->module = m;
         existing->func = f;
+        existing->module_sig = module_sig;
+        existing->module_sig_len = module_sig_len;
+        existing->func_sig = func_sig;
+        existing->func_sig_len = func_sig_len;
         existing->pending_addr = NULL;
         existing->state = LR_LAZY_FUNC_PENDING;
         return existing;
@@ -336,6 +980,10 @@ static lr_lazy_func_entry_t *upsert_lazy_func_entry(lr_jit_t *j, lr_module_t *m,
     entry->hash = hash;
     entry->module = m;
     entry->func = f;
+    entry->module_sig = module_sig;
+    entry->module_sig_len = module_sig_len;
+    entry->func_sig = func_sig;
+    entry->func_sig_len = func_sig_len;
     entry->pending_addr = NULL;
     entry->state = LR_LAZY_FUNC_PENDING;
     entry->next = j->lazy_funcs;
@@ -624,14 +1272,8 @@ static int finalize_module_functions(lr_module_t *m, lr_func_t **funcs, uint32_t
 static int jit_build_module_symbol_cache(lr_objfile_ctx_t *oc, lr_module_t *m) {
     if (!oc || !m)
         return -1;
-    for (lr_func_t *f = m->first_func; f; f = f->next) {
-        if (f->name && f->name[0])
-            lr_module_intern_symbol(m, f->name);
-    }
-    for (lr_global_t *g = m->first_global; g; g = g->next) {
-        if (g->name && g->name[0])
-            lr_module_intern_symbol(m, g->name);
-    }
+    if (jit_ensure_module_symbols_interned(m) != 0)
+        return -1;
 
     oc->module_sym_count = m->num_symbols;
     if (oc->module_sym_count == 0)
@@ -652,6 +1294,8 @@ static int jit_build_module_symbol_cache(lr_objfile_ctx_t *oc, lr_module_t *m) {
         if (!f->name || !f->name[0])
             continue;
         uint32_t sym_id = lr_module_intern_symbol(m, f->name);
+        if (sym_id == UINT32_MAX)
+            return -1;
         if (sym_id >= oc->module_sym_count)
             continue;
         oc->module_sym_funcs[sym_id] = f;
@@ -662,6 +1306,8 @@ static int jit_build_module_symbol_cache(lr_objfile_ctx_t *oc, lr_module_t *m) {
         if (!g->name || !g->name[0] || g->is_external)
             continue;
         uint32_t sym_id = lr_module_intern_symbol(m, g->name);
+        if (sym_id == UINT32_MAX)
+            return -1;
         if (sym_id < oc->module_sym_count)
             oc->module_sym_defined[sym_id] = 1;
     }
@@ -859,6 +1505,89 @@ static int apply_jit_relocs(lr_jit_t *j, const lr_objfile_ctx_t *ctx, const char
     return rc;
 }
 
+static int capture_function_relocs(const lr_objfile_ctx_t *fixup_ctx, uint32_t reloc_base,
+                                   uint32_t code_base, lr_cached_reloc_t **out_relocs,
+                                   uint32_t *out_num_relocs) {
+    if (!fixup_ctx || !out_relocs || !out_num_relocs)
+        return -1;
+    *out_relocs = NULL;
+    *out_num_relocs = 0;
+
+    if (fixup_ctx->num_relocs < reloc_base)
+        return -1;
+    uint32_t num = fixup_ctx->num_relocs - reloc_base;
+    if (num == 0)
+        return 0;
+
+    lr_cached_reloc_t *cached = (lr_cached_reloc_t *)calloc(num, sizeof(*cached));
+    if (!cached)
+        return -1;
+
+    for (uint32_t i = 0; i < num; i++) {
+        const lr_obj_reloc_t *rel = &fixup_ctx->relocs[reloc_base + i];
+        if (rel->symbol_idx >= fixup_ctx->num_symbols) {
+            free(cached);
+            return -1;
+        }
+        if (rel->offset < code_base) {
+            free(cached);
+            return -1;
+        }
+        const char *sym_name = fixup_ctx->symbols[rel->symbol_idx].name;
+        if (!sym_name || !sym_name[0]) {
+            free(cached);
+            return -1;
+        }
+
+        cached[i].offset = rel->offset - code_base;
+        cached[i].type = rel->type;
+        cached[i].symbol_name = sym_name;
+    }
+
+    *out_relocs = cached;
+    *out_num_relocs = num;
+    return 0;
+}
+
+static int replay_cached_function(lr_jit_t *j, lr_objfile_ctx_t *fixup_ctx,
+                                  const lr_lazy_func_entry_t *entry,
+                                  const lr_mat_cache_entry_t *cached_entry,
+                                  void **func_addr_out) {
+    if (!j || !fixup_ctx || !entry || !entry->name || !cached_entry || !cached_entry->code)
+        return -1;
+    if (cached_entry->code_len == 0)
+        return -1;
+
+    size_t free_space = j->code_cap - j->code_size;
+    if (cached_entry->code_len > free_space)
+        return -1;
+
+    uint32_t code_base = (uint32_t)j->code_size;
+    uint8_t *func_start = j->code_buf + j->code_size;
+    uint32_t sym_idx = lr_obj_ensure_symbol(fixup_ctx, entry->name, true, 1, code_base);
+    if (sym_idx == UINT32_MAX)
+        return -1;
+
+    memcpy(func_start, cached_entry->code, cached_entry->code_len);
+
+    for (uint32_t i = 0; i < cached_entry->num_relocs; i++) {
+        const lr_cached_reloc_t *rel = &cached_entry->relocs[i];
+        if (!rel->symbol_name || !rel->symbol_name[0])
+            return -1;
+        if (rel->offset >= cached_entry->code_len)
+            return -1;
+        uint32_t reloc_sym = lr_obj_ensure_symbol(fixup_ctx, rel->symbol_name, false, 0, 0);
+        if (reloc_sym == UINT32_MAX)
+            return -1;
+        lr_obj_add_reloc(fixup_ctx, code_base + rel->offset, reloc_sym, rel->type);
+    }
+
+    if (func_addr_out)
+        *func_addr_out = func_start;
+    j->code_size += cached_entry->code_len;
+    return 0;
+}
+
 static int compile_one_function(lr_jit_t *j, lr_module_t *m, lr_func_t *f,
                                 lr_objfile_ctx_t *fixup_ctx, void **func_addr_out) {
     uint8_t *func_start = j->code_buf + j->code_size;
@@ -892,11 +1621,35 @@ static int register_lazy_module_functions(lr_jit_t *j, lr_module_t *m,
                                           lr_func_t **funcs, uint32_t nfuncs) {
     if (!j || !m)
         return -1;
+
+    if (jit_ensure_module_symbols_interned(m) != 0)
+        return -1;
+
+    uint8_t *module_sig_heap = NULL;
+    size_t module_sig_len = 0;
+    if (build_module_signature(m, &module_sig_heap, &module_sig_len) != 0)
+        return -1;
+
+    const uint8_t *module_sig = arena_dup_bytes(j->arena, module_sig_heap, module_sig_len);
+    free(module_sig_heap);
+    if (module_sig_len > 0 && !module_sig)
+        return -1;
+
     for (uint32_t i = 0; i < nfuncs; i++) {
         lr_func_t *f = funcs[i];
         if (!f || !f->name || !f->name[0])
             continue;
-        if (!upsert_lazy_func_entry(j, m, f))
+        uint8_t *func_sig_heap = NULL;
+        size_t func_sig_len = 0;
+        if (build_function_signature(m, f, &func_sig_heap, &func_sig_len) != 0)
+            return -1;
+        const uint8_t *func_sig = arena_dup_bytes(j->arena, func_sig_heap, func_sig_len);
+        free(func_sig_heap);
+        if (func_sig_len > 0 && !func_sig)
+            return -1;
+
+        if (!upsert_lazy_func_entry(j, m, f, module_sig, module_sig_len,
+                                    func_sig, func_sig_len))
             return -1;
         uint32_t hash = symbol_hash(f->name);
         if (!find_symbol_entry(j, f->name, hash))
@@ -922,6 +1675,13 @@ static int materialize_lazy_function(lr_jit_t *j, lr_lazy_func_entry_t *entry) {
     bool fixup_ctx_ready = false;
     void *saved_obj_ctx = NULL;
     bool obj_ctx_installed = false;
+    bool compiled_from_scratch = false;
+    uint32_t compiled_reloc_base = 0;
+    uint32_t compiled_code_base = 0;
+    size_t compiled_code_len = 0;
+    uint8_t *compiled_code_copy = NULL;
+    lr_cached_reloc_t *compiled_relocs = NULL;
+    uint32_t compiled_num_relocs = 0;
 
     j->materialize_depth++;
 
@@ -946,13 +1706,48 @@ static int materialize_lazy_function(lr_jit_t *j, lr_lazy_func_entry_t *entry) {
     entry->state = LR_LAZY_FUNC_COMPILING;
     entry->pending_addr = NULL;
 
-    JIT_PROF_START(compile_loop);
     void *func_addr = NULL;
-    int func_rc = compile_one_function(j, entry->module, entry->func, &fixup_ctx, &func_addr);
-    JIT_PROF_END(compile_loop);
-    if (func_rc != 0) {
-        rc = func_rc;
-        goto done;
+    const lr_mat_cache_entry_t *cached_entry =
+        materialize_cache_lookup(j->target, entry->module_sig, entry->module_sig_len,
+                                 entry->func_sig, entry->func_sig_len);
+
+    if (cached_entry) {
+        JIT_PROF_START(compile_loop);
+        int replay_rc = replay_cached_function(j, &fixup_ctx, entry, cached_entry, &func_addr);
+        JIT_PROF_END(compile_loop);
+        if (replay_rc != 0) {
+            rc = -1;
+            goto done;
+        }
+    } else {
+        compiled_from_scratch = true;
+        compiled_reloc_base = fixup_ctx.num_relocs;
+        compiled_code_base = (uint32_t)j->code_size;
+
+        JIT_PROF_START(compile_loop);
+        int func_rc = compile_one_function(j, entry->module, entry->func, &fixup_ctx, &func_addr);
+        JIT_PROF_END(compile_loop);
+        if (func_rc != 0) {
+            rc = func_rc;
+            goto done;
+        }
+
+        compiled_code_len = j->code_size - (size_t)compiled_code_base;
+        if (compiled_code_len == 0) {
+            rc = -1;
+            goto done;
+        }
+        compiled_code_copy = (uint8_t *)malloc(compiled_code_len);
+        if (!compiled_code_copy) {
+            rc = -1;
+            goto done;
+        }
+        memcpy(compiled_code_copy, j->code_buf + compiled_code_base, compiled_code_len);
+        if (capture_function_relocs(&fixup_ctx, compiled_reloc_base, compiled_code_base,
+                                    &compiled_relocs, &compiled_num_relocs) != 0) {
+            rc = -1;
+            goto done;
+        }
     }
     entry->pending_addr = func_addr;
 
@@ -996,6 +1791,16 @@ static int materialize_lazy_function(lr_jit_t *j, lr_lazy_func_entry_t *entry) {
     if (apply_module_global_relocs(j, entry->module) != 0)
         goto done;
 
+    if (compiled_from_scratch && compiled_code_copy &&
+        entry->module_sig && entry->module_sig_len > 0 &&
+        entry->func_sig && entry->func_sig_len > 0) {
+        (void)materialize_cache_insert(j->target,
+                                       entry->module_sig, entry->module_sig_len,
+                                       entry->func_sig, entry->func_sig_len,
+                                       compiled_code_copy, compiled_code_len,
+                                       compiled_relocs, compiled_num_relocs);
+    }
+
     rc = 0;
 
 done:
@@ -1013,6 +1818,10 @@ done:
         jit_free_obj_ctx(&fixup_ctx);
         fixup_ctx_ready = false;
     }
+    free(compiled_code_copy);
+    compiled_code_copy = NULL;
+    free(compiled_relocs);
+    compiled_relocs = NULL;
     if (j->update_active && j->code_size > code_size_before)
         j->update_dirty = true;
     if (own_wx_transition) {

--- a/src/jit.h
+++ b/src/jit.h
@@ -4,6 +4,7 @@
 #include "ir.h"
 #include "target.h"
 #include <stddef.h>
+#include <stdint.h>
 
 typedef struct lr_sym_entry {
     char *name;
@@ -75,6 +76,12 @@ int lr_jit_add_module(lr_jit_t *j, lr_module_t *m);
 void lr_jit_end_update(lr_jit_t *j);
 void *lr_jit_get_function(lr_jit_t *j, const char *name);
 void lr_jit_destroy(lr_jit_t *j);
+void lr_jit_materialize_cache_invalidate_all(void);
+uint32_t lr_jit_materialize_cache_epoch(void);
+void lr_jit_materialize_cache_reset_stats(void);
+uint64_t lr_jit_materialize_cache_hits(void);
+uint64_t lr_jit_materialize_cache_misses(void);
+uint64_t lr_jit_materialize_cache_entries(void);
 
 /*
  * POSIX guarantees void* and function pointers have the same size/representation.

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -101,6 +101,8 @@ int test_jit_self_recursive_call(void);
 int test_jit_self_recursive_call_ignores_prebound_symbol(void);
 int test_jit_unresolved_symbol_fails(void);
 int test_jit_lazy_materializes_reachable_functions_only(void);
+int test_jit_materialization_cache_reuse_across_jits(void);
+int test_jit_materialization_cache_invalidation_epoch(void);
 int test_jit_fadd_double_bits(void);
 int test_jit_fmul_float_bits(void);
 int test_jit_phi_select_nested(void);
@@ -255,6 +257,8 @@ int main(void) {
     RUN_TEST(test_jit_self_recursive_call_ignores_prebound_symbol);
     RUN_TEST(test_jit_unresolved_symbol_fails);
     RUN_TEST(test_jit_lazy_materializes_reachable_functions_only);
+    RUN_TEST(test_jit_materialization_cache_reuse_across_jits);
+    RUN_TEST(test_jit_materialization_cache_invalidation_epoch);
     RUN_TEST(test_jit_fadd_double_bits);
     RUN_TEST(test_jit_fmul_float_bits);
     RUN_TEST(test_jit_phi_select_nested);


### PR DESCRIPTION
## Summary
- add a correctness-first function materialization cache in `src/jit.c` keyed by deterministic module/function IR signatures plus target, pointer size, cache schema, and explicit epoch
- cache raw pre-relocation code blobs and relocation metadata, then replay relocations on cache hit with strict compatibility checks
- enforce explicit invalidation/version control via `lr_jit_materialize_cache_invalidate_all()` and expose cache hit/miss/entry stats APIs in `src/jit.h`
- add JIT tests for cache reuse across fresh JIT instances and for explicit invalidation epoch behavior (`tests/test_jit.c`, wired in `tests/test_main.c`)

## Verification
- `./tools/arch_regen.sh`
  - excerpt: `Architecture regeneration complete`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
  - excerpt: `100% tests passed, 0 tests failed out of 8`
- `grep -Ei "fail|error" /tmp/test.log || true`
  - excerpt: `100% tests passed, 0 tests failed out of 8`

## Artifacts
- test log: `/tmp/test.log`
- architecture export: `architecture/export/workspace.json`
