### PR TITLE
fix: P0 build blocker: lfortran/build-liric runtime generation aborts (fixes #221)

### DIFF
--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -19,20 +19,26 @@ class LIRIC_LLVM_HIDDEN StringRef {
 
 public:
     StringRef() : data_(""), len_(0) {}
-    StringRef(const char *s) : data_(s), len_(s ? std::strlen(s) : 0) {}
-    StringRef(const char *s, size_t n) : data_(s), len_(n) {}
+    StringRef(const char *s) : data_(s ? s : ""), len_(s ? std::strlen(s) : 0) {}
+    StringRef(const char *s, size_t n) : data_(s ? s : ""), len_(s ? n : 0) {}
     StringRef(const std::string &s) : data_(s.data()), len_(s.size()) {}
-    StringRef(std::string_view sv) : data_(sv.data()), len_(sv.size()) {}
+    StringRef(std::string_view sv)
+        : data_(sv.data() ? sv.data() : ""), len_(sv.data() ? sv.size() : 0) {}
 
     const char *data() const { return data_; }
     size_t size() const { return len_; }
     bool empty() const { return len_ == 0; }
 
-    std::string str() const { return std::string(data_, len_); }
+    std::string str() const {
+        if (len_ == 0) return std::string();
+        return std::string(data_, len_);
+    }
     operator std::string() const { return str(); }
 
     bool equals(StringRef other) const {
-        return len_ == other.len_ && std::memcmp(data_, other.data_, len_) == 0;
+        if (len_ != other.len_) return false;
+        if (len_ == 0) return true;
+        return std::memcmp(data_, other.data_, len_) == 0;
     }
     bool operator==(StringRef other) const { return equals(other); }
     bool operator!=(StringRef other) const { return !equals(other); }

--- a/include/llvm/ADT/Twine.h
+++ b/include/llvm/ADT/Twine.h
@@ -94,7 +94,7 @@ class LIRIC_LLVM_HIDDEN Twine {
             return;
         case PtrAndLengthKind:
         case StringLiteralKind:
-            if (node.ptrAndLength.ptr != nullptr || node.ptrAndLength.length == 0) {
+            if (node.ptrAndLength.ptr != nullptr && node.ptrAndLength.length != 0) {
                 out.append(node.ptrAndLength.ptr, node.ptrAndLength.length);
             }
             return;

--- a/include/llvm/Support/raw_ostream.h
+++ b/include/llvm/Support/raw_ostream.h
@@ -29,9 +29,11 @@ public:
         return write(&c, 1);
     }
     raw_ostream &operator<<(const std::string &s) {
+        if (s.empty()) return *this;
         return write(s.data(), s.size());
     }
     raw_ostream &operator<<(StringRef s) {
+        if (s.empty()) return *this;
         return write(s.data(), s.size());
     }
     raw_ostream &operator<<(int v) {
@@ -118,6 +120,7 @@ public:
     }
 
     raw_ostream &write(const char *ptr, size_t size) override {
+        if (size == 0) return *this;
         fwrite(ptr, 1, size, f_);
         return *this;
     }
@@ -132,6 +135,7 @@ class LIRIC_LLVM_HIDDEN raw_string_ostream : public raw_pwrite_stream {
 public:
     explicit raw_string_ostream(std::string &s) : str_(s) {}
     raw_ostream &write(const char *ptr, size_t size) override {
+        if (size == 0) return *this;
         str_.append(ptr, size);
         return *this;
     }
@@ -151,6 +155,7 @@ public:
     explicit raw_svector_ostream(VecT &) {}
 
     raw_ostream &write(const char *ptr, size_t size) override {
+        if (size == 0) return *this;
         if (vec_)
             vec_->insert(vec_->end(), ptr, ptr + size);
         else

--- a/tests/test_llvm_compat.cpp
+++ b/tests/test_llvm_compat.cpp
@@ -732,6 +732,23 @@ static int test_stringref_twine() {
     return 0;
 }
 
+static int test_stringref_nullptr_zero_len_safety() {
+    llvm::StringRef empty_from_null(nullptr, 0);
+    TEST_ASSERT(empty_from_null.empty(), "nullptr+0 StringRef is empty");
+
+    std::string rendered = empty_from_null.str();
+    TEST_ASSERT(rendered.empty(), "nullptr+0 StringRef renders empty");
+
+    llvm::Twine tw(empty_from_null);
+    TEST_ASSERT(tw.str().empty(), "twine from nullptr+0 StringRef renders empty");
+
+    std::string out;
+    llvm::raw_string_ostream os(out);
+    os << empty_from_null;
+    TEST_ASSERT(out.empty(), "raw_string_ostream ignores nullptr+0 StringRef");
+    return 0;
+}
+
 static int test_twine_abi_layout_and_concat() {
     size_t expected_size = sizeof(void *) == 8 ? 40u : 20u;
     TEST_ASSERT_EQ(sizeof(llvm::Twine), expected_size, "twine ABI size");
@@ -1115,6 +1132,7 @@ int main() {
     fprintf(stderr, "Infrastructure tests:\n");
     RUN_TEST(test_llvm_version);
     RUN_TEST(test_stringref_twine);
+    RUN_TEST(test_stringref_nullptr_zero_len_safety);
     RUN_TEST(test_twine_abi_layout_and_concat);
     RUN_TEST(test_arrayref);
     RUN_TEST(test_apint_apfloat);


### PR DESCRIPTION
## Summary
- Hardened LLVM shim empty-slice handling so `StringRef(nullptr, 0)` is normalized to a safe empty representation.
- Guarded `Twine` and `raw_ostream` empty-write paths to avoid null-pointer append/write UB.
- Added regression coverage in `tests/test_llvm_compat.cpp` (`test_stringref_nullptr_zero_len_safety`).

## Verification
- `cmake -S . -B build -G Ninja -DWITH_LLVM_COMPAT=ON`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure -R llvm_compat 2>&1 | tee /tmp/test.log`
  - excerpt: `1/1 Test #11: llvm_compat_tests ................   Passed`
- `rg -n "FAIL|FAILED|Error|invalid pointer|Aborted|SIG" /tmp/test.log || true`
  - result: no matches
- `cmake --build ../lfortran/build-liric -j$(nproc) 2>&1 | tee /tmp/issue221_build.log`
  - excerpt: runtime phase completed `[12/16]` through `[16/16]` Fortran object generation without abort
- `rg -n "invalid pointer|Aborted|core dumped|FAILED|error:" /tmp/issue221_build.log || true`
  - result: no matches

## Artifact Paths
- `/tmp/test.log`
- `/tmp/issue221_build.log`
