### PR TITLE
fix: Tracker: fix API-mode stability and benchmarking regressions (fixes #223)

### DIFF
--- a/include/llvm/Support/raw_ostream.h
+++ b/include/llvm/Support/raw_ostream.h
@@ -23,6 +23,7 @@ public:
     virtual raw_ostream &write(const char *ptr, size_t size) = 0;
 
     raw_ostream &operator<<(const char *s) {
+        if (s == nullptr || s[0] == '\0') return *this;
         return write(s, std::strlen(s));
     }
     raw_ostream &operator<<(char c) {
@@ -120,7 +121,7 @@ public:
     }
 
     raw_ostream &write(const char *ptr, size_t size) override {
-        if (size == 0) return *this;
+        if (ptr == nullptr || size == 0) return *this;
         fwrite(ptr, 1, size, f_);
         return *this;
     }
@@ -135,7 +136,7 @@ class LIRIC_LLVM_HIDDEN raw_string_ostream : public raw_pwrite_stream {
 public:
     explicit raw_string_ostream(std::string &s) : str_(s) {}
     raw_ostream &write(const char *ptr, size_t size) override {
-        if (size == 0) return *this;
+        if (ptr == nullptr || size == 0) return *this;
         str_.append(ptr, size);
         return *this;
     }
@@ -155,7 +156,7 @@ public:
     explicit raw_svector_ostream(VecT &) {}
 
     raw_ostream &write(const char *ptr, size_t size) override {
-        if (size == 0) return *this;
+        if (ptr == nullptr || size == 0) return *this;
         if (vec_)
             vec_->insert(vec_->end(), ptr, ptr + size);
         else

--- a/tests/test_llvm_compat.cpp
+++ b/tests/test_llvm_compat.cpp
@@ -749,6 +749,19 @@ static int test_stringref_nullptr_zero_len_safety() {
     return 0;
 }
 
+static int test_raw_ostream_null_cstr_safety() {
+    std::string out;
+    llvm::raw_string_ostream os(out);
+
+    const char *null_cstr = nullptr;
+    os << null_cstr;
+    TEST_ASSERT(out.empty(), "raw_string_ostream ignores null c-string");
+
+    os.write(nullptr, 4);
+    TEST_ASSERT(out.empty(), "raw_string_ostream ignores null write pointer");
+    return 0;
+}
+
 static int test_twine_abi_layout_and_concat() {
     size_t expected_size = sizeof(void *) == 8 ? 40u : 20u;
     TEST_ASSERT_EQ(sizeof(llvm::Twine), expected_size, "twine ABI size");
@@ -1133,6 +1146,7 @@ int main() {
     RUN_TEST(test_llvm_version);
     RUN_TEST(test_stringref_twine);
     RUN_TEST(test_stringref_nullptr_zero_len_safety);
+    RUN_TEST(test_raw_ostream_null_cstr_safety);
     RUN_TEST(test_twine_abi_layout_and_concat);
     RUN_TEST(test_arrayref);
     RUN_TEST(test_apint_apfloat);


### PR DESCRIPTION
## Summary
- harden LLVM compat `raw_ostream` null handling by treating null `const char *` input as empty
- guard `raw_fd_ostream`, `raw_string_ostream`, and `raw_svector_ostream` `write()` paths against null buffers
- add regression coverage in `tests/test_llvm_compat.cpp` for null C-string streaming and null-buffer writes

## Verification
- `./tools/arch_regen.sh`
  - `Architecture regeneration complete`
- `./tools/arch_check.sh`
  - `Architecture check passed`
- `cmake -S . -B build -G Ninja -DWITH_LLVM_COMPAT=ON && cmake --build build -j$(nproc)`
  - built `test_llvm_compat`
- `ctest --test-dir build --output-on-failure -R llvm_compat_tests 2>&1 | tee /tmp/test.log`
  - `1/1 Test #11: llvm_compat_tests ... Passed`
  - `100% tests passed, 0 tests failed out of 1`
- `grep -nE "FAIL|ERROR|Segmentation|Aborted" /tmp/test.log || true`
  - no matches

## Artifacts
- `/tmp/test.log`
