### PR TITLE
fix: meta(perf): materialization 10x program (no-shortcut correctness (fixes #199)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -102,6 +102,7 @@ int test_jit_self_recursive_call_ignores_prebound_symbol(void);
 int test_jit_unresolved_symbol_fails(void);
 int test_jit_lazy_materializes_reachable_functions_only(void);
 int test_jit_parallel_prefetch_replays_pending_functions(void);
+int test_jit_parallel_prefetch_caches_transitive_chain(void);
 int test_jit_parallel_prefetch_stress_repeatable(void);
 int test_jit_materialization_cache_reuse_across_jits(void);
 int test_jit_materialization_cache_invalidation_epoch(void);
@@ -260,6 +261,7 @@ int main(void) {
     RUN_TEST(test_jit_unresolved_symbol_fails);
     RUN_TEST(test_jit_lazy_materializes_reachable_functions_only);
     RUN_TEST(test_jit_parallel_prefetch_replays_pending_functions);
+    RUN_TEST(test_jit_parallel_prefetch_caches_transitive_chain);
     RUN_TEST(test_jit_parallel_prefetch_stress_repeatable);
     RUN_TEST(test_jit_materialization_cache_reuse_across_jits);
     RUN_TEST(test_jit_materialization_cache_invalidation_epoch);


### PR DESCRIPTION
## Summary
- Expand JIT materialization prefetch target discovery from direct callees to full reachable call graph traversal (BFS over pending lazy functions) in `src/jit.c`.
- Keep prefetch bounded/deterministic by restricting candidate tasks to the trigger module and deduplicating task entries.
- Add a new regression test `test_jit_parallel_prefetch_caches_transitive_chain` proving that transitive callees are prefetched into the materialization cache (not only immediate callees), and register it in `tests/test_main.c`.

## Verification
- `./tools/arch_regen.sh`
  - Completed successfully.
- `cmake --build build -j$(nproc)`
  - Build succeeded.
- `ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
  - `100% tests passed, 0 tests failed out of 8`
- `rg -n "FAIL|FAILED|Error|error" /tmp/test.log || true`
  - No matches.

### Artifact Notes
- `/tmp/test.log`
- `/tmp/mat_prefetch_compare.log`
- `/tmp/mat_prefetch_heavy_compare.log`
- `/tmp/mat_prefetch_very_heavy_compare.log`
- `/tmp/bench_corpus.log` (environment lacked corpus cache; command output: `no tests found in corpus`)
