### PR TITLE
CLI: emit runnable ELF executable by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,13 +200,24 @@ add_test(
 )
 
 add_test(
-    NAME liric_cli_obj_disabled_by_default
+    NAME liric_cli_default_emits_exe
     COMMAND ${CMAKE_COMMAND}
         -DCLI=$<TARGET_FILE:liric_bin>
         -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/ret_42.ll
-        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/liric_cli_default_should_not_emit.o
+        -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
         -DMODE=default
-        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_obj_mode.cmake
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_exe_mode.cmake
+)
+
+add_test(
+    NAME liric_cli_output_flag_emits_exe
+    COMMAND ${CMAKE_COMMAND}
+        -DCLI=$<TARGET_FILE:liric_bin>
+        -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/ret_42.ll
+        -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/liric_cli_custom_out
+        -DMODE=output
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_exe_mode.cmake
 )
 
 add_test(

--- a/README.md
+++ b/README.md
@@ -23,15 +23,14 @@ cmake -S . -B build -G Ninja -DLIRIC_ENABLE_LLVM_BITCODE=ON
 ## Run
 
 ```bash
-./build/liric --jit file.ll
+./build/liric file.ll                  # emits ./a.out
+./build/liric -o myprog file.ll        # emits ./myprog
 ./build/liric --dump-ir file.ll
 ./build/liric --emit-obj out.o file.ll
 ./build/liric --jit file.wasm --func add --args 2 3
 ```
 
 For programmatic IR construction, use the C API in `include/liric/liric.h`.
-
-`--emit-obj` is an explicit opt-in compatibility mode. The primary/first-class path is direct JIT for low-latency compilation.
 
 ## Benchmarks
 

--- a/architecture/workspace.dsl
+++ b/architecture/workspace.dsl
@@ -138,16 +138,16 @@ workspace "Liric Architecture" "Curated C4 model for liric with clickable links 
                 }
             }
 
