### PR TITLE
Add riscv64 backend split (rv64im/rv64gc) + QEMU CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
           uname -a
           uname -m
 
+      - name: Install QEMU user-mode (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user
+
       - name: Configure
         run: cmake -S . -B build -G Ninja
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(liric STATIC
     src/target_shared.c
     src/target_x86_64.c
     src/target_aarch64.c
+    src/target_riscv64.c
     src/jit.c
     src/liric.c
     src/builder.c
@@ -256,6 +257,57 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64
             -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
             -DEXPECT_RC=130
             -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_exe_run.cmake
+    )
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    find_program(QEMU_RISCV64_EXE qemu-riscv64)
+    if(QEMU_RISCV64_EXE)
+        add_test(
+            NAME liric_cli_exe_riscv64im_qemu_ret42
+            COMMAND ${CMAKE_COMMAND}
+                -DCLI=$<TARGET_FILE:liric_bin>
+                -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/ret_42.ll
+                -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+                -DTARGET=riscv64im
+                -DQEMU=${QEMU_RISCV64_EXE}
+                -DEXPECT_RC=42
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_riscv_qemu_run.cmake
+        )
+
+        add_test(
+            NAME liric_cli_exe_riscv64im_qemu_add_immediates
+            COMMAND ${CMAKE_COMMAND}
+                -DCLI=$<TARGET_FILE:liric_bin>
+                -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/riscv_add_imm_42.ll
+                -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+                -DTARGET=riscv64im
+                -DQEMU=${QEMU_RISCV64_EXE}
+                -DEXPECT_RC=42
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_riscv_qemu_run.cmake
+        )
+
+        add_test(
+            NAME liric_cli_exe_riscv64gc_qemu_fp
+            COMMAND ${CMAKE_COMMAND}
+                -DCLI=$<TARGET_FILE:liric_bin>
+                -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/riscv_fp_ret_9.ll
+                -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+                -DTARGET=riscv64gc
+                -DQEMU=${QEMU_RISCV64_EXE}
+                -DEXPECT_RC=9
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_riscv_qemu_run.cmake
+        )
+    endif()
+
+    add_test(
+        NAME liric_cli_exe_riscv64im_rejects_fp
+        COMMAND ${CMAKE_COMMAND}
+            -DCLI=$<TARGET_FILE:liric_bin>
+            -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/riscv_fp_ret_9.ll
+            -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+            -DTARGET=riscv64im
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_riscv_emit_fail.cmake
     )
 endif()
 

--- a/src/objfile.c
+++ b/src/objfile.c
@@ -554,6 +554,12 @@ int lr_emit_executable(lr_module_t *m, const lr_target_t *target, FILE *out,
             build.has_data ? build.data_buf : NULL,
             build.has_data ? build.data_pos : 0,
             &build.ctx, entry_symbol);
+    } else if (strncmp(target->name, "riscv64", 7) == 0) {
+        result = write_elf_executable_riscv64(
+            out, build.code_buf, build.code_pos,
+            build.has_data ? build.data_buf : NULL,
+            build.has_data ? build.data_pos : 0,
+            &build.ctx, entry_symbol);
     }
 #else
     if (strcmp(target->name, "aarch64") == 0) {

--- a/src/objfile_elf.h
+++ b/src/objfile_elf.h
@@ -16,8 +16,13 @@ int write_elf_executable_aarch64(FILE *out, const uint8_t *code, size_t code_siz
                                  const uint8_t *data, size_t data_size,
                                  const lr_objfile_ctx_t *oc,
                                  const char *entry_symbol);
+int write_elf_executable_riscv64(FILE *out, const uint8_t *code, size_t code_size,
+                                 const uint8_t *data, size_t data_size,
+                                 const lr_objfile_ctx_t *oc,
+                                 const char *entry_symbol);
 
 lr_reloc_mapped_t elf_reloc_x86_64(uint8_t liric_type);
 lr_reloc_mapped_t elf_reloc_aarch64(uint8_t liric_type);
+lr_reloc_mapped_t elf_reloc_riscv64(uint8_t liric_type);
 
 #endif

--- a/src/target.h
+++ b/src/target.h
@@ -28,6 +28,9 @@ typedef struct lr_target {
 
 const lr_target_t *lr_target_x86_64(void);
 const lr_target_t *lr_target_aarch64(void);
+const lr_target_t *lr_target_riscv64(void);
+const lr_target_t *lr_target_riscv64gc(void);
+const lr_target_t *lr_target_riscv64im(void);
 const lr_target_t *lr_target_by_name(const char *name);
 const lr_target_t *lr_target_host(void);
 bool lr_target_is_host_compatible(const lr_target_t *t);

--- a/src/target_registry.c
+++ b/src/target_registry.c
@@ -10,6 +10,12 @@ static const lr_target_entry_t g_targets[] = {
     { "x86_64", lr_target_x86_64 },
     { "aarch64", lr_target_aarch64 },
     { "arm64", lr_target_aarch64 },
+    { "riscv64", lr_target_riscv64 },
+    { "riscv", lr_target_riscv64 },
+    { "riscv64gc", lr_target_riscv64gc },
+    { "rv64gc", lr_target_riscv64gc },
+    { "riscv64im", lr_target_riscv64im },
+    { "rv64im", lr_target_riscv64im },
 };
 
 const lr_target_t *lr_target_by_name(const char *name) {
@@ -29,6 +35,12 @@ const lr_target_t *lr_target_host(void) {
     return lr_target_by_name("x86_64");
 #elif defined(__aarch64__) || defined(_M_ARM64)
     return lr_target_by_name("aarch64");
+#elif defined(__riscv) && __riscv_xlen == 64
+#if defined(__riscv_flen) && (__riscv_flen >= 64)
+    return lr_target_by_name("riscv64gc");
+#else
+    return lr_target_by_name("riscv64im");
+#endif
 #else
     return NULL;
 #endif

--- a/src/target_riscv64.c
+++ b/src/target_riscv64.c
@@ -1,0 +1,675 @@
+#include "target_riscv64.h"
+
+#include "ir.h"
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define RV_OPCODE_OP     0x33u
+#define RV_OPCODE_OPIMM  0x13u
+#define RV_OPCODE_LUI    0x37u
+#define RV_OPCODE_JALR   0x67u
+#define RV_OPCODE_OPFP   0x53u
+
+#define RV_FUNCT3_ADD_SUB 0x0u
+#define RV_FUNCT3_AND      0x7u
+#define RV_FUNCT3_OR       0x6u
+#define RV_FUNCT3_XOR      0x4u
+#define RV_FUNCT3_SLL      0x1u
+#define RV_FUNCT3_SRL_SRA  0x5u
+#define RV_FUNCT3_DIV      0x4u
+#define RV_FUNCT3_REM      0x6u
+
+#define RV_FUNCT7_ADD     0x00u
+#define RV_FUNCT7_SUB     0x20u
+#define RV_FUNCT7_MULDIV  0x01u
+#define RV_FUNCT7_SRL     0x00u
+#define RV_FUNCT7_SRA     0x20u
+
+typedef enum rv_reg_class {
+    RV_REGCLS_GPR = 1,
+    RV_REGCLS_FPR = 2,
+} rv_reg_class_t;
+
+typedef struct rv_emit_ctx {
+    uint8_t *buf;
+    size_t buflen;
+    size_t pos;
+} rv_emit_ctx_t;
+
+typedef struct rv_vreg_map {
+    uint8_t in_use;
+    uint8_t cls;
+    uint8_t reg;
+} rv_vreg_map_t;
+
+typedef struct rv_features {
+    const char *name;
+    bool ext_m;
+    bool ext_f;
+    bool ext_d;
+} rv_features_t;
+
+static int rv_emit32(rv_emit_ctx_t *ec, uint32_t insn) {
+    if (!ec || ec->pos + 4 > ec->buflen)
+        return -1;
+    ec->buf[ec->pos + 0] = (uint8_t)(insn);
+    ec->buf[ec->pos + 1] = (uint8_t)(insn >> 8);
+    ec->buf[ec->pos + 2] = (uint8_t)(insn >> 16);
+    ec->buf[ec->pos + 3] = (uint8_t)(insn >> 24);
+    ec->pos += 4;
+    return 0;
+}
+
+static uint32_t rv_enc_r(uint8_t funct7, uint8_t rs2, uint8_t rs1,
+                         uint8_t funct3, uint8_t rd, uint8_t opcode) {
+    return ((uint32_t)(funct7 & 0x7Fu) << 25)
+         | ((uint32_t)(rs2 & 0x1Fu) << 20)
+         | ((uint32_t)(rs1 & 0x1Fu) << 15)
+         | ((uint32_t)(funct3 & 0x7u) << 12)
+         | ((uint32_t)(rd & 0x1Fu) << 7)
+         | (uint32_t)(opcode & 0x7Fu);
+}
+
+static uint32_t rv_enc_i(int32_t imm, uint8_t rs1, uint8_t funct3,
+                         uint8_t rd, uint8_t opcode) {
+    uint32_t uimm = (uint32_t)imm & 0xFFFu;
+    return (uimm << 20)
+         | ((uint32_t)(rs1 & 0x1Fu) << 15)
+         | ((uint32_t)(funct3 & 0x7u) << 12)
+         | ((uint32_t)(rd & 0x1Fu) << 7)
+         | (uint32_t)(opcode & 0x7Fu);
+}
+
+static uint32_t rv_enc_u(int32_t imm20, uint8_t rd, uint8_t opcode) {
+    return ((uint32_t)imm20 & 0xFFFFF000u)
+         | ((uint32_t)(rd & 0x1Fu) << 7)
+         | (uint32_t)(opcode & 0x7Fu);
+}
+
+static int rv_type_is_fp(const lr_type_t *t) {
+    return t && (t->kind == LR_TYPE_FLOAT || t->kind == LR_TYPE_DOUBLE);
+}
+
+static int rv_type_is_intlike(const lr_type_t *t) {
+    if (!t)
+        return 0;
+    return t->kind == LR_TYPE_I1 || t->kind == LR_TYPE_I8 ||
+           t->kind == LR_TYPE_I16 || t->kind == LR_TYPE_I32 ||
+           t->kind == LR_TYPE_I64 || t->kind == LR_TYPE_PTR;
+}
+
+static int rv_emit_shift_imm(rv_emit_ctx_t *ec, uint8_t rd, uint8_t rs,
+                             uint8_t funct3, uint8_t shamt) {
+    return rv_emit32(ec, rv_enc_i((int32_t)(shamt & 0x3Fu), rs, funct3, rd, RV_OPCODE_OPIMM));
+}
+
+static int rv_emit_mv(rv_emit_ctx_t *ec, uint8_t rd, uint8_t rs) {
+    return rv_emit32(ec, rv_enc_i(0, rs, RV_FUNCT3_ADD_SUB, rd, RV_OPCODE_OPIMM));
+}
+
+static int rv_emit_li32(rv_emit_ctx_t *ec, uint8_t rd, int32_t imm) {
+    if (imm >= -2048 && imm <= 2047)
+        return rv_emit32(ec, rv_enc_i(imm, RV_X0, RV_FUNCT3_ADD_SUB, rd, RV_OPCODE_OPIMM));
+
+    int32_t hi20 = (imm + 0x800) & ~0xFFF;
+    int32_t lo12 = imm - hi20;
+    if (rv_emit32(ec, rv_enc_u(hi20, rd, RV_OPCODE_LUI)) != 0)
+        return -1;
+    return rv_emit32(ec, rv_enc_i(lo12, rd, RV_FUNCT3_ADD_SUB, rd, RV_OPCODE_OPIMM));
+}
+
+static int rv_emit_li64(rv_emit_ctx_t *ec, uint8_t rd, uint8_t scratch, int64_t imm) {
+    if (imm >= INT32_MIN && imm <= INT32_MAX)
+        return rv_emit_li32(ec, rd, (int32_t)imm);
+
+    if (rd == scratch)
+        return -1;
+
+    uint64_t u = (uint64_t)imm;
+    uint32_t hi = (uint32_t)(u >> 32);
+    uint32_t lo = (uint32_t)u;
+
+    if (rv_emit_li32(ec, rd, (int32_t)hi) != 0)
+        return -1;
+    if (rv_emit_shift_imm(ec, rd, rd, RV_FUNCT3_SLL, 32) != 0)
+        return -1;
+
+    if (rv_emit_li32(ec, scratch, (int32_t)lo) != 0)
+        return -1;
+    if (rv_emit_shift_imm(ec, scratch, scratch, RV_FUNCT3_SLL, 32) != 0)
+        return -1;
+    if (rv_emit_shift_imm(ec, scratch, scratch, RV_FUNCT3_SRL_SRA, 32) != 0)
+        return -1;
+
+    return rv_emit32(ec, rv_enc_r(RV_FUNCT7_ADD, scratch, rd,
+                                  RV_FUNCT3_ADD_SUB, rd, RV_OPCODE_OP));
+}
+
+static int rv_emit_fp_move(rv_emit_ctx_t *ec, uint8_t rd, uint8_t rs, bool is_double) {
+    uint8_t funct7 = is_double ? 0x11u : 0x10u;
+    return rv_emit32(ec, rv_enc_r(funct7, rs, rs, 0x0u, rd, RV_OPCODE_OPFP));
+}
+
+static int rv_emit_fmv_w_x(rv_emit_ctx_t *ec, uint8_t fd, uint8_t rs) {
+    return rv_emit32(ec, rv_enc_r(0x78u, 0u, rs, 0u, fd, RV_OPCODE_OPFP));
+}
+
+static int rv_emit_fmv_d_x(rv_emit_ctx_t *ec, uint8_t fd, uint8_t rs) {
+    return rv_emit32(ec, rv_enc_r(0x79u, 0u, rs, 0u, fd, RV_OPCODE_OPFP));
+}
+
+static int rv_operand_gpr(rv_emit_ctx_t *ec,
+                          const lr_operand_t *op,
+                          const rv_vreg_map_t *vmap,
+                          uint32_t vmap_n,
+                          uint8_t scratch1,
+                          uint8_t scratch2,
+                          uint8_t *out_reg) {
+    if (!ec || !op || !out_reg)
+        return -1;
+
+    if (op->kind == LR_VAL_VREG) {
+        if (op->vreg >= vmap_n || !vmap[op->vreg].in_use || vmap[op->vreg].cls != RV_REGCLS_GPR)
+            return -1;
+        *out_reg = vmap[op->vreg].reg;
+        return 0;
+    }
+
+    if (op->kind == LR_VAL_IMM_I64) {
+        if (rv_emit_li64(ec, scratch1, scratch2, op->imm_i64) != 0)
+            return -1;
+        *out_reg = scratch1;
+        return 0;
+    }
+
+    return -1;
+}
+
+static int rv_operand_fpr(rv_emit_ctx_t *ec,
+                          const lr_operand_t *op,
+                          const rv_vreg_map_t *vmap,
+                          uint32_t vmap_n,
+                          uint8_t gpr_s1,
+                          uint8_t gpr_s2,
+                          uint8_t fpr_s,
+                          const rv_features_t *feat,
+                          uint8_t *out_reg) {
+    if (!ec || !op || !feat || !out_reg)
+        return -1;
+
+    if (!feat->ext_f)
+        return -1;
+
+    if (op->kind == LR_VAL_VREG) {
+        if (op->vreg >= vmap_n || !vmap[op->vreg].in_use || vmap[op->vreg].cls != RV_REGCLS_FPR)
+            return -1;
+        *out_reg = vmap[op->vreg].reg;
+        return 0;
+    }
+
+    if (op->kind == LR_VAL_IMM_F64) {
+        if (!op->type)
+            return -1;
+        if (op->type->kind == LR_TYPE_FLOAT) {
+            float f = (float)op->imm_f64;
+            uint32_t bits = 0;
+            memcpy(&bits, &f, sizeof(bits));
+            if (rv_emit_li64(ec, gpr_s1, gpr_s2, (int64_t)(int32_t)bits) != 0)
+                return -1;
+            if (rv_emit_fmv_w_x(ec, fpr_s, gpr_s1) != 0)
+                return -1;
+            *out_reg = fpr_s;
+            return 0;
+        }
+        if (op->type->kind == LR_TYPE_DOUBLE) {
+            if (!feat->ext_d)
+                return -1;
+            uint64_t bits = 0;
+            memcpy(&bits, &op->imm_f64, sizeof(bits));
+            if (rv_emit_li64(ec, gpr_s1, gpr_s2, (int64_t)bits) != 0)
+                return -1;
+            if (rv_emit_fmv_d_x(ec, fpr_s, gpr_s1) != 0)
+                return -1;
+            *out_reg = fpr_s;
+            return 0;
+        }
+        return -1;
+    }
+
+    return -1;
+}
+
+static int rv_compile_func_with_features(lr_func_t *func, lr_module_t *mod,
+                                         uint8_t *buf, size_t buflen, size_t *out_len,
+                                         lr_arena_t *arena,
+                                         const rv_features_t *feat) {
+    (void)mod;
+    (void)arena;
+
+    if (!func || !buf || !out_len || !feat)
+        return -1;
+    if (func->is_decl)
+        return -1;
+
+    rv_emit_ctx_t ec = {.buf = buf, .buflen = buflen, .pos = 0};
+
+    uint32_t vmap_n = func->next_vreg + 1u;
+    rv_vreg_map_t *vmap = (rv_vreg_map_t *)calloc(vmap_n, sizeof(*vmap));
+    if (!vmap)
+        return -1;
+
+    uint8_t next_iarg = RV_A0;
+    uint8_t next_farg = RV_FA0;
+    for (uint32_t i = 0; i < func->num_params; i++) {
+        uint32_t v = func->param_vregs[i];
+        lr_type_t *pt = func->param_types ? func->param_types[i] : NULL;
+        if (v >= vmap_n) {
+            free(vmap);
+            return -1;
+        }
+        if (rv_type_is_fp(pt)) {
+            if (pt->kind == LR_TYPE_DOUBLE && !feat->ext_d) {
+                free(vmap);
+                return -1;
+            }
+            if (pt->kind == LR_TYPE_FLOAT && !feat->ext_f) {
+                free(vmap);
+                return -1;
+            }
+            if (next_farg > RV_FA7) {
+                free(vmap);
+                return -1;
+            }
+            vmap[v].in_use = 1;
+            vmap[v].cls = RV_REGCLS_FPR;
+            vmap[v].reg = next_farg++;
+        } else {
+            if (!rv_type_is_intlike(pt)) {
+                free(vmap);
+                return -1;
+            }
+            if (next_iarg > RV_A7) {
+                free(vmap);
+                return -1;
+            }
+            vmap[v].in_use = 1;
+            vmap[v].cls = RV_REGCLS_GPR;
+            vmap[v].reg = next_iarg++;
+        }
+    }
+
+    static const uint8_t gpr_tmp_pool[] = {
+        RV_T3, RV_T4, RV_T5, RV_T6,
+        RV_S2, RV_S3, RV_S4, RV_S5, RV_S6, RV_S7, RV_S8, RV_S9, RV_S10, RV_S11,
+    };
+    static const uint8_t fpr_tmp_pool[] = {
+        RV_FT0, RV_FT1, RV_FT2, RV_FT3, RV_FT4, RV_FT5, RV_FT6, RV_FT7,
+        RV_FT8, RV_FT9, RV_FT10, RV_FT11, RV_FS2, RV_FS3, RV_FS4, RV_FS5,
+    };
+    size_t gpr_next = 0;
+    size_t fpr_next = 0;
+
+    if (!func->first_block) {
+        free(vmap);
+        return -1;
+    }
+
+    for (lr_block_t *b = func->first_block; b; b = b->next) {
+        for (lr_inst_t *inst = b->first; inst; inst = inst->next) {
+            switch (inst->op) {
+            case LR_OP_ADD:
+            case LR_OP_SUB:
+            case LR_OP_MUL:
+            case LR_OP_SDIV:
+            case LR_OP_SREM:
+            case LR_OP_AND:
+            case LR_OP_OR:
+            case LR_OP_XOR:
+            case LR_OP_SHL:
+            case LR_OP_LSHR:
+            case LR_OP_ASHR: {
+                if (!rv_type_is_intlike(inst->type) || inst->num_operands != 2 || inst->dest >= vmap_n) {
+                    free(vmap);
+                    return -1;
+                }
+                if ((inst->op == LR_OP_MUL || inst->op == LR_OP_SDIV || inst->op == LR_OP_SREM) && !feat->ext_m) {
+                    free(vmap);
+                    return -1;
+                }
+                if (gpr_next >= sizeof(gpr_tmp_pool)) {
+                    free(vmap);
+                    return -1;
+                }
+
+                uint8_t rd = gpr_tmp_pool[gpr_next++];
+                uint8_t rs1 = 0;
+                uint8_t rs2 = 0;
+                if (rv_operand_gpr(&ec, &inst->operands[0], vmap, vmap_n, RV_T1, RV_T0, &rs1) != 0 ||
+                    rv_operand_gpr(&ec, &inst->operands[1], vmap, vmap_n, RV_T2, RV_T0, &rs2) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+
+                uint32_t enc = 0;
+                switch (inst->op) {
+                case LR_OP_ADD: enc = rv_enc_r(RV_FUNCT7_ADD, rs2, rs1, RV_FUNCT3_ADD_SUB, rd, RV_OPCODE_OP); break;
+                case LR_OP_SUB: enc = rv_enc_r(RV_FUNCT7_SUB, rs2, rs1, RV_FUNCT3_ADD_SUB, rd, RV_OPCODE_OP); break;
+                case LR_OP_MUL: enc = rv_enc_r(RV_FUNCT7_MULDIV, rs2, rs1, RV_FUNCT3_ADD_SUB, rd, RV_OPCODE_OP); break;
+                case LR_OP_SDIV: enc = rv_enc_r(RV_FUNCT7_MULDIV, rs2, rs1, RV_FUNCT3_DIV, rd, RV_OPCODE_OP); break;
+                case LR_OP_SREM: enc = rv_enc_r(RV_FUNCT7_MULDIV, rs2, rs1, RV_FUNCT3_REM, rd, RV_OPCODE_OP); break;
+                case LR_OP_AND: enc = rv_enc_r(RV_FUNCT7_ADD, rs2, rs1, RV_FUNCT3_AND, rd, RV_OPCODE_OP); break;
+                case LR_OP_OR: enc = rv_enc_r(RV_FUNCT7_ADD, rs2, rs1, RV_FUNCT3_OR, rd, RV_OPCODE_OP); break;
+                case LR_OP_XOR: enc = rv_enc_r(RV_FUNCT7_ADD, rs2, rs1, RV_FUNCT3_XOR, rd, RV_OPCODE_OP); break;
+                case LR_OP_SHL: enc = rv_enc_r(RV_FUNCT7_ADD, rs2, rs1, RV_FUNCT3_SLL, rd, RV_OPCODE_OP); break;
+                case LR_OP_LSHR: enc = rv_enc_r(RV_FUNCT7_SRL, rs2, rs1, RV_FUNCT3_SRL_SRA, rd, RV_OPCODE_OP); break;
+                case LR_OP_ASHR: enc = rv_enc_r(RV_FUNCT7_SRA, rs2, rs1, RV_FUNCT3_SRL_SRA, rd, RV_OPCODE_OP); break;
+                default: free(vmap); return -1;
+                }
+                if (rv_emit32(&ec, enc) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                vmap[inst->dest].in_use = 1;
+                vmap[inst->dest].cls = RV_REGCLS_GPR;
+                vmap[inst->dest].reg = rd;
+                break;
+            }
+
+            case LR_OP_FADD:
+            case LR_OP_FSUB:
+            case LR_OP_FMUL:
+            case LR_OP_FDIV:
+            case LR_OP_FNEG: {
+                bool is_double = inst->type && inst->type->kind == LR_TYPE_DOUBLE;
+                bool is_float = inst->type && inst->type->kind == LR_TYPE_FLOAT;
+                if ((!is_float && !is_double) || inst->dest >= vmap_n) {
+                    free(vmap);
+                    return -1;
+                }
+                if ((is_double && !feat->ext_d) || (is_float && !feat->ext_f)) {
+                    free(vmap);
+                    return -1;
+                }
+                if (fpr_next >= sizeof(fpr_tmp_pool)) {
+                    free(vmap);
+                    return -1;
+                }
+
+                uint8_t rd = fpr_tmp_pool[fpr_next++];
+                uint8_t rs1 = 0;
+                uint8_t rs2 = 0;
+                uint8_t funct7_base = 0;
+                uint8_t funct7 = 0;
+                uint8_t rm = 0;
+
+                if (inst->op == LR_OP_FNEG) {
+                    if (inst->num_operands != 1 ||
+                        rv_operand_fpr(&ec, &inst->operands[0], vmap, vmap_n,
+                                       RV_T1, RV_T2, RV_FT0, feat, &rs1) != 0) {
+                        free(vmap);
+                        return -1;
+                    }
+                    funct7 = is_double ? 0x11u : 0x10u;
+                    rm = 0x1u;
+                    rs2 = rs1;
+                } else {
+                    if (inst->num_operands != 2 ||
+                        rv_operand_fpr(&ec, &inst->operands[0], vmap, vmap_n,
+                                       RV_T1, RV_T2, RV_FT0, feat, &rs1) != 0 ||
+                        rv_operand_fpr(&ec, &inst->operands[1], vmap, vmap_n,
+                                       RV_T1, RV_T2, RV_FT1, feat, &rs2) != 0) {
+                        free(vmap);
+                        return -1;
+                    }
+                    switch (inst->op) {
+                    case LR_OP_FADD: funct7_base = 0x00u; break;
+                    case LR_OP_FSUB: funct7_base = 0x04u; break;
+                    case LR_OP_FMUL: funct7_base = 0x08u; break;
+                    case LR_OP_FDIV: funct7_base = 0x0Cu; break;
+                    default: free(vmap); return -1;
+                    }
+                    funct7 = funct7_base + (is_double ? 1u : 0u);
+                    rm = 0u;
+                }
+
+                if (rv_emit32(&ec, rv_enc_r(funct7, rs2, rs1, rm, rd, RV_OPCODE_OPFP)) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                vmap[inst->dest].in_use = 1;
+                vmap[inst->dest].cls = RV_REGCLS_FPR;
+                vmap[inst->dest].reg = rd;
+                break;
+            }
+
+            case LR_OP_SITOFP: {
+                bool is_double = inst->type && inst->type->kind == LR_TYPE_DOUBLE;
+                bool is_float = inst->type && inst->type->kind == LR_TYPE_FLOAT;
+                if ((!is_float && !is_double) || inst->num_operands != 1 || inst->dest >= vmap_n) {
+                    free(vmap);
+                    return -1;
+                }
+                if ((is_double && !feat->ext_d) || (is_float && !feat->ext_f) || fpr_next >= sizeof(fpr_tmp_pool)) {
+                    free(vmap);
+                    return -1;
+                }
+                uint8_t rs1 = 0;
+                if (rv_operand_gpr(&ec, &inst->operands[0], vmap, vmap_n, RV_T1, RV_T2, &rs1) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                uint8_t rd = fpr_tmp_pool[fpr_next++];
+                uint8_t funct7 = is_double ? 0x69u : 0x68u;
+                if (rv_emit32(&ec, rv_enc_r(funct7, 0x2u, rs1, 0x0u, rd, RV_OPCODE_OPFP)) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                vmap[inst->dest].in_use = 1;
+                vmap[inst->dest].cls = RV_REGCLS_FPR;
+                vmap[inst->dest].reg = rd;
+                break;
+            }
+
+            case LR_OP_FPTOSI: {
+                if (!rv_type_is_intlike(inst->type) || inst->num_operands != 1 || inst->dest >= vmap_n || gpr_next >= sizeof(gpr_tmp_pool)) {
+                    free(vmap);
+                    return -1;
+                }
+                const lr_operand_t *src = &inst->operands[0];
+                bool src_double = src->type && src->type->kind == LR_TYPE_DOUBLE;
+                bool src_float = src->type && src->type->kind == LR_TYPE_FLOAT;
+                if ((!src_float && !src_double) || (src_double && !feat->ext_d) || (src_float && !feat->ext_f)) {
+                    free(vmap);
+                    return -1;
+                }
+                uint8_t frs = 0;
+                if (rv_operand_fpr(&ec, src, vmap, vmap_n, RV_T1, RV_T2, RV_FT0, feat, &frs) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                uint8_t rd = gpr_tmp_pool[gpr_next++];
+                uint8_t funct7 = src_double ? 0x61u : 0x60u;
+                if (rv_emit32(&ec, rv_enc_r(funct7, 0x2u, frs, 0x1u, rd, RV_OPCODE_OPFP)) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                vmap[inst->dest].in_use = 1;
+                vmap[inst->dest].cls = RV_REGCLS_GPR;
+                vmap[inst->dest].reg = rd;
+                break;
+            }
+
+            case LR_OP_FPEXT:
+            case LR_OP_FPTRUNC: {
+                bool to_double = inst->op == LR_OP_FPEXT;
+                bool to_float = inst->op == LR_OP_FPTRUNC;
+                if (inst->num_operands != 1 || inst->dest >= vmap_n || fpr_next >= sizeof(fpr_tmp_pool) || !feat->ext_d) {
+                    free(vmap);
+                    return -1;
+                }
+                const lr_operand_t *src = &inst->operands[0];
+                if (!src->type || !inst->type) {
+                    free(vmap);
+                    return -1;
+                }
+                if (to_double && !(src->type->kind == LR_TYPE_FLOAT && inst->type->kind == LR_TYPE_DOUBLE)) {
+                    free(vmap);
+                    return -1;
+                }
+                if (to_float && !(src->type->kind == LR_TYPE_DOUBLE && inst->type->kind == LR_TYPE_FLOAT)) {
+                    free(vmap);
+                    return -1;
+                }
+                uint8_t frs = 0;
+                if (rv_operand_fpr(&ec, src, vmap, vmap_n, RV_T1, RV_T2, RV_FT0, feat, &frs) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                uint8_t rd = fpr_tmp_pool[fpr_next++];
+                uint8_t funct7 = to_double ? 0x21u : 0x20u;
+                uint8_t rs2 = to_double ? 0u : 1u;
+                if (rv_emit32(&ec, rv_enc_r(funct7, rs2, frs, 0x0u, rd, RV_OPCODE_OPFP)) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                vmap[inst->dest].in_use = 1;
+                vmap[inst->dest].cls = RV_REGCLS_FPR;
+                vmap[inst->dest].reg = rd;
+                break;
+            }
+
+            case LR_OP_TRUNC:
+            case LR_OP_ZEXT:
+            case LR_OP_SEXT:
+            case LR_OP_BITCAST: {
+                if (inst->num_operands != 1 || inst->dest >= vmap_n) {
+                    free(vmap);
+                    return -1;
+                }
+                const lr_operand_t *src = &inst->operands[0];
+                if (rv_type_is_intlike(inst->type) && rv_type_is_intlike(src->type)) {
+                    uint8_t rs = 0;
+                    if (rv_operand_gpr(&ec, src, vmap, vmap_n, RV_T1, RV_T2, &rs) != 0) {
+                        free(vmap);
+                        return -1;
+                    }
+                    if (gpr_next >= sizeof(gpr_tmp_pool)) {
+                        free(vmap);
+                        return -1;
+                    }
+                    uint8_t rd = gpr_tmp_pool[gpr_next++];
+                    if (rv_emit_mv(&ec, rd, rs) != 0) {
+                        free(vmap);
+                        return -1;
+                    }
+                    vmap[inst->dest].in_use = 1;
+                    vmap[inst->dest].cls = RV_REGCLS_GPR;
+                    vmap[inst->dest].reg = rd;
+                    break;
+                }
+                free(vmap);
+                return -1;
+            }
+
+            case LR_OP_RET: {
+                if (inst->num_operands != 1) {
+                    free(vmap);
+                    return -1;
+                }
+                const lr_operand_t *rop = &inst->operands[0];
+                if (rv_type_is_fp(rop->type)) {
+                    uint8_t src = 0;
+                    if (rv_operand_fpr(&ec, rop, vmap, vmap_n, RV_T1, RV_T2, RV_FT0, feat, &src) != 0)
+                        { free(vmap); return -1; }
+                    bool is_double = rop->type->kind == LR_TYPE_DOUBLE;
+                    uint8_t ret_reg = RV_FA0;
+                    if (src != ret_reg && rv_emit_fp_move(&ec, ret_reg, src, is_double) != 0)
+                        { free(vmap); return -1; }
+                } else {
+                    uint8_t src = 0;
+                    if (rv_operand_gpr(&ec, rop, vmap, vmap_n, RV_T1, RV_T2, &src) != 0)
+                        { free(vmap); return -1; }
+                    if (src != RV_A0 && rv_emit_mv(&ec, RV_A0, src) != 0)
+                        { free(vmap); return -1; }
+                }
+                if (rv_emit32(&ec, rv_enc_i(0, RV_RA, 0, RV_X0, RV_OPCODE_JALR)) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                *out_len = ec.pos;
+                free(vmap);
+                return 0;
+            }
+
+            case LR_OP_RET_VOID:
+                if (rv_emit32(&ec, rv_enc_i(0, RV_RA, 0, RV_X0, RV_OPCODE_JALR)) != 0) {
+                    free(vmap);
+                    return -1;
+                }
+                *out_len = ec.pos;
+                free(vmap);
+                return 0;
+
+            default:
+                free(vmap);
+                return -1;
+            }
+        }
+    }
+
+    free(vmap);
+    return -1;
+}
+
+static int rv_compile_func_rv64im(lr_func_t *func, lr_module_t *mod,
+                                  uint8_t *buf, size_t buflen, size_t *out_len,
+                                  lr_arena_t *arena) {
+    static const rv_features_t feat = {
+        .name = "rv64im",
+        .ext_m = true,
+        .ext_f = false,
+        .ext_d = false,
+    };
+    return rv_compile_func_with_features(func, mod, buf, buflen, out_len, arena, &feat);
+}
+
+static int rv_compile_func_rv64gc(lr_func_t *func, lr_module_t *mod,
+                                  uint8_t *buf, size_t buflen, size_t *out_len,
+                                  lr_arena_t *arena) {
+    static const rv_features_t feat = {
+        .name = "rv64gc",
+        .ext_m = true,
+        .ext_f = true,
+        .ext_d = true,
+    };
+    return rv_compile_func_with_features(func, mod, buf, buflen, out_len, arena, &feat);
+}
+
+static const lr_target_t target_riscv64gc = {
+    .name = "riscv64gc",
+    .ptr_size = 8,
+    .compile_func = rv_compile_func_rv64gc,
+};
+
+static const lr_target_t target_riscv64im = {
+    .name = "riscv64im",
+    .ptr_size = 8,
+    .compile_func = rv_compile_func_rv64im,
+};
+
+const lr_target_t *lr_target_riscv64(void) {
+    return &target_riscv64gc;
+}
+
+const lr_target_t *lr_target_riscv64gc(void) {
+    return &target_riscv64gc;
+}
+
+const lr_target_t *lr_target_riscv64im(void) {
+    return &target_riscv64im;
+}

--- a/src/target_riscv64.h
+++ b/src/target_riscv64.h
@@ -1,0 +1,78 @@
+#ifndef LIRIC_TARGET_RISCV64_H
+#define LIRIC_TARGET_RISCV64_H
+
+#include "target.h"
+
+/* RV64 GPR numbering */
+enum {
+    RV_X0  = 0,
+    RV_RA  = 1,
+    RV_SP  = 2,
+    RV_GP  = 3,
+    RV_TP  = 4,
+    RV_T0  = 5,
+    RV_T1  = 6,
+    RV_T2  = 7,
+    RV_S0  = 8,
+    RV_S1  = 9,
+    RV_A0  = 10,
+    RV_A1  = 11,
+    RV_A2  = 12,
+    RV_A3  = 13,
+    RV_A4  = 14,
+    RV_A5  = 15,
+    RV_A6  = 16,
+    RV_A7  = 17,
+    RV_S2  = 18,
+    RV_S3  = 19,
+    RV_S4  = 20,
+    RV_S5  = 21,
+    RV_S6  = 22,
+    RV_S7  = 23,
+    RV_S8  = 24,
+    RV_S9  = 25,
+    RV_S10 = 26,
+    RV_S11 = 27,
+    RV_T3  = 28,
+    RV_T4  = 29,
+    RV_T5  = 30,
+    RV_T6  = 31,
+};
+
+/* RV64 FPR numbering */
+enum {
+    RV_FT0  = 0,
+    RV_FT1  = 1,
+    RV_FT2  = 2,
+    RV_FT3  = 3,
+    RV_FT4  = 4,
+    RV_FT5  = 5,
+    RV_FT6  = 6,
+    RV_FT7  = 7,
+    RV_FS0  = 8,
+    RV_FS1  = 9,
+    RV_FA0  = 10,
+    RV_FA1  = 11,
+    RV_FA2  = 12,
+    RV_FA3  = 13,
+    RV_FA4  = 14,
+    RV_FA5  = 15,
+    RV_FA6  = 16,
+    RV_FA7  = 17,
+    RV_FS2  = 18,
+    RV_FS3  = 19,
+    RV_FS4  = 20,
+    RV_FS5  = 21,
+    RV_FS6  = 22,
+    RV_FS7  = 23,
+    RV_FS8  = 24,
+    RV_FS9  = 25,
+    RV_FS10 = 26,
+    RV_FS11 = 27,
+    RV_FT8  = 28,
+    RV_FT9  = 29,
+    RV_FT10 = 30,
+    RV_FT11 = 31,
+};
+
+#endif

--- a/tests/cmake/test_liric_cli_riscv_emit_fail.cmake
+++ b/tests/cmake/test_liric_cli_riscv_emit_fail.cmake
@@ -1,0 +1,26 @@
+if(NOT DEFINED CLI OR NOT DEFINED INPUT OR NOT DEFINED WORKDIR OR NOT DEFINED TARGET)
+    message(FATAL_ERROR "CLI, INPUT, WORKDIR, and TARGET are required")
+endif()
+
+set(EXE "${WORKDIR}/liric_riscv_fail_test.out")
+file(REMOVE "${EXE}")
+
+execute_process(
+    COMMAND "${CLI}" "--target" "${TARGET}" "-o" "${EXE}" "${INPUT}"
+    WORKING_DIRECTORY "${WORKDIR}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+)
+if(rc EQUAL 0)
+    message(FATAL_ERROR "emit unexpectedly succeeded for target=${TARGET}\nstdout:\n${out}\nstderr:\n${err}")
+endif()
+
+string(FIND "${err}" "executable emission failed" emsg_pos)
+if(emsg_pos LESS 0)
+    message(FATAL_ERROR "expected executable emission failure message\nstdout:\n${out}\nstderr:\n${err}")
+endif()
+
+if(EXISTS "${EXE}")
+    file(REMOVE "${EXE}")
+endif()

--- a/tests/cmake/test_liric_cli_riscv_qemu_run.cmake
+++ b/tests/cmake/test_liric_cli_riscv_qemu_run.cmake
@@ -1,0 +1,34 @@
+if(NOT DEFINED CLI OR NOT DEFINED INPUT OR NOT DEFINED WORKDIR OR NOT DEFINED TARGET OR
+   NOT DEFINED EXPECT_RC OR NOT DEFINED QEMU)
+    message(FATAL_ERROR "CLI, INPUT, WORKDIR, TARGET, EXPECT_RC, and QEMU are required")
+endif()
+
+set(EXE "${WORKDIR}/liric_riscv_test.out")
+file(REMOVE "${EXE}")
+
+execute_process(
+    COMMAND "${CLI}" "--target" "${TARGET}" "-o" "${EXE}" "${INPUT}"
+    WORKING_DIRECTORY "${WORKDIR}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+)
+if(NOT rc EQUAL 0)
+    message(FATAL_ERROR "emit executable failed rc=${rc}\nstdout:\n${out}\nstderr:\n${err}")
+endif()
+if(NOT EXISTS "${EXE}")
+    message(FATAL_ERROR "executable was not created: ${EXE}")
+endif()
+
+execute_process(
+    COMMAND "${QEMU}" "${EXE}"
+    WORKING_DIRECTORY "${WORKDIR}"
+    RESULT_VARIABLE run_rc
+    OUTPUT_VARIABLE run_out
+    ERROR_VARIABLE run_err
+)
+if(NOT run_rc EQUAL EXPECT_RC)
+    message(FATAL_ERROR "qemu run returned ${run_rc}, expected ${EXPECT_RC}\nstdout:\n${run_out}\nstderr:\n${run_err}")
+endif()
+
+file(REMOVE "${EXE}")

--- a/tests/ll/riscv_add_imm_42.ll
+++ b/tests/ll/riscv_add_imm_42.ll
@@ -1,0 +1,5 @@
+define i32 @main() {
+entry:
+  %sum = add i32 20, 22
+  ret i32 %sum
+}

--- a/tests/ll/riscv_fp_ret_9.ll
+++ b/tests/ll/riscv_fp_ret_9.ll
@@ -1,0 +1,6 @@
+define i32 @main() {
+entry:
+  %sum = fadd double 4.5, 4.5
+  %ret = fptosi double %sum to i32
+  ret i32 %ret
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -76,6 +76,7 @@ int test_create_unknown_target_fails(void);
 int test_non_host_target_fails(void);
 int test_load_missing_runtime_library_fails(void);
 int test_target_alias_arm64_resolves(void);
+int test_target_riscv64_split_resolves(void);
 int test_parse_auto_selects_ll_frontend(void);
 int test_parse_auto_selects_wasm_frontend(void);
 int test_parse_auto_selects_bc_frontend(void);
@@ -245,6 +246,7 @@ int main(void) {
     RUN_TEST(test_non_host_target_fails);
     RUN_TEST(test_load_missing_runtime_library_fails);
     RUN_TEST(test_target_alias_arm64_resolves);
+    RUN_TEST(test_target_riscv64_split_resolves);
     RUN_TEST(test_parse_auto_selects_ll_frontend);
     RUN_TEST(test_parse_auto_selects_wasm_frontend);
     RUN_TEST(test_parse_auto_selects_bc_frontend);

--- a/tests/test_targets.c
+++ b/tests/test_targets.c
@@ -17,7 +17,10 @@ int test_host_target_name(void) {
     const char *name = lr_jit_host_target_name();
     TEST_ASSERT(name != NULL, "host target name exists");
     TEST_ASSERT(name[0] != '\0', "host target name non-empty");
-    TEST_ASSERT(strcmp(name, "x86_64") == 0 || strcmp(name, "aarch64") == 0,
+    TEST_ASSERT(strcmp(name, "x86_64") == 0 ||
+                strcmp(name, "aarch64") == 0 ||
+                strcmp(name, "riscv64gc") == 0 ||
+                strcmp(name, "riscv64im") == 0,
                 "host target is known");
     return 0;
 }
@@ -65,6 +68,26 @@ int test_target_alias_arm64_resolves(void) {
     TEST_ASSERT(canonical != NULL, "aarch64 target exists");
     TEST_ASSERT(alias != NULL, "arm64 alias exists");
     TEST_ASSERT(strcmp(canonical->name, alias->name) == 0, "arm64 alias maps to aarch64");
+    return 0;
+}
+
+int test_target_riscv64_split_resolves(void) {
+    const lr_target_t *def = lr_target_by_name("riscv64");
+    const lr_target_t *gc = lr_target_by_name("riscv64gc");
+    const lr_target_t *im = lr_target_by_name("riscv64im");
+    const lr_target_t *rv64gc = lr_target_by_name("rv64gc");
+    const lr_target_t *rv64im = lr_target_by_name("rv64im");
+
+    TEST_ASSERT(def != NULL, "riscv64 target exists");
+    TEST_ASSERT(gc != NULL, "riscv64gc target exists");
+    TEST_ASSERT(im != NULL, "riscv64im target exists");
+    TEST_ASSERT(rv64gc != NULL, "rv64gc alias exists");
+    TEST_ASSERT(rv64im != NULL, "rv64im alias exists");
+
+    TEST_ASSERT(strcmp(gc->name, "riscv64gc") == 0, "gc canonical target name");
+    TEST_ASSERT(strcmp(im->name, "riscv64im") == 0, "im canonical target name");
+    TEST_ASSERT(strcmp(rv64gc->name, gc->name) == 0, "rv64gc alias maps to riscv64gc");
+    TEST_ASSERT(strcmp(rv64im->name, im->name) == 0, "rv64im alias maps to riscv64im");
     return 0;
 }
 

--- a/tools/liric_main.c
+++ b/tools/liric_main.c
@@ -48,6 +48,7 @@ int main(int argc, char **argv) {
     bool dump_ir = false;
     const char *emit_obj_path = NULL;
     const char *emit_exe_path = NULL;
+    const char *target_name = NULL;
     const char *input_file = NULL;
     const char *func_name = "main";
     const char *load_libs[64];
@@ -57,6 +58,7 @@ int main(int argc, char **argv) {
         if (strcmp(argv[i], "--jit") == 0) jit_mode = true;
         else if (strcmp(argv[i], "--dump-ir") == 0) dump_ir = true;
         else if (strcmp(argv[i], "--emit-obj") == 0 && i + 1 < argc) emit_obj_path = argv[++i];
+        else if (strcmp(argv[i], "--target") == 0 && i + 1 < argc) target_name = argv[++i];
         else if (strcmp(argv[i], "-o") == 0 && i + 1 < argc) emit_exe_path = argv[++i];
         else if (strcmp(argv[i], "--func") == 0 && i + 1 < argc) func_name = argv[++i];
         else if (strcmp(argv[i], "--load-lib") == 0 && i + 1 < argc) {
@@ -113,9 +115,9 @@ int main(int argc, char **argv) {
     }
 
     if (emit_obj_path) {
-        const lr_target_t *target = lr_target_host();
+        const lr_target_t *target = target_name ? lr_target_by_name(target_name) : lr_target_host();
         if (!target) {
-            fprintf(stderr, "failed to detect host target\n");
+            fprintf(stderr, "unknown target: %s\n", target_name ? target_name : "<host>");
             lr_module_free(m);
             free(src);
             return 1;
@@ -144,9 +146,9 @@ int main(int argc, char **argv) {
     }
 
     if (jit_mode) {
-        lr_jit_t *jit = lr_jit_create();
+        lr_jit_t *jit = target_name ? lr_jit_create_for_target(target_name) : lr_jit_create();
         if (!jit) {
-            fprintf(stderr, "failed to create JIT\n");
+            fprintf(stderr, "failed to create JIT for target %s\n", target_name ? target_name : "<host>");
             lr_module_free(m);
             free(src);
             return 1;
@@ -190,9 +192,9 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    const lr_target_t *target = lr_target_host();
+    const lr_target_t *target = target_name ? lr_target_by_name(target_name) : lr_target_host();
     if (!target) {
-        fprintf(stderr, "failed to detect host target\n");
+        fprintf(stderr, "unknown target: %s\n", target_name ? target_name : "<host>");
         lr_module_free(m);
         free(src);
         return 1;


### PR DESCRIPTION
## Summary
- add a new riscv64 backend in C (`src/target_riscv64.c`)
- split target profiles similar to GCC/LLVM ISA-style feature split:
  - `riscv64gc` / `rv64gc` (with floating-point)
  - `riscv64im` / `rv64im` (no floating-point)
- update target registry and host detection to select `riscv64gc` vs `riscv64im` on riscv64 hosts by `__riscv_flen`
- add ELF riscv64 object/executable emission path and riscv64 startup stub
- extend CLI with `--target <name>` for object/executable/JIT paths
- add QEMU-backed tests for riscv64 direct executable mode
- add negative test that `riscv64im` rejects FP IR
- wire Linux CI to install `qemu-user` so riscv qemu tests run in GitHub Actions
- update architecture model to include riscv64 backend

## Validation
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure` (26/26 pass, includes riscv qemu tests)
- `./tools/arch_regen.sh`
- `./tools/arch_check.sh`
