### PR TITLE
fix: P0 crash: WITH_LIRIC lfortran aborts on startup (--version) with (fixes #219)

### DIFF
--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -5,9 +5,15 @@
 #include <string>
 #include <string_view>
 
+#if defined(__GNUC__) || defined(__clang__)
+#define LIRIC_LLVM_HIDDEN __attribute__((visibility("hidden")))
+#else
+#define LIRIC_LLVM_HIDDEN
+#endif
+
 namespace llvm {
 
-class StringRef {
+class LIRIC_LLVM_HIDDEN StringRef {
     const char *data_;
     size_t len_;
 
@@ -33,5 +39,7 @@ public:
 };
 
 } // namespace llvm
+
+#undef LIRIC_LLVM_HIDDEN
 
 #endif

--- a/include/llvm/ADT/Twine.h
+++ b/include/llvm/ADT/Twine.h
@@ -2,28 +2,303 @@
 #define LLVM_ADT_TWINE_H
 
 #include "llvm/ADT/StringRef.h"
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
 #include <string>
+#include <string_view>
+
+#if defined(__GNUC__) || defined(__clang__)
+#define LIRIC_LLVM_HIDDEN __attribute__((visibility("hidden")))
+#else
+#define LIRIC_LLVM_HIDDEN
+#endif
 
 namespace llvm {
 
-class Twine {
-    std::string storage_;
+class formatv_object_base;
+
+class LIRIC_LLVM_HIDDEN Twine {
+    enum NodeKind : unsigned char {
+        NullKind,
+        EmptyKind,
+        TwineKind,
+        CStringKind,
+        StdStringKind,
+        PtrAndLengthKind,
+        StringLiteralKind,
+        FormatvObjectKind,
+        CharKind,
+        DecUIKind,
+        DecIKind,
+        DecULKind,
+        DecLKind,
+        DecULLKind,
+        DecLLKind,
+        UHexKind
+    };
+
+    union Child {
+        const Twine *twine;
+        const char *cString;
+        const std::string *stdString;
+        struct {
+            const char *ptr;
+            size_t length;
+        } ptrAndLength;
+        const formatv_object_base *formatvObject;
+        char character;
+        unsigned int decUI;
+        int decI;
+        const unsigned long *decUL;
+        const long *decL;
+        const unsigned long long *decULL;
+        const long long *decLL;
+        const uint64_t *uHex;
+    };
+
+    Child LHS;
+    Child RHS;
+    NodeKind LHSKind = EmptyKind;
+    NodeKind RHSKind = EmptyKind;
+
+    explicit Twine(NodeKind Kind) : LHSKind(Kind) {}
+
+    explicit Twine(Child lhs, NodeKind lhs_kind, Child rhs, NodeKind rhs_kind)
+        : LHS(lhs), RHS(rhs), LHSKind(lhs_kind), RHSKind(rhs_kind) {}
+
+    bool isNull() const { return LHSKind == NullKind; }
+    bool isEmpty() const { return LHSKind == EmptyKind; }
+    bool isNullary() const { return isNull() || isEmpty(); }
+    bool isUnary() const { return RHSKind == EmptyKind && !isNullary(); }
+
+    void appendChild(std::string &out, Child node, NodeKind kind) const {
+        switch (kind) {
+        case NullKind:
+        case EmptyKind:
+            return;
+        case TwineKind:
+            if (node.twine != nullptr) {
+                node.twine->appendTo(out);
+            }
+            return;
+        case CStringKind:
+            if (node.cString != nullptr) {
+                out += node.cString;
+            }
+            return;
+        case StdStringKind:
+            if (node.stdString != nullptr) {
+                out += *node.stdString;
+            }
+            return;
+        case PtrAndLengthKind:
+        case StringLiteralKind:
+            if (node.ptrAndLength.ptr != nullptr || node.ptrAndLength.length == 0) {
+                out.append(node.ptrAndLength.ptr, node.ptrAndLength.length);
+            }
+            return;
+        case FormatvObjectKind:
+            out += "<formatv>";
+            return;
+        case CharKind:
+            out.push_back(node.character);
+            return;
+        case DecUIKind:
+            out += std::to_string(node.decUI);
+            return;
+        case DecIKind:
+            out += std::to_string(node.decI);
+            return;
+        case DecULKind:
+            if (node.decUL != nullptr) {
+                out += std::to_string(*node.decUL);
+            }
+            return;
+        case DecLKind:
+            if (node.decL != nullptr) {
+                out += std::to_string(*node.decL);
+            }
+            return;
+        case DecULLKind:
+            if (node.decULL != nullptr) {
+                out += std::to_string(*node.decULL);
+            }
+            return;
+        case DecLLKind:
+            if (node.decLL != nullptr) {
+                out += std::to_string(*node.decLL);
+            }
+            return;
+        case UHexKind:
+            if (node.uHex != nullptr) {
+                char buf[32];
+                std::snprintf(buf, sizeof(buf), "%llx",
+                              static_cast<unsigned long long>(*node.uHex));
+                out += buf;
+            }
+            return;
+        }
+    }
+
+    void appendTo(std::string &out) const {
+        if (isNull()) {
+            return;
+        }
+        appendChild(out, LHS, LHSKind);
+        appendChild(out, RHS, RHSKind);
+    }
 
 public:
     Twine() = default;
-    Twine(const char *s) : storage_(s ? s : "") {}
-    Twine(const std::string &s) : storage_(s) {}
-    Twine(StringRef s) : storage_(s.data(), s.size()) {}
+    Twine(const Twine &) = default;
 
-    std::string str() const { return storage_; }
-    const char *c_str() const { return storage_.c_str(); }
-    StringRef getSingleStringRef() const { return storage_; }
+    Twine(const char *Str) {
+        if (Str != nullptr && Str[0] != '\0') {
+            LHS.cString = Str;
+            LHSKind = CStringKind;
+        } else {
+            LHSKind = EmptyKind;
+        }
+    }
+    Twine(std::nullptr_t) = delete;
 
-    Twine operator+(const Twine &other) const {
-        return Twine(storage_ + other.storage_);
+    Twine(const std::string &Str) : LHSKind(StdStringKind) {
+        LHS.stdString = &Str;
+    }
+
+    Twine(const std::string_view &Str) : LHSKind(PtrAndLengthKind) {
+        LHS.ptrAndLength.ptr = Str.data();
+        LHS.ptrAndLength.length = Str.length();
+    }
+
+    Twine(const StringRef &Str) : LHSKind(PtrAndLengthKind) {
+        LHS.ptrAndLength.ptr = Str.data();
+        LHS.ptrAndLength.length = Str.size();
+    }
+
+    explicit Twine(char Val) : LHSKind(CharKind) { LHS.character = Val; }
+    explicit Twine(signed char Val) : LHSKind(CharKind) {
+        LHS.character = static_cast<char>(Val);
+    }
+    explicit Twine(unsigned char Val) : LHSKind(CharKind) {
+        LHS.character = static_cast<char>(Val);
+    }
+
+    explicit Twine(unsigned Val) : LHSKind(DecUIKind) { LHS.decUI = Val; }
+    explicit Twine(int Val) : LHSKind(DecIKind) { LHS.decI = Val; }
+    explicit Twine(const unsigned long &Val) : LHSKind(DecULKind) {
+        LHS.decUL = &Val;
+    }
+    explicit Twine(const long &Val) : LHSKind(DecLKind) { LHS.decL = &Val; }
+    explicit Twine(const unsigned long long &Val) : LHSKind(DecULLKind) {
+        LHS.decULL = &Val;
+    }
+    explicit Twine(const long long &Val) : LHSKind(DecLLKind) {
+        LHS.decLL = &Val;
+    }
+
+    Twine(const char *lhs, const StringRef &rhs)
+        : LHSKind(CStringKind), RHSKind(PtrAndLengthKind) {
+        LHS.cString = lhs;
+        RHS.ptrAndLength.ptr = rhs.data();
+        RHS.ptrAndLength.length = rhs.size();
+    }
+
+    Twine(const StringRef &lhs, const char *rhs)
+        : LHSKind(PtrAndLengthKind), RHSKind(CStringKind) {
+        LHS.ptrAndLength.ptr = lhs.data();
+        LHS.ptrAndLength.length = lhs.size();
+        RHS.cString = rhs;
+    }
+
+    Twine &operator=(const Twine &) = delete;
+
+    static Twine createNull() { return Twine(NullKind); }
+
+    bool isTriviallyEmpty() const { return isNullary(); }
+
+    bool isSingleStringRef() const {
+        if (RHSKind != EmptyKind) {
+            return false;
+        }
+        return LHSKind == EmptyKind || LHSKind == CStringKind ||
+               LHSKind == StdStringKind || LHSKind == PtrAndLengthKind ||
+               LHSKind == StringLiteralKind;
+    }
+
+    StringRef getSingleStringRef() const {
+        assert(isSingleStringRef() && "Twine is not representable as a single StringRef");
+        switch (LHSKind) {
+        case EmptyKind:
+            return StringRef();
+        case CStringKind:
+            return StringRef(LHS.cString);
+        case StdStringKind:
+            return StringRef(*LHS.stdString);
+        case PtrAndLengthKind:
+        case StringLiteralKind:
+            return StringRef(LHS.ptrAndLength.ptr, LHS.ptrAndLength.length);
+        default:
+            return StringRef();
+        }
+    }
+
+    Twine concat(const Twine &Suffix) const {
+        if (isNull() || Suffix.isNull()) {
+            return Twine(NullKind);
+        }
+        if (isEmpty()) {
+            return Suffix;
+        }
+        if (Suffix.isEmpty()) {
+            return *this;
+        }
+
+        Child new_lhs;
+        Child new_rhs;
+        NodeKind new_lhs_kind = TwineKind;
+        NodeKind new_rhs_kind = TwineKind;
+        new_lhs.twine = this;
+        new_rhs.twine = &Suffix;
+        if (isUnary()) {
+            new_lhs = LHS;
+            new_lhs_kind = LHSKind;
+        }
+        if (Suffix.isUnary()) {
+            new_rhs = Suffix.LHS;
+            new_rhs_kind = Suffix.LHSKind;
+        }
+        return Twine(new_lhs, new_lhs_kind, new_rhs, new_rhs_kind);
+    }
+
+    std::string str() const {
+        std::string out;
+        appendTo(out);
+        return out;
+    }
+
+    const char *c_str() const {
+        thread_local std::string storage;
+        storage = str();
+        return storage.c_str();
     }
 };
 
+inline Twine operator+(const Twine &LHS, const Twine &RHS) {
+    return LHS.concat(RHS);
+}
+
+inline Twine operator+(const char *LHS, const StringRef &RHS) {
+    return Twine(LHS, RHS);
+}
+
+inline Twine operator+(const StringRef &LHS, const char *RHS) {
+    return Twine(LHS, RHS);
+}
+
 } // namespace llvm
+
+#undef LIRIC_LLVM_HIDDEN
 
 #endif

--- a/include/llvm/DebugInfo/Symbolize/Symbolize.h
+++ b/include/llvm/DebugInfo/Symbolize/Symbolize.h
@@ -1,0 +1,34 @@
+#ifndef LLVM_DEBUGINFO_SYMBOLIZE_SYMBOLIZE_H
+#define LLVM_DEBUGINFO_SYMBOLIZE_SYMBOLIZE_H
+
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Support/Error.h"
+#include <string>
+
+namespace llvm {
+namespace symbolize {
+
+struct DILineInfo {
+    std::string FileName = "<invalid>";
+    std::string FunctionName = "??";
+    uint32_t Line = 0;
+};
+
+class LLVMSymbolizer {
+public:
+    struct Options {
+        bool Demangle = false;
+    };
+
+    explicit LLVMSymbolizer(const Options &) {}
+
+    Expected<DILineInfo> symbolizeCode(const std::string &,
+                                       object::SectionedAddress) {
+        return DILineInfo();
+    }
+};
+
+} // namespace symbolize
+} // namespace llvm
+
+#endif

--- a/include/llvm/Object/ELFObjectFile.h
+++ b/include/llvm/Object/ELFObjectFile.h
@@ -1,0 +1,62 @@
+#ifndef LLVM_OBJECT_ELFOBJECTFILE_H
+#define LLVM_OBJECT_ELFOBJECTFILE_H
+
+#include "llvm/Support/Error.h"
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace llvm {
+namespace object {
+
+struct SectionedAddress {
+    uint64_t Address = 0;
+    uint64_t SectionIndex = 0;
+};
+
+class SectionRef {
+    uint64_t Address_ = 0;
+    uint64_t Size_ = 0;
+    uint64_t Index_ = 0;
+
+public:
+    SectionRef() = default;
+    SectionRef(uint64_t Address, uint64_t Size, uint64_t Index)
+        : Address_(Address), Size_(Size), Index_(Index) {}
+
+    uint64_t getAddress() const { return Address_; }
+    uint64_t getSize() const { return Size_; }
+    uint64_t getIndex() const { return Index_; }
+};
+
+template <typename T>
+class OwningBinary {
+    T Binary_;
+
+public:
+    explicit OwningBinary(T Binary) : Binary_(std::move(Binary)) {}
+    T *getBinary() { return &Binary_; }
+    const T *getBinary() const { return &Binary_; }
+};
+
+class ObjectFile {
+    std::vector<SectionRef> Sections_;
+
+public:
+    ObjectFile() {
+        Sections_.emplace_back(0, std::numeric_limits<uint64_t>::max(), 0);
+    }
+
+    static Expected<OwningBinary<ObjectFile>> createObjectFile(const std::string &) {
+        return OwningBinary<ObjectFile>(ObjectFile());
+    }
+
+    const std::vector<SectionRef> &sections() const { return Sections_; }
+};
+
+} // namespace object
+} // namespace llvm
+
+#endif

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -8,9 +8,15 @@
 #include <type_traits>
 #include <utility>
 
+#if defined(__GNUC__) || defined(__clang__)
+#define LIRIC_LLVM_HIDDEN __attribute__((visibility("hidden")))
+#else
+#define LIRIC_LLVM_HIDDEN
+#endif
+
 namespace llvm {
 
-class ErrorInfoBase {
+class LIRIC_LLVM_HIDDEN ErrorInfoBase {
 public:
     virtual ~ErrorInfoBase() = default;
     virtual void log(raw_ostream &OS) const = 0;
@@ -22,7 +28,7 @@ public:
     }
 };
 
-class StringError : public ErrorInfoBase {
+class LIRIC_LLVM_HIDDEN StringError : public ErrorInfoBase {
     std::string Msg;
 public:
     StringError(const std::string &S, std::error_code = {}) : Msg(S) {}
@@ -30,7 +36,7 @@ public:
     std::string message() const override { return Msg; }
 };
 
-class Error {
+class LIRIC_LLVM_HIDDEN Error {
     std::unique_ptr<ErrorInfoBase> Payload;
     bool Checked = false;
 
@@ -231,5 +237,7 @@ inline std::string toString(Error E) {
 }
 
 } // namespace llvm
+
+#undef LIRIC_LLVM_HIDDEN
 
 #endif

--- a/include/llvm/Support/raw_ostream.h
+++ b/include/llvm/Support/raw_ostream.h
@@ -9,9 +9,15 @@
 #include <type_traits>
 #include <vector>
 
+#if defined(__GNUC__) || defined(__clang__)
+#define LIRIC_LLVM_HIDDEN __attribute__((visibility("hidden")))
+#else
+#define LIRIC_LLVM_HIDDEN
+#endif
+
 namespace llvm {
 
-class raw_ostream {
+class LIRIC_LLVM_HIDDEN raw_ostream {
 public:
     virtual ~raw_ostream() = default;
     virtual raw_ostream &write(const char *ptr, size_t size) = 0;
@@ -74,14 +80,14 @@ public:
     }
 };
 
-class raw_pwrite_stream : public raw_ostream {
+class LIRIC_LLVM_HIDDEN raw_pwrite_stream : public raw_ostream {
 public:
     virtual void pwrite(const char *Ptr, size_t Size, uint64_t Offset) {
         (void)Ptr; (void)Size; (void)Offset;
     }
 };
 
-class raw_fd_ostream : public raw_pwrite_stream {
+class LIRIC_LLVM_HIDDEN raw_fd_ostream : public raw_pwrite_stream {
     FILE *f_;
     bool owns_;
 
@@ -120,7 +126,7 @@ public:
     FILE *getFileOrNull() const override { return f_; }
 };
 
-class raw_string_ostream : public raw_pwrite_stream {
+class LIRIC_LLVM_HIDDEN raw_string_ostream : public raw_pwrite_stream {
     std::string &str_;
 
 public:
@@ -132,7 +138,7 @@ public:
     std::string &str() { return str_; }
 };
 
-class raw_svector_ostream : public raw_pwrite_stream {
+class LIRIC_LLVM_HIDDEN raw_svector_ostream : public raw_pwrite_stream {
     std::vector<char> *vec_ = nullptr;
     std::string fallback_;
 
@@ -159,16 +165,18 @@ public:
     }
 };
 
-inline raw_fd_ostream &errs() {
+inline LIRIC_LLVM_HIDDEN raw_fd_ostream &errs() {
     static raw_fd_ostream s(2, false);
     return s;
 }
 
-inline raw_fd_ostream &outs() {
+inline LIRIC_LLVM_HIDDEN raw_fd_ostream &outs() {
     static raw_fd_ostream s(1, false);
     return s;
 }
 
 } // namespace llvm
+
+#undef LIRIC_LLVM_HIDDEN
 
 #endif

--- a/include/llvm/Target/TargetMachine.h
+++ b/include/llvm/Target/TargetMachine.h
@@ -18,7 +18,7 @@ class raw_pwrite_stream;
 namespace legacy { class PassManager; }
 
 namespace detail {
-struct ObjEmitState {
+struct __attribute__((visibility("hidden"))) ObjEmitState {
     raw_pwrite_stream *out = nullptr;
     CodeGenFileType file_type{};
 };

--- a/tests/test_llvm_compat.cpp
+++ b/tests/test_llvm_compat.cpp
@@ -666,6 +666,22 @@ static int test_stringref_twine() {
     return 0;
 }
 
+static int test_twine_abi_layout_and_concat() {
+    size_t expected_size = sizeof(void *) == 8 ? 40u : 20u;
+    TEST_ASSERT_EQ(sizeof(llvm::Twine), expected_size, "twine ABI size");
+    TEST_ASSERT_EQ(alignof(llvm::Twine), alignof(void *), "twine ABI alignment");
+
+    llvm::Twine lhs("ab");
+    llvm::Twine rhs("cd");
+    std::string joined = (lhs + rhs).str();
+    TEST_ASSERT(joined == "abcd", "twine concat");
+
+    llvm::Twine null_twine = llvm::Twine::createNull();
+    TEST_ASSERT(null_twine.str().empty(), "null twine renders empty");
+
+    return 0;
+}
+
 static int test_arrayref() {
     int arr[] = {1, 2, 3};
     llvm::ArrayRef<int> ref(arr, 3);
@@ -1013,6 +1029,7 @@ int main() {
     fprintf(stderr, "Infrastructure tests:\n");
     RUN_TEST(test_llvm_version);
     RUN_TEST(test_stringref_twine);
+    RUN_TEST(test_twine_abi_layout_and_concat);
     RUN_TEST(test_arrayref);
     RUN_TEST(test_apint_apfloat);
     RUN_TEST(test_casting_helpers);


### PR DESCRIPTION
## Summary
- Reworked `llvm::Twine` shim to mirror LLVM's ABI-facing object shape (node kinds + child union) instead of owning `std::string` storage.
- Added hidden visibility for ABI-sensitive shim surfaces (`StringRef`, `Twine`, `raw_ostream`, `Error` families) so `--export-dynamic` builds do not interpose these compatibility symbols into `libLLVM` startup paths.
- Added minimal compat stubs for `llvm/DebugInfo/Symbolize/Symbolize.h` and `llvm/Object/ELFObjectFile.h` to keep WITH_LIRIC builds on shim headers.
- Added LLVM compat regression test coverage for `Twine` ABI size/alignment and concat/null behavior.

## Verification
- `cmake --build build -j$(nproc)`
  - Rebuilt successfully.
- `ctest --test-dir build -R llvm_compat_tests --output-on-failure`
  - `1/1 Test #11: llvm_compat_tests ... Passed`
- `cmake --build ../lfortran/build-liric --target lfortran -j$(nproc)`
  - Rebuilt `src/bin/lfortran` successfully.
- `../lfortran/build-liric/src/bin/lfortran --version`
  - Exit `0`.
  - Output excerpt:
    - `LFortran version: 0.59.0-315-gbdda5f74b-dirty`
    - `LLVM: 21.0.0-liric`
- `../lfortran/build-liric/src/bin/lfortran --help`
  - Exit `0`.
  - Output captured at `/tmp/lfortran_help.out`.
- `nm -D -C ../lfortran/build-liric/src/bin/lfortran | rg "llvm::raw_ostream::flush|llvm::StringError::log|llvm::Twine::c_str\(\) const"`
  - No matches.
- Prior full-suite run log remains at `/tmp/test.log`.
