### PR TITLE
fix: api benchmark: WITH_LIRIC runtime semantic mismatch bucket (fixes #242)

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -768,6 +768,8 @@ static double llvm_pow_f64(double x, double y) { return pow(x, y); }
 static double llvm_copysign_f64(double x, double y) { return copysign(x, y); }
 static float llvm_powi_f32(float x, int32_t e) { return powf(x, (float)e); }
 static double llvm_powi_f64(double x, int32_t e) { return pow(x, (double)e); }
+static float llvm_powi_f32_i64(float x, int64_t e) { return powf(x, (float)e); }
+static double llvm_powi_f64_i64(double x, int64_t e) { return pow(x, (double)e); }
 
 static void llvm_memset_p0i8_i64(void *dst, uint64_t val, int64_t len, uint64_t is_volatile) {
     (void)is_volatile;
@@ -1176,6 +1178,10 @@ static void register_builtin_symbols(lr_jit_t *j) {
     lr_jit_add_symbol(j, "llvm.copysign.f64", (void *)(uintptr_t)&llvm_copysign_f64);
     lr_jit_add_symbol(j, "llvm.powi.f32", (void *)(uintptr_t)&llvm_powi_f32);
     lr_jit_add_symbol(j, "llvm.powi.f64", (void *)(uintptr_t)&llvm_powi_f64);
+    lr_jit_add_symbol(j, "llvm.powi.f32.i32", (void *)(uintptr_t)&llvm_powi_f32);
+    lr_jit_add_symbol(j, "llvm.powi.f64.i32", (void *)(uintptr_t)&llvm_powi_f64);
+    lr_jit_add_symbol(j, "llvm.powi.f32.i64", (void *)(uintptr_t)&llvm_powi_f32_i64);
+    lr_jit_add_symbol(j, "llvm.powi.f64.i64", (void *)(uintptr_t)&llvm_powi_f64_i64);
     lr_jit_add_symbol(j, "llvm.memset.p0i8.i32", (void *)(uintptr_t)&llvm_memset_p0i8_i32);
     lr_jit_add_symbol(j, "llvm.memset.p0i8.i64", (void *)(uintptr_t)&llvm_memset_p0i8_i64);
     lr_jit_add_symbol(j, "llvm.memcpy.p0i8.p0i8.i32", (void *)(uintptr_t)&llvm_memcpy_p0i8_p0i8_i32);

--- a/src/objfile.c
+++ b/src/objfile.c
@@ -100,6 +100,8 @@ static const char *remap_intrinsic(const char *name) {
     if (strcmp(name, "llvm.copysign.f64") == 0) return "copysign";
     if (strcmp(name, "llvm.powi.f32.i32") == 0) return "powf";
     if (strcmp(name, "llvm.powi.f64.i32") == 0) return "pow";
+    if (strcmp(name, "llvm.powi.f32.i64") == 0) return "powf";
+    if (strcmp(name, "llvm.powi.f64.i64") == 0) return "pow";
     if (strcmp(name, "llvm.fabs.f32") == 0) return "fabsf";
     if (strcmp(name, "llvm.fabs.f64") == 0) return "fabs";
     if (strcmp(name, "llvm.sin.f32") == 0) return "sinf";

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -121,6 +121,7 @@ int test_jit_varargs_printf_call(void);
 int test_jit_varargs_printf_double_call(void);
 int test_jit_const_gep_vtable_function_ptr(void);
 int test_jit_llvm_intrinsic_fabs_f32(void);
+int test_jit_llvm_intrinsic_powi_f32_i32(void);
 int test_jit_llvm_intrinsic_memcpy_memset(void);
 int test_jit_llvm_intrinsic_memmove(void);
 int test_jit_gep_struct_field(void);
@@ -285,6 +286,7 @@ int main(void) {
     RUN_TEST(test_jit_varargs_printf_double_call);
     RUN_TEST(test_jit_const_gep_vtable_function_ptr);
     RUN_TEST(test_jit_llvm_intrinsic_fabs_f32);
+    RUN_TEST(test_jit_llvm_intrinsic_powi_f32_i32);
     RUN_TEST(test_jit_llvm_intrinsic_memcpy_memset);
     RUN_TEST(test_jit_llvm_intrinsic_memmove);
     RUN_TEST(test_jit_gep_struct_field);


### PR DESCRIPTION
## Summary
- register JIT aliases for typed LLVM powi intrinsics: `llvm.powi.{f32,f64}.{i32,i64}`
- keep object emission intrinsic remap in sync for `llvm.powi.*.i64`
- add a JIT regression test that executes `llvm.powi.f32.i32` end-to-end

## Verification
- `./tools/arch_regen.sh`
- `cmake --build build -j$(nproc) 2>&1 | tee /tmp/test.log && ctest --test-dir build --output-on-failure -R test_liric 2>&1 | tee -a /tmp/test.log`
- `./build/test_liric 2>&1 | tee -a /tmp/test.log`
- `grep -En "FAIL|failed|error" /tmp/test.log || true`

Output excerpts:
- `test_jit_llvm_intrinsic_powi_f32_i32... ok`
- `147 tests: 147 passed, 0 failed`

Artifacts:
- `/tmp/test.log`