-            obj_emit = container "Object Emission" "Object generation path for ELF/Mach-O files from liric IR." "C11" {
+            obj_emit = container "Object + Executable Emission" "Emission path for relocatable objects and standalone executables from liric IR." "C11" {
                 tags "ObjEmit"
                 url "https://github.com/krystophny/liric/blob/main/src/objfile.c"
 
-                obj_orchestrator = component "Objfile Orchestrator" "Coordinates backend compile output and object writer sections/relocations." "src/objfile.c" {
+                obj_orchestrator = component "Objfile Orchestrator" "Coordinates backend compile output and object/executable writer sections/relocations." "src/objfile.c" {
                     tags "ObjEmit"
                     url "https://github.com/krystophny/liric/blob/main/src/objfile.c"
                 }
 
-                obj_elf = component "ELF Writer" "Linux ELF relocatable object emission." "src/objfile_elf.c" {
+                obj_elf = component "ELF Writer" "Linux ELF relocatable and standalone executable emission." "src/objfile_elf.c" {
                     tags "ObjEmit"
                     url "https://github.com/krystophny/liric/blob/main/src/objfile_elf.c"
                 }
@@ -197,7 +197,7 @@ workspace "Liric Architecture" "Curated C4 model for liric with clickable links 
         api_frontdoor -> wasm_frontend "Routes .wasm parsing" "frontend dispatch"
         api_frontdoor -> core_ir "Owns module lifecycle and builder entrypoints" "C API calls"
         api_frontdoor -> jit_runtime "Creates JIT, adds modules, resolves functions" "C API calls"
-        api_frontdoor -> obj_emit "Emits object files from liric modules" "C API calls"
+        api_frontdoor -> obj_emit "Emits object files and standalone executables from liric modules" "C API calls"
 
         ll_frontend -> core_ir "Builds lr_module_t from text IR" "IR builder calls"
         bc_frontend -> core_ir "Builds lr_module_t from LLVM bitcode decode path" "IR builder calls"
@@ -211,14 +211,14 @@ workspace "Liric Architecture" "Curated C4 model for liric with clickable links 
 
         core_ir -> backends "Supplies target-independent SSA for codegen" "compile interface"
         backends -> jit_runtime "Produces machine code for in-memory execution" "code buffer"
-        backends -> obj_emit "Produces machine code/relocations for object files" "object code sections"
+        backends -> obj_emit "Produces machine code/relocations for object/executable output" "code sections + relocations"
 
-        obj_emit -> host_runtime "Objects are linked and resolved by host linker/runtime" "ELF/Mach-O and linker"
+        obj_emit -> host_runtime "Objects are linked by host linker/runtime; standalone executables run directly" "ELF/Mach-O and runtime"
 
         jit_runtime -> host_runtime "Loads shared libraries and resolves symbols" "dlopen/dlsym"
         jit_runtime -> backends "Invokes host-compatible target compiler" "compile interface"
 
-        tools -> api_frontdoor "CLI parse/dump/jit workflows" "direct API usage"
+        tools -> api_frontdoor "CLI parse/dump/jit/object/executable workflows" "direct API usage"
         tools -> jit_runtime "Probe runner and JIT execution harness" "JIT invocation"
         tools -> lli "Benchmarks compare liric against lli baseline" "subprocess benchmark harness"
 
@@ -250,7 +250,7 @@ workspace "Liric Architecture" "Curated C4 model for liric with clickable links 
 
         obj_orchestrator -> target_registry "Selects host backend" "target lookup"
         obj_orchestrator -> target_shared "Compiles IR for object emission" "compile interface"
-        obj_orchestrator -> obj_elf "Writes ELF relocatable output" "ELF writer API"
+        obj_orchestrator -> obj_elf "Writes ELF relocatable/executable output" "ELF writer API"
         obj_orchestrator -> obj_macho "Writes Mach-O object output" "Mach-O writer API"
 
         compat_cpp -> compat_c "Maps LLVM C++ APIs to lc_* calls" "header wrappers"
@@ -271,7 +271,7 @@ workspace "Liric Architecture" "Curated C4 model for liric with clickable links 
             include *
             autolayout lr
             title "Liric Container View"
-            description "Primary subsystems and major internal flow: parse/build -> IR -> backend -> JIT/object output."
+            description "Primary subsystems and major internal flow: parse/build -> IR -> backend -> JIT/object/executable output."
         }
 
         component ll_frontend "LLFrontendComponents" {

--- a/src/objfile.h
+++ b/src/objfile.h
@@ -63,6 +63,8 @@ typedef struct {
 typedef lr_reloc_mapped_t (*lr_reloc_mapper_fn)(uint8_t liric_type);
 
 int lr_emit_object(lr_module_t *m, const lr_target_t *target, FILE *out);
+int lr_emit_executable(lr_module_t *m, const lr_target_t *target, FILE *out,
+                       const char *entry_symbol);
 
 uint32_t lr_obj_ensure_symbol(lr_objfile_ctx_t *oc, const char *name,
                                bool is_defined, uint8_t section,

--- a/src/objfile_elf.h
+++ b/src/objfile_elf.h
@@ -8,6 +8,11 @@ int write_elf(FILE *out, const uint8_t *code, size_t code_size,
               const lr_objfile_ctx_t *oc,
               uint16_t e_machine, lr_reloc_mapper_fn reloc_mapper);
 
+int write_elf_executable_x86_64(FILE *out, const uint8_t *code, size_t code_size,
+                                const uint8_t *data, size_t data_size,
+                                const lr_objfile_ctx_t *oc,
+                                const char *entry_symbol);
+
 lr_reloc_mapped_t elf_reloc_x86_64(uint8_t liric_type);
 
 #endif

--- a/tests/cmake/test_liric_cli_exe_mode.cmake
+++ b/tests/cmake/test_liric_cli_exe_mode.cmake
@@ -1,0 +1,69 @@
+if(NOT DEFINED CLI OR NOT DEFINED INPUT OR NOT DEFINED WORKDIR OR NOT DEFINED MODE)
+    message(FATAL_ERROR "CLI, INPUT, WORKDIR, and MODE are required")
+endif()
+
+if(MODE STREQUAL "default")
+    set(EXE "${WORKDIR}/a.out")
+    file(REMOVE "${EXE}")
+
+    execute_process(
+        COMMAND "${CLI}" "${INPUT}"
+        WORKING_DIRECTORY "${WORKDIR}"
+        RESULT_VARIABLE rc
+        OUTPUT_VARIABLE out
+        ERROR_VARIABLE err
+    )
+    if(NOT rc EQUAL 0)
+        message(FATAL_ERROR "default mode failed rc=${rc}\nstdout:\n${out}\nstderr:\n${err}")
+    endif()
+    if(NOT EXISTS "${EXE}")
+        message(FATAL_ERROR "default mode did not create executable: ${EXE}")
+    endif()
+
+    execute_process(
+        COMMAND "${EXE}"
+        WORKING_DIRECTORY "${WORKDIR}"
+        RESULT_VARIABLE run_rc
+        OUTPUT_VARIABLE run_out
+        ERROR_VARIABLE run_err
+    )
+    if(NOT run_rc EQUAL 42)
+        message(FATAL_ERROR "default executable returned ${run_rc}, expected 42\nstdout:\n${run_out}\nstderr:\n${run_err}")
+    endif()
+
+    file(REMOVE "${EXE}")
+elseif(MODE STREQUAL "output")
+    if(NOT DEFINED OUT)
+        message(FATAL_ERROR "OUT is required for MODE=output")
+    endif()
+    file(REMOVE "${OUT}")
+
+    execute_process(
+        COMMAND "${CLI}" -o "${OUT}" "${INPUT}"
+        WORKING_DIRECTORY "${WORKDIR}"
+        RESULT_VARIABLE rc
+        OUTPUT_VARIABLE out
+        ERROR_VARIABLE err
+    )
+    if(NOT rc EQUAL 0)
+        message(FATAL_ERROR "output mode failed rc=${rc}\nstdout:\n${out}\nstderr:\n${err}")
+    endif()
+    if(NOT EXISTS "${OUT}")
+        message(FATAL_ERROR "output mode did not create executable: ${OUT}")
+    endif()
+
+    execute_process(
+        COMMAND "${OUT}"
+        WORKING_DIRECTORY "${WORKDIR}"
+        RESULT_VARIABLE run_rc
+        OUTPUT_VARIABLE run_out
+        ERROR_VARIABLE run_err
+    )
+    if(NOT run_rc EQUAL 42)
+        message(FATAL_ERROR "custom executable returned ${run_rc}, expected 42\nstdout:\n${run_out}\nstderr:\n${run_err}")
+    endif()
+
+    file(REMOVE "${OUT}")
+else()
+    message(FATAL_ERROR "Unknown MODE=${MODE}")
+endif()


### PR DESCRIPTION
## Summary
- make `liric <input.ll>` emit a runnable Linux x86_64 ELF executable (`a.out`) by default
- add `-o <path>` for executable output path override
- keep `--jit` explicit and keep `--emit-obj <path>` for relocatable object output
- add Linux x86_64 ELF ET_EXEC writer with relocation fixups and `_start` entry stub (`call <entry>; exit` syscall)
- fail executable emission when unresolved external relocations remain
- add ctest coverage for default executable emission and `-o` output mode
- update README run examples
- update architecture workspace model for object+executable emission path

## Validation
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`
- `./tools/arch_regen.sh`
- `./tools/arch_check.sh`
- manual smoke: emitted `a.out` and `-o mybin` both run and return exit code `42`
