### PR TITLE
fix: meta: API-mode zero-failure tracker (full compat corpus) (fixes #245)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,14 @@ add_test(
 )
 
 add_test(
+    NAME bench_api_zero_skip_gate
+    COMMAND ${CMAKE_COMMAND}
+        -DBENCH_API=$<TARGET_FILE:bench_api>
+        -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_api_zero_skip_gate.cmake
+)
+
+add_test(
     NAME nightly_mass_workflow_contract
     COMMAND ${CMAKE_COMMAND}
         -DWORKFLOW=${CMAKE_CURRENT_SOURCE_DIR}/.github/workflows/nightly_mass.yml

--- a/tests/cmake/test_bench_api_zero_skip_gate.cmake
+++ b/tests/cmake/test_bench_api_zero_skip_gate.cmake
@@ -1,0 +1,112 @@
+if(NOT DEFINED BENCH_API OR NOT DEFINED WORKDIR)
+    message(FATAL_ERROR "BENCH_API and WORKDIR are required")
+endif()
+
+set(root "${WORKDIR}/bench_api_zero_skip_gate")
+set(bench_dir "${root}/bench")
+set(test_dir "${root}/integration_tests")
+set(fake_llvm "${root}/fake_lfortran_llvm.sh")
+set(fake_liric "${root}/fake_lfortran_liric.sh")
+
+file(REMOVE_RECURSE "${root}")
+file(MAKE_DIRECTORY "${bench_dir}")
+file(MAKE_DIRECTORY "${test_dir}")
+
+file(WRITE "${bench_dir}/compat_ll.txt"
+"ok_case\n"
+"segv_case\n")
+
+file(WRITE "${bench_dir}/compat_ll_options.jsonl"
+"{\"name\":\"ok_case\",\"options\":\"\"}\n"
+"{\"name\":\"segv_case\",\"options\":\"\"}\n")
+
+file(WRITE "${test_dir}/ok_case.f90"
+"program ok_case\n"
+"print *, 42\n"
+"end program\n")
+
+file(WRITE "${test_dir}/segv_case.f90"
+"program segv_case\n"
+"print *, 0\n"
+"end program\n")
+
+file(WRITE "${fake_llvm}" "#!/usr/bin/env bash\n"
+"set -euo pipefail\n"
+"cat <<'OUT'\n"
+"File reading: 1.0\n"
+"Src -> ASR: 2.0\n"
+"ASR passes (total): 3.0\n"
+"ASR -> mod: 4.0\n"
+"LLVM IR creation: 5.0\n"
+"LLVM opt: 6.0\n"
+"LLVM -> JIT: 7.0\n"
+"JIT run: 8.0\n"
+"Total time: 36.0\n"
+"OUT\n"
+"exit 0\n")
+
+file(WRITE "${fake_liric}" "#!/usr/bin/env bash\n"
+"set -euo pipefail\n"
+"src=\"\"\n"
+"for arg in \"$@\"; do\n"
+"  src=\"$arg\"\n"
+"done\n"
+"if [[ \"$src\" == *\"segv_case.f90\" ]]; then\n"
+"  kill -s SEGV $$\n"
+"fi\n"
+"cat <<'OUT'\n"
+"File reading: 1.5\n"
+"Src -> ASR: 2.5\n"
+"ASR passes (total): 3.5\n"
+"ASR -> mod: 4.5\n"
+"LLVM IR creation: 5.5\n"
+"LLVM opt: 6.5\n"
+"LLVM -> JIT: 7.5\n"
+"JIT run: 8.5\n"
+"Total time: 40.0\n"
+"OUT\n"
+"exit 0\n")
+
+execute_process(COMMAND chmod +x "${fake_llvm}" "${fake_liric}"
+                RESULT_VARIABLE chmod_rc)
+if(NOT chmod_rc EQUAL 0)
+    message(FATAL_ERROR "chmod failed")
+endif()
+
+execute_process(
+    COMMAND "${BENCH_API}"
+        --lfortran "${fake_llvm}"
+        --lfortran-liric "${fake_liric}"
+        --test-dir "${test_dir}"
+        --bench-dir "${bench_dir}"
+        --iters 1
+        --timeout 5
+        --min-completed 1
+        --require-zero-skips
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+)
+
+if(rc EQUAL 0)
+    message(FATAL_ERROR "bench_api should fail when --require-zero-skips is enabled and skips are present\nstdout:\n${out}\nstderr:\n${err}")
+endif()
+if(NOT err MATCHES "zero-skip gate failed: skipped=1 > 0")
+    message(FATAL_ERROR "stderr missing zero-skip gate failure message:\n${err}")
+endif()
+
+set(summary "${bench_dir}/bench_api_summary.json")
+if(NOT EXISTS "${summary}")
+    message(FATAL_ERROR "missing bench_api_summary.json")
+endif()
+
+file(READ "${summary}" summary_text)
+if(NOT summary_text MATCHES "\"skipped\": 1")
+    message(FATAL_ERROR "summary missing skipped count:\n${summary_text}")
+endif()
+if(NOT summary_text MATCHES "\"require_zero_skips\": true")
+    message(FATAL_ERROR "summary missing require_zero_skips flag:\n${summary_text}")
+endif()
+if(NOT summary_text MATCHES "\"zero_skip_gate_met\": false")
+    message(FATAL_ERROR "summary missing zero_skip_gate_met flag:\n${summary_text}")
+endif()


### PR DESCRIPTION
## Summary
- add `--require-zero-skips` to `bench_api` so API benchmark runs can fail fast when any case is skipped
- emit `require_zero_skips` and `zero_skip_gate_met` in `bench_api_summary.json` for machine-readable policy checks
- add `bench_api_zero_skip_gate` CTest coverage and register it in `CMakeLists.txt`

## Verification
- `./tools/arch_regen.sh`
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure -R "bench_api_(nonzero_compat|signal_classification|timeout_diagnostics|llvm_retry_paths|strict_mode|zero_skip_gate)" 2>&1 | tee /tmp/test.log`
- `grep -E "100% tests passed|tests failed|FAILED|zero-skip gate failed" /tmp/test.log`

Output excerpt:
- `100% tests passed, 0 tests failed out of 6`

Artifacts:
- `/tmp/test.log`
- `build/bench_api_zero_skip_gate/bench/bench_api_summary.json` (contains `"require_zero_skips": true` and `"zero_skip_gate_met": false`)
