### PR TITLE
fix: Integration link break: lfortran build-liric unresolved LLVM C A (fixes #211)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ if(LIRIC_ENABLE_LTO)
     endif()
 endif()
 
+option(LIRIC_ENABLE_LLVM_BITCODE "Enable in-process LLVM bitcode (.bc) decoding via LLVM C API" OFF)
+
 add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 
 if(UNIX AND NOT APPLE)
@@ -115,21 +117,25 @@ if(LLVM_CONFIG_EXE)
         OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    execute_process(
-        COMMAND ${LLVM_CONFIG_EXE} --libs core bitreader
-        OUTPUT_VARIABLE LLVM_BITCODE_LIBS
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
     separate_arguments(LLVM_LDFLAGS_LIST NATIVE_COMMAND "${LLVM_LDFLAGS}")
     separate_arguments(LLVM_LIBS_LIST NATIVE_COMMAND "${LLVM_LIBS}")
     separate_arguments(LLVM_SYSTEM_LIBS_LIST NATIVE_COMMAND "${LLVM_SYSTEM_LIBS}")
-    separate_arguments(LLVM_BITCODE_LIBS_LIST NATIVE_COMMAND "${LLVM_BITCODE_LIBS}")
 
-    if(LLVM_BITCODE_LIBS_LIST)
-        set(LIRIC_HAVE_LLVM_BITCODE ON)
-        set(LIRIC_LLVM_BITCODE_LDFLAGS_LIST ${LLVM_LDFLAGS_LIST})
-        set(LIRIC_LLVM_BITCODE_LIBS_LIST ${LLVM_BITCODE_LIBS_LIST})
-        set(LIRIC_LLVM_BITCODE_SYSTEM_LIBS_LIST ${LLVM_SYSTEM_LIBS_LIST})
+    if(LIRIC_ENABLE_LLVM_BITCODE)
+        execute_process(
+            COMMAND ${LLVM_CONFIG_EXE} --libs core bitreader
+            OUTPUT_VARIABLE LLVM_BITCODE_LIBS
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        separate_arguments(LLVM_BITCODE_LIBS_LIST NATIVE_COMMAND "${LLVM_BITCODE_LIBS}")
+        if(LLVM_BITCODE_LIBS_LIST)
+            set(LIRIC_HAVE_LLVM_BITCODE ON)
+            set(LIRIC_LLVM_BITCODE_LDFLAGS_LIST ${LLVM_LDFLAGS_LIST})
+            set(LIRIC_LLVM_BITCODE_LIBS_LIST ${LLVM_BITCODE_LIBS_LIST})
+            set(LIRIC_LLVM_BITCODE_SYSTEM_LIBS_LIST ${LLVM_SYSTEM_LIBS_LIST})
+        else()
+            message(WARNING "LIRIC_ENABLE_LLVM_BITCODE=ON but llvm-config did not return bitcode libraries; disabling LLVM bitcode decoder")
+        endif()
     endif()
 
     add_executable(bench_lli_phases tools/bench_lli_phases.c)
@@ -144,6 +150,9 @@ if(LLVM_CONFIG_EXE)
     )
 else()
     message(STATUS "llvm-config not found: bench_lli_phases target will not be built")
+    if(LIRIC_ENABLE_LLVM_BITCODE)
+        message(WARNING "LIRIC_ENABLE_LLVM_BITCODE=ON but llvm-config was not found; disabling LLVM bitcode decoder")
+    endif()
 endif()
 
 if(LIRIC_HAVE_LLVM_BITCODE)
@@ -237,6 +246,17 @@ add_test(
         -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_nightly_mass_shell_runner.cmake
 )
+
+if(CMAKE_NM)
+    add_test(
+        NAME liric_static_archive_no_llvm_undef_when_bitcode_off
+        COMMAND ${CMAKE_COMMAND}
+            -DNM_EXE=${CMAKE_NM}
+            -DARCHIVE=$<TARGET_FILE:liric>
+            -DHAVE_LLVM_BITCODE=${LIRIC_HAVE_LLVM_BITCODE}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_static_archive_symbols.cmake
+    )
+endif()
 
 include(GNUInstallDirs)
 install(TARGETS liric ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ cmake --build build -j$(nproc)
 ctest --test-dir build --output-on-failure
 ```
 
+Enable direct `.bc` decoding support (requires LLVM C API libs) only when needed:
+
+```bash
+cmake -S . -B build -G Ninja -DLIRIC_ENABLE_LLVM_BITCODE=ON
+```
+
 ## Run
 
 ```bash

--- a/tests/cmake/test_liric_static_archive_symbols.cmake
+++ b/tests/cmake/test_liric_static_archive_symbols.cmake
@@ -1,0 +1,34 @@
+if(HAVE_LLVM_BITCODE)
+    message(STATUS "Skipping LLVM symbol check: bitcode decoder is enabled")
+    return()
+endif()
+
+if(NOT DEFINED ARCHIVE OR ARCHIVE STREQUAL "")
+    message(FATAL_ERROR "ARCHIVE is required")
+endif()
+
+if(NOT EXISTS "${ARCHIVE}")
+    message(FATAL_ERROR "archive does not exist: ${ARCHIVE}")
+endif()
+
+set(_nm "${NM_EXE}")
+if(_nm STREQUAL "")
+    set(_nm nm)
+endif()
+
+execute_process(
+    COMMAND "${_nm}" -u "${ARCHIVE}"
+    RESULT_VARIABLE NM_RC
+    OUTPUT_VARIABLE NM_OUT
+    ERROR_VARIABLE NM_ERR
+)
+
+if(NOT NM_RC EQUAL 0)
+    message(FATAL_ERROR "nm failed (${NM_RC}): ${NM_ERR}")
+endif()
+
+string(REGEX MATCH "(^|[ \t\r\n])_?LLVM[A-Za-z0-9_]+" LLVM_UNDEF_MATCH "${NM_OUT}")
+if(LLVM_UNDEF_MATCH)
+    string(STRIP "${LLVM_UNDEF_MATCH}" LLVM_UNDEF_MATCH)
+    message(FATAL_ERROR "unexpected unresolved LLVM symbol in libliric.a: ${LLVM_UNDEF_MATCH}")
+endif()


### PR DESCRIPTION
## Summary
- make LLVM bitcode decoder opt-in via `-DLIRIC_ENABLE_LLVM_BITCODE=ON` (default remains off)
- keep `bench_lli_phases` auto-discovery unchanged while preventing default `libliric.a` from requiring LLVM C API symbols
- add a CTest guard that fails if unresolved `LLVM*` symbols appear in `libliric.a` when bitcode support is disabled
- document the new opt-in flag in `README.md`

## Verification
Commands run:
```bash
./tools/arch_regen.sh
set -o pipefail; (cmake -S . -B build-issue-211 -G Ninja && cmake --build build-issue-211 -j"$(nproc)" && ctest --test-dir build-issue-211 --output-on-failure -R "liric_tests|liric_static_archive_no_llvm_undef_when_bitcode_off") 2>&1 | tee /tmp/test.log
grep -nE "(FAIL|FAILED|Error|error:|undefined reference)" /tmp/test.log || true
cmake -LA -N build-issue-211 | rg "LIRIC_ENABLE_LLVM_BITCODE"
nm -u build-issue-211/libliric.a | rg "_?LLVM" -n || echo "no unresolved LLVM symbols"
```

Output excerpts:
- `LIRIC_ENABLE_LLVM_BITCODE:BOOL=OFF`
- `100% tests passed, 0 tests failed out of 2`
- `no unresolved LLVM symbols`

Artifacts:
- `/tmp/test.log`
- `build-issue-211/libliric.a`
