### PR TITLE
runtime: support intrinsic calls in direct executable mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(liric VERSION 0.1.0 LANGUAGES C)
+project(liric VERSION 0.1.0 LANGUAGES C ASM)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -56,7 +56,11 @@ add_library(liric STATIC
     src/objfile_macho.c
     src/objfile_elf.c
     src/llvm_stubs.c
+    src/platform/platform_intrinsics.c
 )
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+    target_sources(liric PRIVATE src/platform/platform_intrinsic_stubs_x86_64_linux.S)
+endif()
 target_include_directories(liric PUBLIC include)
 target_include_directories(liric PRIVATE src)
 
@@ -229,6 +233,28 @@ add_test(
         -DMODE=conflict
         -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_obj_mode.cmake
 )
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+    add_test(
+        NAME liric_cli_exe_intrinsic_math
+        COMMAND ${CMAKE_COMMAND}
+            -DCLI=$<TARGET_FILE:liric_bin>
+            -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/intrinsic_exec_math.ll
+            -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+            -DEXPECT_RC=20
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_exe_run.cmake
+    )
+
+    add_test(
+        NAME liric_cli_exe_intrinsic_mem
+        COMMAND ${CMAKE_COMMAND}
+            -DCLI=$<TARGET_FILE:liric_bin>
+            -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/intrinsic_exec_mem.ll
+            -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+            -DEXPECT_RC=130
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_exe_run.cmake
+    )
+endif()
 
 add_test(
     NAME bench_compat_check_freeze_artifacts

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ cmake -S . -B build -G Ninja -DLIRIC_ENABLE_LLVM_BITCODE=ON
 ./build/liric --jit file.wasm --func add --args 2 3
 ```
 
+Direct executable mode now embeds liric-owned intrinsic helpers for the core
+LLVM intrinsic set used by JIT builtins (`llvm.fabs/sqrt/exp/pow/powi`,
+`llvm.memset/memcpy/memmove`) on Linux x86_64, so these calls no longer depend
+on JIT process symbol namespace lookup.
+
 For programmatic IR construction, use the C API in `include/liric/liric.h`.
 
 ## Benchmarks

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -1,0 +1,14 @@
+#ifndef LIRIC_PLATFORM_RUNTIME_H
+#define LIRIC_PLATFORM_RUNTIME_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Internal runtime intrinsic blob lookup used by direct executable emission. */
+bool lr_platform_intrinsic_supported(const char *name);
+bool lr_platform_intrinsic_blob_lookup(const char *name,
+                                       const uint8_t **begin,
+                                       const uint8_t **end);
+
+#endif

--- a/src/platform/platform_intrinsic_stubs_x86_64_linux.S
+++ b/src/platform/platform_intrinsic_stubs_x86_64_linux.S
@@ -1,0 +1,373 @@
+.text
+.intel_syntax noprefix
+
+.globl lr_stub_llvm_fabs_f32_begin
+.globl lr_stub_llvm_fabs_f32_end
+lr_stub_llvm_fabs_f32_begin:
+    movd eax, xmm0
+    and eax, 0x7fffffff
+    movd xmm0, eax
+    ret
+lr_stub_llvm_fabs_f32_end:
+
+.globl lr_stub_llvm_fabs_f64_begin
+.globl lr_stub_llvm_fabs_f64_end
+lr_stub_llvm_fabs_f64_begin:
+    movq rax, xmm0
+    movabs rcx, 0x7fffffffffffffff
+    and rax, rcx
+    movq xmm0, rax
+    ret
+lr_stub_llvm_fabs_f64_end:
+
+.globl lr_stub_llvm_sqrt_f32_begin
+.globl lr_stub_llvm_sqrt_f32_end
+lr_stub_llvm_sqrt_f32_begin:
+    sqrtss xmm0, xmm0
+    ret
+lr_stub_llvm_sqrt_f32_end:
+
+.globl lr_stub_llvm_sqrt_f64_begin
+.globl lr_stub_llvm_sqrt_f64_end
+lr_stub_llvm_sqrt_f64_begin:
+    sqrtsd xmm0, xmm0
+    ret
+lr_stub_llvm_sqrt_f64_end:
+
+.globl lr_stub_llvm_copysign_f32_begin
+.globl lr_stub_llvm_copysign_f32_end
+lr_stub_llvm_copysign_f32_begin:
+    movd eax, xmm0
+    movd edx, xmm1
+    and eax, 0x7fffffff
+    and edx, 0x80000000
+    or eax, edx
+    movd xmm0, eax
+    ret
+lr_stub_llvm_copysign_f32_end:
+
+.globl lr_stub_llvm_copysign_f64_begin
+.globl lr_stub_llvm_copysign_f64_end
+lr_stub_llvm_copysign_f64_begin:
+    movq rax, xmm0
+    movq rdx, xmm1
+    movabs rcx, 0x7fffffffffffffff
+    and rax, rcx
+    movabs rcx, 0x8000000000000000
+    and rdx, rcx
+    or rax, rdx
+    movq xmm0, rax
+    ret
+lr_stub_llvm_copysign_f64_end:
+
+.globl lr_stub_llvm_exp_f64_begin
+.globl lr_stub_llvm_exp_f64_end
+lr_stub_llvm_exp_f64_begin:
+    sub rsp, 8
+    movsd qword ptr [rsp], xmm0
+    fld qword ptr [rsp]
+    fldl2e
+    fmulp st(1), st(0)
+    fld st(0)
+    frndint
+    fsub st(1), st(0)
+    fxch st(1)
+    f2xm1
+    fld1
+    faddp st(1), st(0)
+    fscale
+    fstp st(1)
+    fstp qword ptr [rsp]
+    movsd xmm0, qword ptr [rsp]
+    add rsp, 8
+    ret
+lr_stub_llvm_exp_f64_end:
+
+.globl lr_stub_llvm_exp_f32_begin
+.globl lr_stub_llvm_exp_f32_end
+lr_stub_llvm_exp_f32_begin:
+    sub rsp, 8
+    cvtss2sd xmm0, xmm0
+    movsd qword ptr [rsp], xmm0
+    fld qword ptr [rsp]
+    fldl2e
+    fmulp st(1), st(0)
+    fld st(0)
+    frndint
+    fsub st(1), st(0)
+    fxch st(1)
+    f2xm1
+    fld1
+    faddp st(1), st(0)
+    fscale
+    fstp st(1)
+    fstp qword ptr [rsp]
+    movsd xmm0, qword ptr [rsp]
+    cvtsd2ss xmm0, xmm0
+    add rsp, 8
+    ret
+lr_stub_llvm_exp_f32_end:
+
+.globl lr_stub_llvm_pow_f64_begin
+.globl lr_stub_llvm_pow_f64_end
+lr_stub_llvm_pow_f64_begin:
+    sub rsp, 16
+    movsd qword ptr [rsp], xmm0
+    movsd qword ptr [rsp + 8], xmm1
+    fld qword ptr [rsp + 8]
+    fld qword ptr [rsp]
+    fyl2x
+    fld st(0)
+    frndint
+    fsub st(1), st(0)
+    fxch st(1)
+    f2xm1
+    fld1
+    faddp st(1), st(0)
+    fscale
+    fstp st(1)
+    fstp qword ptr [rsp]
+    movsd xmm0, qword ptr [rsp]
+    add rsp, 16
+    ret
+lr_stub_llvm_pow_f64_end:
+
+.globl lr_stub_llvm_pow_f32_begin
+.globl lr_stub_llvm_pow_f32_end
+lr_stub_llvm_pow_f32_begin:
+    sub rsp, 16
+    cvtss2sd xmm0, xmm0
+    cvtss2sd xmm1, xmm1
+    movsd qword ptr [rsp], xmm0
+    movsd qword ptr [rsp + 8], xmm1
+    fld qword ptr [rsp + 8]
+    fld qword ptr [rsp]
+    fyl2x
+    fld st(0)
+    frndint
+    fsub st(1), st(0)
+    fxch st(1)
+    f2xm1
+    fld1
+    faddp st(1), st(0)
+    fscale
+    fstp st(1)
+    fstp qword ptr [rsp]
+    movsd xmm0, qword ptr [rsp]
+    cvtsd2ss xmm0, xmm0
+    add rsp, 16
+    ret
+lr_stub_llvm_pow_f32_end:
+
+.globl lr_stub_llvm_powi_f32_i64_begin
+.globl lr_stub_llvm_powi_f32_i64_end
+lr_stub_llvm_powi_f32_i64_begin:
+    mov eax, 0x3f800000
+    movd xmm1, eax
+    mov rax, rdi
+    test rax, rax
+    jge .Lpowi_f32_i64_loop_entry
+    neg rax
+    mov eax, 0x3f800000
+    movd xmm2, eax
+    divss xmm2, xmm0
+    movaps xmm0, xmm2
+.Lpowi_f32_i64_loop_entry:
+    test rax, rax
+    je .Lpowi_f32_i64_done
+.Lpowi_f32_i64_loop:
+    test rax, 1
+    je .Lpowi_f32_i64_skip_mul
+    mulss xmm1, xmm0
+.Lpowi_f32_i64_skip_mul:
+    mulss xmm0, xmm0
+    shr rax, 1
+    jne .Lpowi_f32_i64_loop
+.Lpowi_f32_i64_done:
+    movaps xmm0, xmm1
+    ret
+lr_stub_llvm_powi_f32_i64_end:
+
+.globl lr_stub_llvm_powi_f64_i64_begin
+.globl lr_stub_llvm_powi_f64_i64_end
+lr_stub_llvm_powi_f64_i64_begin:
+    movabs rax, 0x3ff0000000000000
+    movq xmm1, rax
+    mov rax, rdi
+    test rax, rax
+    jge .Lpowi_f64_i64_loop_entry
+    neg rax
+    movabs rdx, 0x3ff0000000000000
+    movq xmm2, rdx
+    divsd xmm2, xmm0
+    movapd xmm0, xmm2
+.Lpowi_f64_i64_loop_entry:
+    test rax, rax
+    je .Lpowi_f64_i64_done
+.Lpowi_f64_i64_loop:
+    test rax, 1
+    je .Lpowi_f64_i64_skip_mul
+    mulsd xmm1, xmm0
+.Lpowi_f64_i64_skip_mul:
+    mulsd xmm0, xmm0
+    shr rax, 1
+    jne .Lpowi_f64_i64_loop
+.Lpowi_f64_i64_done:
+    movapd xmm0, xmm1
+    ret
+lr_stub_llvm_powi_f64_i64_end:
+
+.globl lr_stub_llvm_powi_f32_i32_begin
+.globl lr_stub_llvm_powi_f32_i32_end
+lr_stub_llvm_powi_f32_i32_begin:
+    mov eax, 0x3f800000
+    movd xmm1, eax
+    movsxd rax, edi
+    test rax, rax
+    jge .Lpowi_f32_i32_loop_entry
+    neg rax
+    mov eax, 0x3f800000
+    movd xmm2, eax
+    divss xmm2, xmm0
+    movaps xmm0, xmm2
+.Lpowi_f32_i32_loop_entry:
+    test rax, rax
+    je .Lpowi_f32_i32_done
+.Lpowi_f32_i32_loop:
+    test rax, 1
+    je .Lpowi_f32_i32_skip_mul
+    mulss xmm1, xmm0
+.Lpowi_f32_i32_skip_mul:
+    mulss xmm0, xmm0
+    shr rax, 1
+    jne .Lpowi_f32_i32_loop
+.Lpowi_f32_i32_done:
+    movaps xmm0, xmm1
+    ret
+lr_stub_llvm_powi_f32_i32_end:
+
+.globl lr_stub_llvm_powi_f64_i32_begin
+.globl lr_stub_llvm_powi_f64_i32_end
+lr_stub_llvm_powi_f64_i32_begin:
+    movabs rax, 0x3ff0000000000000
+    movq xmm1, rax
+    movsxd rax, edi
+    test rax, rax
+    jge .Lpowi_f64_i32_loop_entry
+    neg rax
+    movabs rdx, 0x3ff0000000000000
+    movq xmm2, rdx
+    divsd xmm2, xmm0
+    movapd xmm0, xmm2
+.Lpowi_f64_i32_loop_entry:
+    test rax, rax
+    je .Lpowi_f64_i32_done
+.Lpowi_f64_i32_loop:
+    test rax, 1
+    je .Lpowi_f64_i32_skip_mul
+    mulsd xmm1, xmm0
+.Lpowi_f64_i32_skip_mul:
+    mulsd xmm0, xmm0
+    shr rax, 1
+    jne .Lpowi_f64_i32_loop
+.Lpowi_f64_i32_done:
+    movapd xmm0, xmm1
+    ret
+lr_stub_llvm_powi_f64_i32_end:
+
+.globl lr_stub_llvm_memset_i32_begin
+.globl lr_stub_llvm_memset_i32_end
+lr_stub_llvm_memset_i32_begin:
+    test edx, edx
+    jle .Lmemset_i32_done
+    mov ecx, edx
+    mov al, sil
+    rep stosb
+.Lmemset_i32_done:
+    ret
+lr_stub_llvm_memset_i32_end:
+
+.globl lr_stub_llvm_memset_i64_begin
+.globl lr_stub_llvm_memset_i64_end
+lr_stub_llvm_memset_i64_begin:
+    test rdx, rdx
+    jle .Lmemset_i64_done
+    mov rcx, rdx
+    mov al, sil
+    rep stosb
+.Lmemset_i64_done:
+    ret
+lr_stub_llvm_memset_i64_end:
+
+.globl lr_stub_llvm_memcpy_i32_begin
+.globl lr_stub_llvm_memcpy_i32_end
+lr_stub_llvm_memcpy_i32_begin:
+    test edx, edx
+    jle .Lmemcpy_i32_done
+    mov ecx, edx
+    rep movsb
+.Lmemcpy_i32_done:
+    ret
+lr_stub_llvm_memcpy_i32_end:
+
+.globl lr_stub_llvm_memcpy_i64_begin
+.globl lr_stub_llvm_memcpy_i64_end
+lr_stub_llvm_memcpy_i64_begin:
+    test rdx, rdx
+    jle .Lmemcpy_i64_done
+    mov rcx, rdx
+    rep movsb
+.Lmemcpy_i64_done:
+    ret
+lr_stub_llvm_memcpy_i64_end:
+
+.globl lr_stub_llvm_memmove_i32_begin
+.globl lr_stub_llvm_memmove_i32_end
+lr_stub_llvm_memmove_i32_begin:
+    test edx, edx
+    jle .Lmemmove_i32_done
+    movsxd rdx, edx
+    cmp rdi, rsi
+    je .Lmemmove_i32_done
+    jb .Lmemmove_i32_forward
+    lea r8, [rsi + rdx]
+    cmp rdi, r8
+    jae .Lmemmove_i32_forward
+    lea rsi, [rsi + rdx - 1]
+    lea rdi, [rdi + rdx - 1]
+    mov rcx, rdx
+    std
+    rep movsb
+    cld
+    ret
+.Lmemmove_i32_forward:
+    mov rcx, rdx
+    rep movsb
+.Lmemmove_i32_done:
+    ret
+lr_stub_llvm_memmove_i32_end:
+
+.globl lr_stub_llvm_memmove_i64_begin
+.globl lr_stub_llvm_memmove_i64_end
+lr_stub_llvm_memmove_i64_begin:
+    test rdx, rdx
+    jle .Lmemmove_i64_done
+    cmp rdi, rsi
+    je .Lmemmove_i64_done
+    jb .Lmemmove_i64_forward
+    lea r8, [rsi + rdx]
+    cmp rdi, r8
+    jae .Lmemmove_i64_forward
+    lea rsi, [rsi + rdx - 1]
+    lea rdi, [rdi + rdx - 1]
+    mov rcx, rdx
+    std
+    rep movsb
+    cld
+    ret
+.Lmemmove_i64_forward:
+    mov rcx, rdx
+    rep movsb
+.Lmemmove_i64_done:
+    ret
+lr_stub_llvm_memmove_i64_end:

--- a/src/platform/platform_intrinsics.c
+++ b/src/platform/platform_intrinsics.c
@@ -1,0 +1,107 @@
+#include "platform.h"
+
+#include <string.h>
+
+typedef struct {
+    const char *name;
+    const uint8_t *blob_begin;
+    const uint8_t *blob_end;
+} lr_platform_intrinsic_desc_t;
+
+#if defined(__linux__) && defined(__x86_64__)
+extern const uint8_t lr_stub_llvm_fabs_f32_begin[];
+extern const uint8_t lr_stub_llvm_fabs_f32_end[];
+extern const uint8_t lr_stub_llvm_fabs_f64_begin[];
+extern const uint8_t lr_stub_llvm_fabs_f64_end[];
+extern const uint8_t lr_stub_llvm_sqrt_f32_begin[];
+extern const uint8_t lr_stub_llvm_sqrt_f32_end[];
+extern const uint8_t lr_stub_llvm_sqrt_f64_begin[];
+extern const uint8_t lr_stub_llvm_sqrt_f64_end[];
+extern const uint8_t lr_stub_llvm_exp_f32_begin[];
+extern const uint8_t lr_stub_llvm_exp_f32_end[];
+extern const uint8_t lr_stub_llvm_exp_f64_begin[];
+extern const uint8_t lr_stub_llvm_exp_f64_end[];
+extern const uint8_t lr_stub_llvm_pow_f32_begin[];
+extern const uint8_t lr_stub_llvm_pow_f32_end[];
+extern const uint8_t lr_stub_llvm_pow_f64_begin[];
+extern const uint8_t lr_stub_llvm_pow_f64_end[];
+extern const uint8_t lr_stub_llvm_copysign_f32_begin[];
+extern const uint8_t lr_stub_llvm_copysign_f32_end[];
+extern const uint8_t lr_stub_llvm_copysign_f64_begin[];
+extern const uint8_t lr_stub_llvm_copysign_f64_end[];
+extern const uint8_t lr_stub_llvm_powi_f32_i32_begin[];
+extern const uint8_t lr_stub_llvm_powi_f32_i32_end[];
+extern const uint8_t lr_stub_llvm_powi_f64_i32_begin[];
+extern const uint8_t lr_stub_llvm_powi_f64_i32_end[];
+extern const uint8_t lr_stub_llvm_powi_f32_i64_begin[];
+extern const uint8_t lr_stub_llvm_powi_f32_i64_end[];
+extern const uint8_t lr_stub_llvm_powi_f64_i64_begin[];
+extern const uint8_t lr_stub_llvm_powi_f64_i64_end[];
+extern const uint8_t lr_stub_llvm_memset_i32_begin[];
+extern const uint8_t lr_stub_llvm_memset_i32_end[];
+extern const uint8_t lr_stub_llvm_memset_i64_begin[];
+extern const uint8_t lr_stub_llvm_memset_i64_end[];
+extern const uint8_t lr_stub_llvm_memcpy_i32_begin[];
+extern const uint8_t lr_stub_llvm_memcpy_i32_end[];
+extern const uint8_t lr_stub_llvm_memcpy_i64_begin[];
+extern const uint8_t lr_stub_llvm_memcpy_i64_end[];
+extern const uint8_t lr_stub_llvm_memmove_i32_begin[];
+extern const uint8_t lr_stub_llvm_memmove_i32_end[];
+extern const uint8_t lr_stub_llvm_memmove_i64_begin[];
+extern const uint8_t lr_stub_llvm_memmove_i64_end[];
+#define LR_STUB_BLOB(begin, end) begin, end
+#else
+#define LR_STUB_BLOB(begin, end) NULL, NULL
+#endif
+
+static const lr_platform_intrinsic_desc_t g_intrinsics[] = {
+    { "llvm.fabs.f32", LR_STUB_BLOB(lr_stub_llvm_fabs_f32_begin, lr_stub_llvm_fabs_f32_end) },
+    { "llvm.fabs.f64", LR_STUB_BLOB(lr_stub_llvm_fabs_f64_begin, lr_stub_llvm_fabs_f64_end) },
+    { "llvm.sqrt.f32", LR_STUB_BLOB(lr_stub_llvm_sqrt_f32_begin, lr_stub_llvm_sqrt_f32_end) },
+    { "llvm.sqrt.f64", LR_STUB_BLOB(lr_stub_llvm_sqrt_f64_begin, lr_stub_llvm_sqrt_f64_end) },
+    { "llvm.exp.f32", LR_STUB_BLOB(lr_stub_llvm_exp_f32_begin, lr_stub_llvm_exp_f32_end) },
+    { "llvm.exp.f64", LR_STUB_BLOB(lr_stub_llvm_exp_f64_begin, lr_stub_llvm_exp_f64_end) },
+    { "llvm.pow.f32", LR_STUB_BLOB(lr_stub_llvm_pow_f32_begin, lr_stub_llvm_pow_f32_end) },
+    { "llvm.pow.f64", LR_STUB_BLOB(lr_stub_llvm_pow_f64_begin, lr_stub_llvm_pow_f64_end) },
+    { "llvm.copysign.f32", LR_STUB_BLOB(lr_stub_llvm_copysign_f32_begin, lr_stub_llvm_copysign_f32_end) },
+    { "llvm.copysign.f64", LR_STUB_BLOB(lr_stub_llvm_copysign_f64_begin, lr_stub_llvm_copysign_f64_end) },
+    { "llvm.powi.f32", LR_STUB_BLOB(lr_stub_llvm_powi_f32_i32_begin, lr_stub_llvm_powi_f32_i32_end) },
+    { "llvm.powi.f64", LR_STUB_BLOB(lr_stub_llvm_powi_f64_i32_begin, lr_stub_llvm_powi_f64_i32_end) },
+    { "llvm.powi.f32.i32", LR_STUB_BLOB(lr_stub_llvm_powi_f32_i32_begin, lr_stub_llvm_powi_f32_i32_end) },
+    { "llvm.powi.f64.i32", LR_STUB_BLOB(lr_stub_llvm_powi_f64_i32_begin, lr_stub_llvm_powi_f64_i32_end) },
+    { "llvm.powi.f32.i64", LR_STUB_BLOB(lr_stub_llvm_powi_f32_i64_begin, lr_stub_llvm_powi_f32_i64_end) },
+    { "llvm.powi.f64.i64", LR_STUB_BLOB(lr_stub_llvm_powi_f64_i64_begin, lr_stub_llvm_powi_f64_i64_end) },
+    { "llvm.memset.p0i8.i32", LR_STUB_BLOB(lr_stub_llvm_memset_i32_begin, lr_stub_llvm_memset_i32_end) },
+    { "llvm.memset.p0i8.i64", LR_STUB_BLOB(lr_stub_llvm_memset_i64_begin, lr_stub_llvm_memset_i64_end) },
+    { "llvm.memcpy.p0i8.p0i8.i32", LR_STUB_BLOB(lr_stub_llvm_memcpy_i32_begin, lr_stub_llvm_memcpy_i32_end) },
+    { "llvm.memcpy.p0i8.p0i8.i64", LR_STUB_BLOB(lr_stub_llvm_memcpy_i64_begin, lr_stub_llvm_memcpy_i64_end) },
+    { "llvm.memmove.p0i8.p0i8.i32", LR_STUB_BLOB(lr_stub_llvm_memmove_i32_begin, lr_stub_llvm_memmove_i32_end) },
+    { "llvm.memmove.p0i8.p0i8.i64", LR_STUB_BLOB(lr_stub_llvm_memmove_i64_begin, lr_stub_llvm_memmove_i64_end) },
+};
+
+static const lr_platform_intrinsic_desc_t *lookup_intrinsic(const char *name) {
+    if (!name || !name[0])
+        return NULL;
+
+    size_t n = sizeof(g_intrinsics) / sizeof(g_intrinsics[0]);
+    for (size_t i = 0; i < n; i++) {
+        if (strcmp(g_intrinsics[i].name, name) == 0)
+            return &g_intrinsics[i];
+    }
+    return NULL;
+}
+
+bool lr_platform_intrinsic_supported(const char *name) {
+    return lookup_intrinsic(name) != NULL;
+}
+
+bool lr_platform_intrinsic_blob_lookup(const char *name,
+                                       const uint8_t **begin,
+                                       const uint8_t **end) {
+    const lr_platform_intrinsic_desc_t *d = lookup_intrinsic(name);
+    if (!d || !begin || !end || !d->blob_begin || !d->blob_end || d->blob_end <= d->blob_begin)
+        return false;
+    *begin = d->blob_begin;
+    *end = d->blob_end;
+    return true;
+}

--- a/tests/cmake/test_liric_cli_exe_run.cmake
+++ b/tests/cmake/test_liric_cli_exe_run.cmake
@@ -1,0 +1,33 @@
+if(NOT DEFINED CLI OR NOT DEFINED INPUT OR NOT DEFINED WORKDIR OR NOT DEFINED EXPECT_RC)
+    message(FATAL_ERROR "CLI, INPUT, WORKDIR, and EXPECT_RC are required")
+endif()
+
+set(EXE "${WORKDIR}/a.out")
+file(REMOVE "${EXE}")
+
+execute_process(
+    COMMAND "${CLI}" "${INPUT}"
+    WORKING_DIRECTORY "${WORKDIR}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+)
+if(NOT rc EQUAL 0)
+    message(FATAL_ERROR "emit executable failed rc=${rc}\nstdout:\n${out}\nstderr:\n${err}")
+endif()
+if(NOT EXISTS "${EXE}")
+    message(FATAL_ERROR "executable was not created: ${EXE}")
+endif()
+
+execute_process(
+    COMMAND "${EXE}"
+    WORKING_DIRECTORY "${WORKDIR}"
+    RESULT_VARIABLE run_rc
+    OUTPUT_VARIABLE run_out
+    ERROR_VARIABLE run_err
+)
+if(NOT run_rc EQUAL EXPECT_RC)
+    message(FATAL_ERROR "executable returned ${run_rc}, expected ${EXPECT_RC}\nstdout:\n${run_out}\nstderr:\n${run_err}")
+endif()
+
+file(REMOVE "${EXE}")

--- a/tests/ll/intrinsic_exec_math.ll
+++ b/tests/ll/intrinsic_exec_math.ll
@@ -1,0 +1,34 @@
+declare float @llvm.fabs.f32(float)
+declare float @llvm.sqrt.f32(float)
+declare float @llvm.copysign.f32(float, float)
+declare float @llvm.powi.f32.i32(float, i32)
+declare double @llvm.exp.f64(double)
+declare double @llvm.pow.f64(double, double)
+
+define i32 @main() {
+entry:
+  %a = call float @llvm.fabs.f32(float -3.5)
+  %ai = fptosi float %a to i32
+
+  %b = call float @llvm.sqrt.f32(float 9.0)
+  %bi = fptosi float %b to i32
+
+  %c = call float @llvm.copysign.f32(float 3.0, float -1.0)
+  %ci = fptosi float %c to i32
+
+  %d = call float @llvm.powi.f32.i32(float 2.0, i32 3)
+  %di = fptosi float %d to i32
+
+  %e = call double @llvm.exp.f64(double 0.0)
+  %ei = fptosi double %e to i32
+
+  %f = call double @llvm.pow.f64(double 2.0, double 3.0)
+  %fi = fptosi double %f to i32
+
+  %s0 = add i32 %ai, %bi
+  %s1 = add i32 %s0, %ci
+  %s2 = add i32 %s1, %di
+  %s3 = add i32 %s2, %ei
+  %s4 = add i32 %s3, %fi
+  ret i32 %s4
+}

--- a/tests/ll/intrinsic_exec_mem.ll
+++ b/tests/ll/intrinsic_exec_mem.ll
@@ -1,0 +1,23 @@
+declare void @llvm.memset.p0i8.i32(ptr, i8, i32, i1)
+declare void @llvm.memcpy.p0i8.p0i8.i32(ptr, ptr, i32, i1)
+declare void @llvm.memmove.p0i8.p0i8.i32(ptr, ptr, i32, i1)
+
+define i32 @main() {
+entry:
+  %src = alloca [8 x i8], align 1
+  %dst = alloca [8 x i8], align 1
+  %srcp = getelementptr inbounds [8 x i8], ptr %src, i64 0, i64 0
+  %dstp = getelementptr inbounds [8 x i8], ptr %dst, i64 0, i64 0
+
+  call void @llvm.memset.p0i8.i32(ptr %srcp, i8 65, i32 8, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i32(ptr %dstp, ptr %srcp, i32 8, i1 false)
+  %dstp1 = getelementptr i8, ptr %dstp, i64 1
+  call void @llvm.memmove.p0i8.p0i8.i32(ptr %dstp1, ptr %dstp, i32 6, i1 false)
+
+  %b0 = load i8, ptr %dstp, align 1
+  %b1 = load i8, ptr %dstp1, align 1
+  %i0 = zext i8 %b0 to i32
+  %i1 = zext i8 %b1 to i32
+  %sum = add i32 %i0, %i1
+  ret i32 %sum
+}


### PR DESCRIPTION
## Summary
- add internal `src/platform/platform.h` intrinsic runtime contract
- add intrinsic descriptor/lookup table in `src/platform/platform_intrinsics.c`
- add Linux x86_64 standalone intrinsic code blobs in `src/platform/platform_intrinsic_stubs_x86_64_linux.S`
- during direct executable build (`lr_emit_executable` path), auto-materialize unresolved supported LLVM intrinsic symbols into in-binary `.text` stubs
- fix ELF executable relocation handling for `LR_RELOC_X86_64_GOTPCREL` by creating an in-binary GOT area and patching loads correctly
- add direct executable intrinsic tests:
  - `tests/ll/intrinsic_exec_math.ll`
  - `tests/ll/intrinsic_exec_mem.ll`
- add ctest runner `tests/cmake/test_liric_cli_exe_run.cmake`
- update architecture model and README to document embedded intrinsic runtime behavior

## Why
Direct executable mode did not have access to JIT symbol namespace lookup, so intrinsic-heavy `.ll` programs could not run reliably. This change makes the executable self-contained for the supported intrinsic set on Linux x86_64.

## Validation
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`
- `./tools/arch_regen.sh`
- `./tools/arch_check.sh`

All tests passed, including new intrinsic direct-executable tests.
