### PR TITLE
fix: perf(api): reduce symbol lookup/dispatch overhead in liric JIT (fixes #231)

### DIFF
--- a/src/jit.h
+++ b/src/jit.h
@@ -55,6 +55,8 @@ typedef struct lr_jit {
     uint32_t sym_bucket_count;
     lr_sym_entry_t *lookup_last_entry;
     uint32_t lookup_last_hash;
+    lr_lazy_func_entry_t *lookup_last_lazy_entry;
+    uint32_t lookup_last_lazy_hash;
     lr_sym_miss_entry_t **miss_buckets;
     uint32_t miss_bucket_count;
     lr_lazy_func_entry_t *lazy_funcs;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -101,6 +101,7 @@ int test_jit_forward_call_chain(void);
 int test_jit_batched_module_updates(void);
 int test_jit_self_recursive_call(void);
 int test_jit_self_recursive_call_ignores_prebound_symbol(void);
+int test_jit_lazy_function_ignores_prebound_symbol(void);
 int test_jit_unresolved_symbol_fails(void);
 int test_jit_lazy_materializes_reachable_functions_only(void);
 int test_jit_parallel_prefetch_replays_pending_functions(void);
@@ -264,6 +265,7 @@ int main(void) {
     RUN_TEST(test_jit_batched_module_updates);
     RUN_TEST(test_jit_self_recursive_call);
     RUN_TEST(test_jit_self_recursive_call_ignores_prebound_symbol);
+    RUN_TEST(test_jit_lazy_function_ignores_prebound_symbol);
     RUN_TEST(test_jit_unresolved_symbol_fails);
     RUN_TEST(test_jit_lazy_materializes_reachable_functions_only);
     RUN_TEST(test_jit_parallel_prefetch_replays_pending_functions);


### PR DESCRIPTION
## Summary
- Added a lazy-symbol hot cache in `src/jit.c` (`lookup_last_lazy_entry` / `update_last_lazy_lookup`) to cut repeated lazy table probes.
- Avoided unnecessary lazy-path work in `lookup_symbol_hashed()` when no lazy functions are registered.
- Reduced duplicate symbol-table work by using `module_symbol_id()` in `jit_build_module_symbol_cache()` instead of re-interning names.
- Switched relocation-time external resolution in `apply_jit_relocs()` to hashed lookup (`lookup_symbol_hashed`) and added missing symbol-name validation.
- Deduplicated miss-cache inserts in `miss_cache_add()`.
- Added regression coverage for lazy symbol shadowing (`test_jit_lazy_function_ignores_prebound_symbol`) and registered it in `tests/test_main.c`.

## Verification
Commands run:
```bash
cmake -S . -B build -G Ninja
cmake --build build -j$(nproc)
ctest --test-dir build --output-on-failure
./tools/arch_regen.sh
./tools/arch_check.sh
```

Key excerpts:
- `ctest`: `100% tests passed, 0 tests failed out of 11`
- `arch_check`: `Architecture check passed`

Logs:
- `/tmp/issue231-cmake.log`
- `/tmp/issue231-build.log`
- `/tmp/issue231-ctest.log`
- `/tmp/issue231-arch_regen.log`
- `/tmp/issue231-arch_check.log`

## Profiling Snippets (Issue Artifacts)
Callgraph snippets were taken from the issue artifact paths:
- Before: `/tmp/liric_bench_profile/cg_api_liric_la.txt`
- After: `/tmp/liric_bench_profile/cg_api_liric_after_la.txt`

Relevant lookup/dispatch lines:
```text
85,976 ( 0.19%)  src/jit.c:lookup_symbol
60,583 ( 0.14%)  src/jit.c:resolve_symbol_from_jit_table
44,360 ( 0.10%)  src/jit.c:find_symbol_entry
39,663 ( 0.09%)  src/jit.c:apply_jit_relocs.constprop.0
28,096 ( 0.06%)  src/jit.c:lr_jit_add_symbol
19,648 ( 0.04%)  src/jit.c:find_lazy_func_entry
9,139 ( 0.02%)   src/jit.c:jit_build_module_symbol_cache.constprop.0
```
