### PR TITLE
macos: direct executable emission without cc fallback

### DIFF
--- a/src/objfile.c
+++ b/src/objfile.c
@@ -2,12 +2,14 @@
 #include "objfile_macho.h"
 #include "objfile_elf.h"
 #include "arena.h"
+#ifdef __APPLE__
 #include <errno.h>
 #include <fcntl.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#endif
+#include <stdlib.h>
+#include <string.h>
 
 #define OBJ_CODE_BUF_SIZE (4 * 1024 * 1024)
 #define OBJ_DATA_BUF_SIZE (1 * 1024 * 1024)
@@ -284,6 +286,7 @@ static int write_object_payload(FILE *out, const lr_target_t *target,
 #endif
 }
 
+#ifdef __APPLE__
 static int run_process_quiet(char *const argv[]) {
     pid_t pid;
     int status = 0;
@@ -344,6 +347,7 @@ static int copy_file_to_stream(const char *path, FILE *out) {
     fclose(in);
     return fflush(out) == 0 ? 0 : -1;
 }
+#endif
 
 static int obj_build_module(lr_module_t *m, const lr_target_t *target,
                             bool preserve_symbol_names,

--- a/src/objfile.c
+++ b/src/objfile.c
@@ -2,8 +2,12 @@
 #include "objfile_macho.h"
 #include "objfile_elf.h"
 #include "arena.h"
+#include <errno.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #define OBJ_CODE_BUF_SIZE (4 * 1024 * 1024)
 #define OBJ_DATA_BUF_SIZE (1 * 1024 * 1024)
@@ -248,6 +252,99 @@ static void obj_build_result_destroy(lr_obj_build_result_t *build) {
     memset(build, 0, sizeof(*build));
 }
 
+static int write_object_payload(FILE *out, const lr_target_t *target,
+                                const lr_obj_build_result_t *build) {
+    if (!out || !target || !build)
+        return -1;
+#ifdef __APPLE__
+    if (strcmp(target->name, "aarch64") == 0) {
+        return write_macho(out, build->code_buf, build->code_pos,
+                           build->has_data ? build->data_buf : NULL,
+                           build->has_data ? build->data_pos : 0,
+                           (lr_objfile_ctx_t *)&build->ctx, 0x0100000Cu,
+                           macho_reloc_arm64);
+    }
+    return -1;
+#else
+    if (strcmp(target->name, "x86_64") == 0) {
+        return write_elf(out, build->code_buf, build->code_pos,
+                         build->has_data ? build->data_buf : NULL,
+                         build->has_data ? build->data_pos : 0,
+                         (lr_objfile_ctx_t *)&build->ctx, 62,
+                         elf_reloc_x86_64);
+    }
+    if (strcmp(target->name, "aarch64") == 0) {
+        return write_elf(out, build->code_buf, build->code_pos,
+                         build->has_data ? build->data_buf : NULL,
+                         build->has_data ? build->data_pos : 0,
+                         (lr_objfile_ctx_t *)&build->ctx, 183,
+                         elf_reloc_x86_64);
+    }
+    return -1;
+#endif
+}
+
+static int run_process_quiet(char *const argv[]) {
+    pid_t pid;
+    int status = 0;
+    if (!argv || !argv[0])
+        return -1;
+    pid = fork();
+    if (pid < 0)
+        return -1;
+    if (pid == 0) {
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0) {
+            (void)dup2(devnull, STDOUT_FILENO);
+            (void)dup2(devnull, STDERR_FILENO);
+            close(devnull);
+        }
+        execvp(argv[0], argv);
+        _exit(127);
+    }
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno != EINTR)
+            return -1;
+    }
+    if (WIFEXITED(status))
+        return WEXITSTATUS(status);
+    if (WIFSIGNALED(status))
+        return 128 + WTERMSIG(status);
+    return -1;
+}
+
+static int run_codesign_adhoc(const char *path) {
+    char *const argv[] = {
+        "/usr/bin/codesign", "--force", "--sign", "-", (char *)path, NULL
+    };
+    if (!path || !path[0])
+        return -1;
+    return run_process_quiet(argv);
+}
+
+static int copy_file_to_stream(const char *path, FILE *out) {
+    FILE *in = NULL;
+    uint8_t buf[4096];
+    size_t nread;
+    if (!path || !out)
+        return -1;
+    in = fopen(path, "rb");
+    if (!in)
+        return -1;
+    while ((nread = fread(buf, 1, sizeof(buf), in)) > 0) {
+        if (fwrite(buf, 1, nread, out) != nread) {
+            fclose(in);
+            return -1;
+        }
+    }
+    if (ferror(in)) {
+        fclose(in);
+        return -1;
+    }
+    fclose(in);
+    return fflush(out) == 0 ? 0 : -1;
+}
+
 static int obj_build_module(lr_module_t *m, const lr_target_t *target,
                             bool preserve_symbol_names,
                             lr_obj_build_result_t *out) {
@@ -379,29 +476,7 @@ int lr_emit_object(lr_module_t *m, const lr_target_t *target, FILE *out) {
     if (obj_build_module(m, target, false, &build) != 0)
         return -1;
 
-    int result;
-#ifdef __APPLE__
-    if (strcmp(target->name, "aarch64") == 0)
-        result = write_macho(out, build.code_buf, build.code_pos,
-                             build.has_data ? build.data_buf : NULL,
-                             build.has_data ? build.data_pos : 0,
-                             &build.ctx, 0x0100000Cu, macho_reloc_arm64);
-    else
-        result = -1;
-#else
-    if (strcmp(target->name, "x86_64") == 0)
-        result = write_elf(out, build.code_buf, build.code_pos,
-                           build.has_data ? build.data_buf : NULL,
-                           build.has_data ? build.data_pos : 0,
-                           &build.ctx, 62, elf_reloc_x86_64);
-    else if (strcmp(target->name, "aarch64") == 0)
-        result = write_elf(out, build.code_buf, build.code_pos,
-                           build.has_data ? build.data_buf : NULL,
-                           build.has_data ? build.data_pos : 0,
-                           &build.ctx, 183, elf_reloc_x86_64);
-    else
-        result = -1;
-#endif
+    int result = write_object_payload(out, target, &build);
 
     obj_build_result_destroy(&build);
     return result;
@@ -428,7 +503,56 @@ int lr_emit_executable(lr_module_t *m, const lr_target_t *target, FILE *out,
             &build.ctx, entry_symbol);
     }
 #else
-    (void)entry_symbol;
+    if (strcmp(target->name, "aarch64") == 0) {
+        char exe_tpl[] = "/tmp/liric_exe_XXXXXX";
+        int exe_fd = -1;
+        FILE *exe_out = NULL;
+        int sign_rc;
+        int copy_rc;
+
+        exe_fd = mkstemp(exe_tpl);
+        if (exe_fd < 0)
+            goto done;
+        exe_out = fdopen(exe_fd, "wb");
+        if (!exe_out) {
+            close(exe_fd);
+            exe_fd = -1;
+            goto done;
+        }
+        exe_fd = -1;
+
+        result = write_macho_executable_arm64(
+            exe_out, build.code_buf, build.code_pos,
+            build.has_data ? build.data_buf : NULL,
+            build.has_data ? build.data_pos : 0,
+            &build.ctx, entry_symbol
+        );
+        if (fclose(exe_out) != 0)
+            result = -1;
+        exe_out = NULL;
+        if (result != 0)
+            goto done;
+
+        sign_rc = run_codesign_adhoc(exe_tpl);
+        if (sign_rc != 0) {
+            result = -1;
+            goto done;
+        }
+
+        copy_rc = copy_file_to_stream(exe_tpl, out);
+        if (copy_rc != 0) {
+            result = -1;
+            goto done;
+        }
+        result = 0;
+
+done:
+        if (exe_out)
+            fclose(exe_out);
+        if (exe_fd >= 0)
+            close(exe_fd);
+        unlink(exe_tpl);
+    }
 #endif
 
     obj_build_result_destroy(&build);

--- a/src/objfile_macho.c
+++ b/src/objfile_macho.c
@@ -4,13 +4,28 @@
 
 #define MH_MAGIC_64     0xFEEDFACFu
 #define MH_OBJECT       0x1u
+#define MH_EXECUTE      0x2u
 #define CPU_TYPE_ARM64  0x0100000Cu
 #define CPU_SUBTYPE_ALL 0x00000000u
 #define MH_SUBSECTIONS_VIA_SYMBOLS 0x00002000u
+#define MH_NOUNDEFS     0x00000001u
+#define MH_DYLDLINK     0x00000004u
+#define MH_TWOLEVEL     0x00000080u
+#define MH_PIE          0x00200000u
 
 #define LC_SEGMENT_64   0x19u
 #define LC_SYMTAB       0x02u
+#define LC_DYSYMTAB     0x0Bu
+#define LC_LOAD_DYLIB   0x0Cu
+#define LC_LOAD_DYLINKER 0x0Eu
+#define LC_UUID         0x1Bu
+#define LC_FUNCTION_STARTS 0x26u
+#define LC_DATA_IN_CODE 0x29u
+#define LC_SOURCE_VERSION 0x2Au
 #define LC_BUILD_VERSION 0x32u
+#define LC_MAIN         0x80000028u
+#define LC_DYLD_EXPORTS_TRIE 0x80000033u
+#define LC_DYLD_CHAINED_FIXUPS 0x80000034u
 
 #define S_REGULAR           0x0u
 #define S_ATTR_PURE_INSTRUCTIONS 0x80000000u
@@ -20,6 +35,23 @@
 #define N_SECT  0xEu
 
 #define PLATFORM_MACOS 1u
+#define TOOL_LD 3u
+
+static size_t append_uleb128(uint8_t *buf, size_t cap, uint64_t value) {
+    size_t n = 0;
+    if (!buf || cap == 0)
+        return 0;
+    do {
+        uint8_t byte = (uint8_t)(value & 0x7Fu);
+        value >>= 7;
+        if (value != 0)
+            byte |= 0x80u;
+        if (n >= cap)
+            return 0;
+        buf[n++] = byte;
+    } while (value != 0);
+    return n;
+}
 
 lr_reloc_mapped_t macho_reloc_arm64(uint8_t liric_type) {
     lr_reloc_mapped_t m = {0};
@@ -284,5 +316,320 @@ int write_macho(FILE *out, const uint8_t *code, size_t code_size,
     free(sym_remap);
     free(sym_order);
 
+    return written == total_size ? 0 : -1;
+}
+
+int write_macho_executable_arm64(FILE *out,
+                                 const uint8_t *code, size_t code_size,
+                                 const uint8_t *data, size_t data_size,
+                                 const lr_objfile_ctx_t *oc,
+                                 const char *entry_symbol) {
+    static const uint8_t fixups_blob[56] = {
+        0x00,0x00,0x00,0x00, 0x20,0x00,0x00,0x00, 0x30,0x00,0x00,0x00,
+        0x30,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x01,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x03,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00
+    };
+    static const char dyld_path[] = "/usr/lib/dyld";
+    static const char libsystem_path[] = "/usr/lib/libSystem.B.dylib";
+    const uint64_t image_base = 0x100000000ULL;
+    const size_t page = 0x4000u;
+    const uint32_t ncmds = 15;
+    const uint32_t sizeofcmds = 648;
+    const size_t code_sig_cmd_slack = 16u;
+    const size_t header_and_cmds = 32u + (size_t)sizeofcmds + code_sig_cmd_slack;
+    const size_t text_off = obj_align_up(header_and_cmds, 8);
+    const size_t text_file_size = obj_align_up(text_off + code_size, page);
+    const size_t linkedit_off = text_file_size;
+    size_t fixups_off = linkedit_off;
+    size_t exports_off = 0;
+    size_t func_starts_off = 0;
+    size_t symtab_off = 0;
+    size_t strtab_off = 0;
+    size_t linkedit_size = 0;
+    size_t total_size = 0;
+    const lr_obj_symbol_t *entry = NULL;
+    uint8_t exports_blob[64];
+    size_t exports_size = 0;
+    uint8_t func_starts_blob[16];
+    size_t func_starts_size = 0;
+    uint8_t symtab_blob[32];
+    uint8_t strtab_blob[32];
+    uint8_t *buf = NULL;
+    uint8_t *p = NULL;
+    size_t written;
+    uint64_t entry_off = 0;
+    uint64_t entry_addr = 0;
+
+    if (!out || !code || !oc || !entry_symbol || !entry_symbol[0])
+        return -1;
+    if (data != NULL || data_size != 0)
+        return -1;
+
+    for (uint32_t i = 0; i < oc->num_symbols; i++) {
+        const lr_obj_symbol_t *sym = &oc->symbols[i];
+        if (sym->is_defined && sym->section == 1 &&
+            strcmp(sym->name, entry_symbol) == 0) {
+            entry = sym;
+            break;
+        }
+    }
+    if (!entry || (size_t)entry->offset >= code_size)
+        return -1;
+
+    entry_off = text_off + (uint64_t)entry->offset;
+    entry_addr = image_base + entry_off;
+
+    memset(exports_blob, 0, sizeof(exports_blob));
+    {
+        size_t ep = 0;
+        size_t n = 0;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x01;
+        exports_blob[ep++] = '_';
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x12;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x02;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x03;
+        exports_blob[ep++] = 0x00;
+        n = append_uleb128(exports_blob + ep, sizeof(exports_blob) - ep,
+                           entry_off);
+        if (n == 0)
+            return -1;
+        ep += n;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x02;
+        memcpy(exports_blob + ep, "_mh_execute_header", 18);
+        ep += 18;
+        exports_blob[ep++] = 0x09;
+        memcpy(exports_blob + ep, "main", 5);
+        ep += 5;
+        exports_blob[ep++] = 0x0D;
+        exports_blob[ep++] = 0x00;
+        exports_blob[ep++] = 0x00;
+        exports_size = ep;
+    }
+
+    memset(func_starts_blob, 0, sizeof(func_starts_blob));
+    {
+        size_t n = append_uleb128(func_starts_blob, sizeof(func_starts_blob),
+                                  entry_off);
+        if (n == 0 || n + 1 > sizeof(func_starts_blob))
+            return -1;
+        func_starts_blob[n] = 0x00;
+        func_starts_size = 8;
+    }
+
+    memset(symtab_blob, 0, sizeof(symtab_blob));
+    memset(strtab_blob, 0, sizeof(strtab_blob));
+    strtab_blob[0] = 0x20;
+    strtab_blob[1] = 0x00;
+    memcpy(strtab_blob + 2, "__mh_execute_header", 18);
+    memcpy(strtab_blob + 22, "_main", 6);
+    {
+        uint8_t *s = symtab_blob;
+        /* __mh_execute_header */
+        w32(&s, 2u);
+        w8(&s, N_SECT | N_EXT);
+        w8(&s, 1u);
+        w16(&s, 0x0010u);
+        w64(&s, image_base);
+        /* _main */
+        w32(&s, 22u);
+        w8(&s, N_SECT | N_EXT);
+        w8(&s, 1u);
+        w16(&s, 0u);
+        w64(&s, entry_addr);
+    }
+
+    exports_off = fixups_off + sizeof(fixups_blob);
+    func_starts_off = exports_off + exports_size;
+    symtab_off = func_starts_off + func_starts_size;
+    strtab_off = symtab_off + sizeof(symtab_blob);
+    linkedit_size = strtab_off + sizeof(strtab_blob) - linkedit_off;
+    total_size = strtab_off + sizeof(strtab_blob);
+
+    buf = (uint8_t *)calloc(1, total_size);
+    if (!buf)
+        return -1;
+    p = buf;
+
+    w32(&p, MH_MAGIC_64);
+    w32(&p, CPU_TYPE_ARM64);
+    w32(&p, CPU_SUBTYPE_ALL);
+    w32(&p, MH_EXECUTE);
+    w32(&p, ncmds);
+    w32(&p, sizeofcmds);
+    w32(&p, MH_NOUNDEFS | MH_DYLDLINK | MH_TWOLEVEL | MH_PIE);
+    w32(&p, 0u);
+
+    /* __PAGEZERO */
+    w32(&p, LC_SEGMENT_64);
+    w32(&p, 72u);
+    {
+        char segname[16] = {0};
+        memcpy(segname, "__PAGEZERO", 10);
+        wbytes(&p, segname, sizeof(segname));
+    }
+    w64(&p, 0u);
+    w64(&p, image_base);
+    w64(&p, 0u);
+    w64(&p, 0u);
+    w32(&p, 0u);
+    w32(&p, 0u);
+    w32(&p, 0u);
+    w32(&p, 0u);
+
+    /* __TEXT */
+    w32(&p, LC_SEGMENT_64);
+    w32(&p, 152u);
+    {
+        char segname[16] = {0};
+        char sectname[16] = {0};
+        memcpy(segname, "__TEXT", 6);
+        wbytes(&p, segname, sizeof(segname));
+        w64(&p, image_base);
+        w64(&p, text_file_size);
+        w64(&p, 0u);
+        w64(&p, text_file_size);
+        w32(&p, 5u);
+        w32(&p, 5u);
+        w32(&p, 1u);
+        w32(&p, 0u);
+
+        memcpy(sectname, "__text", 6);
+        wbytes(&p, sectname, sizeof(sectname));
+        memset(segname, 0, sizeof(segname));
+        memcpy(segname, "__TEXT", 6);
+        wbytes(&p, segname, sizeof(segname));
+        w64(&p, image_base + text_off);
+        w64(&p, code_size);
+        w32(&p, (uint32_t)text_off);
+        w32(&p, 2u);
+        w32(&p, 0u);
+        w32(&p, 0u);
+        w32(&p, S_REGULAR | S_ATTR_PURE_INSTRUCTIONS |
+                 S_ATTR_SOME_INSTRUCTIONS);
+        w32(&p, 0u);
+        w32(&p, 0u);
+        w32(&p, 0u);
+    }
+
+    /* __LINKEDIT */
+    w32(&p, LC_SEGMENT_64);
+    w32(&p, 72u);
+    {
+        char segname[16] = {0};
+        memcpy(segname, "__LINKEDIT", 10);
+        wbytes(&p, segname, sizeof(segname));
+    }
+    w64(&p, image_base + linkedit_off);
+    w64(&p, obj_align_up(linkedit_size, page));
+    w64(&p, linkedit_off);
+    w64(&p, linkedit_size);
+    w32(&p, 1u);
+    w32(&p, 1u);
+    w32(&p, 0u);
+    w32(&p, 0u);
+
+    w32(&p, LC_DYLD_CHAINED_FIXUPS);
+    w32(&p, 16u);
+    w32(&p, (uint32_t)fixups_off);
+    w32(&p, (uint32_t)sizeof(fixups_blob));
+
+    w32(&p, LC_DYLD_EXPORTS_TRIE);
+    w32(&p, 16u);
+    w32(&p, (uint32_t)exports_off);
+    w32(&p, (uint32_t)exports_size);
+
+    w32(&p, LC_SYMTAB);
+    w32(&p, 24u);
+    w32(&p, (uint32_t)symtab_off);
+    w32(&p, 2u);
+    w32(&p, (uint32_t)strtab_off);
+    w32(&p, (uint32_t)sizeof(strtab_blob));
+
+    w32(&p, LC_DYSYMTAB);
+    w32(&p, 80u);
+    w32(&p, 0u); w32(&p, 0u); /* ilocalsym, nlocalsym */
+    w32(&p, 0u); w32(&p, 2u); /* iextdefsym, nextdefsym */
+    w32(&p, 2u); w32(&p, 0u); /* iundefsym, nundefsym */
+    w32(&p, 0u); w32(&p, 0u); /* tocoff, ntoc */
+    w32(&p, 0u); w32(&p, 0u); /* modtaboff, nmodtab */
+    w32(&p, 0u); w32(&p, 0u); /* extrefsymoff, nextrefsyms */
+    w32(&p, 0u); w32(&p, 0u); /* indirectsymoff, nindirectsyms */
+    w32(&p, 0u); w32(&p, 0u); /* extreloff, nextrel */
+    w32(&p, 0u); w32(&p, 0u); /* locreloff, nlocrel */
+
+    w32(&p, LC_LOAD_DYLINKER);
+    w32(&p, 32u);
+    w32(&p, 12u);
+    wbytes(&p, dyld_path, strlen(dyld_path) + 1u);
+    wpad(&p, 32u - 12u - (strlen(dyld_path) + 1u));
+
+    w32(&p, LC_UUID);
+    w32(&p, 24u);
+    wpad(&p, 16u);
+
+    w32(&p, LC_BUILD_VERSION);
+    w32(&p, 32u);
+    w32(&p, PLATFORM_MACOS);
+    w32(&p, (14u << 16));
+    w32(&p, (14u << 16));
+    w32(&p, 1u);
+    w32(&p, TOOL_LD);
+    w32(&p, 0x04ce0100u);
+
+    w32(&p, LC_SOURCE_VERSION);
+    w32(&p, 16u);
+    w64(&p, 0u);
+
+    w32(&p, LC_MAIN);
+    w32(&p, 24u);
+    w64(&p, entry_off);
+    w64(&p, 0u);
+
+    w32(&p, LC_LOAD_DYLIB);
+    w32(&p, 56u);
+    w32(&p, 24u);
+    w32(&p, 2u);
+    w32(&p, 0x054c0000u);
+    w32(&p, 0x00010000u);
+    wbytes(&p, libsystem_path, strlen(libsystem_path) + 1u);
+    wpad(&p, 56u - 24u - (strlen(libsystem_path) + 1u));
+
+    w32(&p, LC_FUNCTION_STARTS);
+    w32(&p, 16u);
+    w32(&p, (uint32_t)func_starts_off);
+    w32(&p, (uint32_t)func_starts_size);
+
+    w32(&p, LC_DATA_IN_CODE);
+    w32(&p, 16u);
+    w32(&p, (uint32_t)symtab_off);
+    w32(&p, 0u);
+
+    if ((size_t)(p - buf) > text_off) {
+        free(buf);
+        return -1;
+    }
+
+    memcpy(buf + text_off, code, code_size);
+    memcpy(buf + fixups_off, fixups_blob, sizeof(fixups_blob));
+    memcpy(buf + exports_off, exports_blob, exports_size);
+    memcpy(buf + func_starts_off, func_starts_blob, func_starts_size);
+    memcpy(buf + symtab_off, symtab_blob, sizeof(symtab_blob));
+    memcpy(buf + strtab_off, strtab_blob, sizeof(strtab_blob));
+
+    written = fwrite(buf, 1, total_size, out);
+    free(buf);
     return written == total_size ? 0 : -1;
 }

--- a/src/objfile_macho.h
+++ b/src/objfile_macho.h
@@ -8,6 +8,12 @@ int write_macho(FILE *out, const uint8_t *code, size_t code_size,
                 const lr_objfile_ctx_t *oc,
                 uint32_t cpu_type, lr_reloc_mapper_fn reloc_mapper);
 
+int write_macho_executable_arm64(FILE *out,
+                                 const uint8_t *code, size_t code_size,
+                                 const uint8_t *data, size_t data_size,
+                                 const lr_objfile_ctx_t *oc,
+                                 const char *entry_symbol);
+
 lr_reloc_mapped_t macho_reloc_arm64(uint8_t liric_type);
 
 #endif


### PR DESCRIPTION
## Summary
- add direct arm64 Mach-O executable writer in `write_macho_executable_arm64`
- wire macOS executable emission to use direct writer plus ad-hoc `codesign` only
- remove linker-based executable fallback path from macOS emission
- keep object emission behavior unchanged

Fixes #270

## Notes
- current direct executable path supports text-only payloads no data section
- this resolves issue #270 via option 2 implement macOS executable emission while keeping CLI executable tests enabled cross-platform

## Validation
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j32`
- `ctest --test-dir build --output-on-failure`
- `./tools/arch_regen.sh`
