### PR TITLE
fix: api benchmark: dominant WITH_LIRIC SIGSEGV crash bucket (fixes #240)

### DIFF
--- a/src/target_x86_64.c
+++ b/src/target_x86_64.c
@@ -1269,6 +1269,8 @@ static int x86_64_compile_func(lr_func_t *func, lr_module_t *mod,
             case LR_OP_LOAD: {
                 emit_load_operand(&ctx, &inst->operands[0], X86_RAX);
                 size_t load_sz = lr_type_size(inst->type);
+                if (load_sz == 0)
+                    load_sz = 8;
                 if (load_sz > 8) {
                     size_t load_align = lr_type_align(inst->type);
                     int32_t dst_off = alloc_slot(&ctx, inst->dest, load_sz, load_align);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -95,6 +95,7 @@ int test_jit_select_immediate_zero(void);
 int test_jit_branch(void);
 int test_jit_loop(void);
 int test_jit_alloca_load_store(void);
+int test_jit_typeless_load_defaults_to_ptr_width(void);
 int test_jit_alloca_many_static_slots(void);
 int test_jit_forward_typed_call(void);
 int test_jit_forward_call_chain(void);
@@ -260,6 +261,7 @@ int main(void) {
     RUN_TEST(test_jit_branch);
     RUN_TEST(test_jit_loop);
     RUN_TEST(test_jit_alloca_load_store);
+    RUN_TEST(test_jit_typeless_load_defaults_to_ptr_width);
     RUN_TEST(test_jit_alloca_many_static_slots);
     RUN_TEST(test_jit_forward_typed_call);
     RUN_TEST(test_jit_forward_call_chain);


### PR DESCRIPTION
## Summary
- guard x86_64 `LR_OP_LOAD` codegen against typeless loads (`inst->type == NULL`) by defaulting to pointer-width (8-byte) loads instead of emitting a zero-size load encoding
- add regression test `test_jit_typeless_load_defaults_to_ptr_width` to force a typeless load through JIT codegen and verify stable execution/result

## Verification
- Targeted tests:
  - `cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure -R "^liric_tests$"`
  - Result: `1/1` passed (`/tmp/issue240_test.log`)
- Issue-artifact to post-fix repro:
  - Baseline artifact shows `array_bound_1` in `liric_jit_sigsegv` bucket:
    - `/tmp/liric_bench_20260210_232210/bench_api_failures.jsonl` (entry contains `"name":"array_bound_1"`, `"reason":"liric_jit_sigsegv"`)
  - Post-fix command:
    - `timeout 12s ../lfortran/build-liric/src/bin/lfortran --backend=llvm --jit --no-color ../lfortran/integration_tests/array_bound_1.f90`
  - Result: `RC=0` with successful program output (`/tmp/issue240_array_bound_1.log`)
