### PR TITLE
fix: perf(api): optimize liric add/materialize/compile path (fixes #230)

### DIFF
--- a/src/target_x86_64.c
+++ b/src/target_x86_64.c
@@ -96,8 +96,6 @@ static uint32_t *build_vreg_use_counts(lr_arena_t *arena, lr_func_t *func,
         return NULL;
 
     uint32_t *counts = lr_arena_array(arena, uint32_t, func->next_vreg);
-    for (uint32_t i = 0; i < func->next_vreg; i++)
-        counts[i] = 0;
 
     for (uint32_t ii = 0; ii < func->num_linear_insts; ii++) {
         lr_inst_t *inst = func->linear_inst_array[ii];
@@ -1030,6 +1028,7 @@ static int x86_64_compile_func(lr_func_t *func, lr_module_t *mod,
                                 uint8_t *buf, size_t buflen, size_t *out_len,
                                 lr_arena_t *arena) {
     lr_arena_t *layout_arena = (mod && mod->arena) ? mod->arena : arena;
+    uint32_t initial_stack_slots = func->next_vreg > 64 ? func->next_vreg : 64;
 
     uint32_t nb = func->num_blocks > 0 ? func->num_blocks : 1;
     uint32_t fc = nb * 2;
@@ -1038,9 +1037,9 @@ static int x86_64_compile_func(lr_func_t *func, lr_module_t *mod,
         .buflen = buflen,
         .pos = 0,
         .stack_size = 0,
-        .stack_slots = NULL,
-        .stack_slot_sizes = NULL,
-        .num_stack_slots = 0,
+        .stack_slots = lr_arena_array(arena, int32_t, initial_stack_slots),
+        .stack_slot_sizes = lr_arena_array(arena, uint32_t, initial_stack_slots),
+        .num_stack_slots = initial_stack_slots,
         .static_alloca_offsets = NULL,
         .num_static_alloca_offsets = 0,
         .block_offsets = lr_arena_array_uninit(arena, size_t, nb),

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -113,6 +113,7 @@ int test_jit_phi_select_loop_carried(void);
 int test_jit_internal_global_load_store(void);
 int test_jit_internal_global_address_relocation(void);
 int test_jit_external_call_abs(void);
+int test_jit_external_call_abs_twice(void);
 int test_jit_varargs_printf_call(void);
 int test_jit_varargs_printf_double_call(void);
 int test_jit_const_gep_vtable_function_ptr(void);
@@ -273,6 +274,7 @@ int main(void) {
     RUN_TEST(test_jit_internal_global_load_store);
     RUN_TEST(test_jit_internal_global_address_relocation);
     RUN_TEST(test_jit_external_call_abs);
+    RUN_TEST(test_jit_external_call_abs_twice);
     RUN_TEST(test_jit_varargs_printf_call);
     RUN_TEST(test_jit_varargs_printf_double_call);
     RUN_TEST(test_jit_const_gep_vtable_function_ptr);


### PR DESCRIPTION
## Summary
- pre-sized x86_64 stack-slot tables using `func->next_vreg` in `x86_64_compile_func()` to avoid repeated arena realloc/copy growth during `alloc_slot()` hot paths
- removed redundant zero-initialization loop in `build_vreg_use_counts()` (arena allocations are already zeroed)
- cached relocation target resolution by symbol index in `apply_jit_relocs()` to avoid repeated `lookup_symbol()` work for duplicate relocations
- avoided duplicate miss-cache insertions in `lr_jit_add_module()` when function names are already cached
- added `test_jit_external_call_abs_twice` to validate repeated relocations against the same external symbol

## Verification
Commands run:
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
- `grep -Ein "error|fail" /tmp/test.log || true`
- `./tools/arch_regen.sh`

Output excerpts:
- `100% tests passed, 0 tests failed out of 11`
- `Architecture regeneration complete`

Artifacts:
- `/tmp/test.log`
