### PR TITLE
Implement LLVM mode-C backend and 7-21 backend matrix

### DIFF
--- a/.github/workflows/llvm_backend_compat.yml
+++ b/.github/workflows/llvm_backend_compat.yml
@@ -1,0 +1,49 @@
+name: LLVM Backend Compat
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  llvm-backend-matrix:
+    name: LLVM backend (llvmdev=${{ matrix.llvm-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm-version: ["7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup micromamba
+        uses: mamba-org/setup-micromamba@v2.0.2
+        with:
+          micromamba-version: "2.0.4-0"
+          environment-file: tools/llvm_backend_environment.yml
+          create-args: >-
+            llvmdev=${{ matrix.llvm-version }}
+          cache-environment: true
+          cache-environment-key: llvm-backend-${{ matrix.llvm-version }}
+
+      - name: Build and test
+        shell: bash -e -l {0}
+        run: |
+          with_compat=OFF
+          if [[ "${{ matrix.llvm-version }}" -ge 11 ]]; then
+            with_compat=ON
+          fi
+          llvm_config="$(command -v llvm-config)"
+          if [[ -z "${llvm_config}" ]]; then
+            echo "llvm-config not found" >&2
+            exit 1
+          fi
+          cmake -S . -B build -G Ninja \
+            -DWITH_REAL_LLVM_BACKEND=ON \
+            -DWITH_LLVM_COMPAT="${with_compat}" \
+            -DWITH_BENCH_TCC=OFF \
+            -DWITH_BENCH_LLI_PHASES=OFF \
+            -DLIRIC_LLVM_CONFIG_EXE="${llvm_config}"
+          cmake --build build -j"$(nproc)"
+          ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,85 @@ endif()
 
 add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 
+option(WITH_REAL_LLVM_BACKEND "Enable real LLVM C API backend for mode 'llvm'" OFF)
+set(LIRIC_LLVM_CONFIG_EXE "" CACHE FILEPATH "Path to llvm-config for real LLVM backend")
+
+set(LIRIC_REAL_LLVM_INCLUDE_DIR "")
+set(LIRIC_REAL_LLVM_CFLAGS_LIST "")
+set(LIRIC_REAL_LLVM_LDFLAGS_LIST "")
+set(LIRIC_REAL_LLVM_LIBS_LIST "")
+set(LIRIC_REAL_LLVM_SYSTEM_LIBS_LIST "")
+set(LIRIC_BACKEND_LLVM_VERSION "")
+set(LIRIC_BACKEND_LLVM_VERSION_MAJOR "0")
+
+if(WITH_REAL_LLVM_BACKEND)
+    if(LIRIC_LLVM_CONFIG_EXE)
+        set(LLVM_BACKEND_CONFIG_EXE "${LIRIC_LLVM_CONFIG_EXE}")
+    else()
+        find_program(LLVM_BACKEND_CONFIG_EXE llvm-config)
+    endif()
+    if(NOT LLVM_BACKEND_CONFIG_EXE)
+        message(FATAL_ERROR "WITH_REAL_LLVM_BACKEND=ON requires llvm-config (or set LIRIC_LLVM_CONFIG_EXE)")
+    endif()
+
+    execute_process(
+        COMMAND ${LLVM_BACKEND_CONFIG_EXE} --version
+        OUTPUT_VARIABLE LIRIC_BACKEND_LLVM_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REGEX MATCH "^[0-9]+" LIRIC_BACKEND_LLVM_VERSION_MAJOR "${LIRIC_BACKEND_LLVM_VERSION}")
+    if(NOT LIRIC_BACKEND_LLVM_VERSION_MAJOR)
+        message(FATAL_ERROR "Could not parse LLVM major version from: ${LIRIC_BACKEND_LLVM_VERSION}")
+    endif()
+
+    execute_process(
+        COMMAND ${LLVM_BACKEND_CONFIG_EXE} --includedir
+        OUTPUT_VARIABLE LIRIC_REAL_LLVM_INCLUDE_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    execute_process(
+        COMMAND ${LLVM_BACKEND_CONFIG_EXE} --cflags
+        OUTPUT_VARIABLE LIRIC_REAL_LLVM_CFLAGS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    execute_process(
+        COMMAND ${LLVM_BACKEND_CONFIG_EXE} --ldflags
+        OUTPUT_VARIABLE LIRIC_REAL_LLVM_LDFLAGS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    execute_process(
+        COMMAND ${LLVM_BACKEND_CONFIG_EXE} --libs all
+        OUTPUT_VARIABLE LIRIC_REAL_LLVM_LIBS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    execute_process(
+        COMMAND ${LLVM_BACKEND_CONFIG_EXE} --system-libs
+        OUTPUT_VARIABLE LIRIC_REAL_LLVM_SYSTEM_LIBS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    separate_arguments(LIRIC_REAL_LLVM_CFLAGS_LIST NATIVE_COMMAND "${LIRIC_REAL_LLVM_CFLAGS}")
+    separate_arguments(LIRIC_REAL_LLVM_LDFLAGS_LIST NATIVE_COMMAND "${LIRIC_REAL_LLVM_LDFLAGS}")
+    separate_arguments(LIRIC_REAL_LLVM_LIBS_LIST NATIVE_COMMAND "${LIRIC_REAL_LLVM_LIBS}")
+    separate_arguments(LIRIC_REAL_LLVM_SYSTEM_LIBS_LIST NATIVE_COMMAND "${LIRIC_REAL_LLVM_SYSTEM_LIBS}")
+
+    add_compile_definitions(
+        LIRIC_HAVE_REAL_LLVM_BACKEND=1
+        LIRIC_BACKEND_LLVM_VERSION_MAJOR=${LIRIC_BACKEND_LLVM_VERSION_MAJOR}
+    )
+    message(STATUS "Real LLVM backend enabled (llvm-config=${LLVM_BACKEND_CONFIG_EXE}, version=${LIRIC_BACKEND_LLVM_VERSION})")
+endif()
+
+option(WITH_LLVM_COMPAT "Build LLVM C++ compatibility layer tests" OFF)
+if(WITH_REAL_LLVM_BACKEND AND WITH_LLVM_COMPAT)
+    if(LIRIC_BACKEND_LLVM_VERSION_MAJOR LESS 11)
+        message(WARNING
+            "WITH_LLVM_COMPAT is disabled for real backend with LLVM < 11 "
+            "(known static-link C++ symbol collision in llvmdev packages).")
+        set(WITH_LLVM_COMPAT OFF CACHE BOOL "Build LLVM C++ compatibility layer tests" FORCE)
+    endif()
+endif()
+
 if(UNIX AND NOT APPLE)
     add_link_options("$<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>:-rdynamic>")
 endif()
@@ -37,6 +116,7 @@ add_library(liric STATIC
     src/ll_lexer.c
     src/ll_parser.c
     src/frontend_common.c
+    src/compile_mode.c
     src/bc_decode.c
     src/frontend_registry.c
     src/wasm_decode.c
@@ -52,6 +132,7 @@ add_library(liric STATIC
     src/liric.c
     src/liric_compat.c
     src/session.c
+    src/llvm_backend.c
     src/objfile.c
     src/objfile_macho.c
     src/objfile_elf.c
@@ -69,6 +150,20 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch6
 endif()
 target_include_directories(liric PUBLIC include)
 target_include_directories(liric PRIVATE src)
+if(WITH_REAL_LLVM_BACKEND)
+    target_include_directories(liric PRIVATE "${LIRIC_REAL_LLVM_INCLUDE_DIR}")
+    target_compile_options(liric PRIVATE ${LIRIC_REAL_LLVM_CFLAGS_LIST})
+    target_compile_definitions(liric PRIVATE
+        LIRIC_HAVE_REAL_LLVM_BACKEND=1
+        LIRIC_BACKEND_LLVM_VERSION_MAJOR=${LIRIC_BACKEND_LLVM_VERSION_MAJOR}
+    )
+    target_link_options(liric PRIVATE ${LIRIC_REAL_LLVM_LDFLAGS_LIST})
+    target_link_libraries(liric PRIVATE
+        ${LIRIC_REAL_LLVM_LIBS_LIST}
+        ${LIRIC_REAL_LLVM_SYSTEM_LIBS_LIST}
+        stdc++
+    )
+endif()
 
 add_executable(liric_bin tools/liric_main.c)
 set_target_properties(liric_bin PROPERTIES OUTPUT_NAME liric)
@@ -103,12 +198,24 @@ target_link_libraries(bench_api_callgrind_hot PRIVATE ${LIRIC_PLATFORM_LIBS})
 add_executable(bench_corpus tools/bench_corpus.c)
 target_link_libraries(bench_corpus PRIVATE ${LIRIC_PLATFORM_LIBS})
 
-add_executable(bench_tcc tools/bench_tcc.c)
-target_link_libraries(bench_tcc PRIVATE liric tcc ${LIRIC_PLATFORM_LIBS})
-target_include_directories(bench_tcc PRIVATE src)
+option(WITH_BENCH_TCC "Build bench_tcc target (requires libtcc)" ON)
+if(WITH_BENCH_TCC)
+    find_path(LIRTCC_INCLUDE_DIR libtcc.h)
+    find_library(LIRTCC_LIB tcc)
+    if(LIRTCC_INCLUDE_DIR AND LIRTCC_LIB)
+        add_executable(bench_tcc tools/bench_tcc.c)
+        target_include_directories(bench_tcc PRIVATE src "${LIRTCC_INCLUDE_DIR}")
+        target_link_libraries(bench_tcc PRIVATE liric "${LIRTCC_LIB}" ${LIRIC_PLATFORM_LIBS})
+    else()
+        message(STATUS "libtcc not found: bench_tcc target will not be built")
+    endif()
+else()
+    message(STATUS "bench_tcc target disabled (WITH_BENCH_TCC=OFF)")
+endif()
 
+option(WITH_BENCH_LLI_PHASES "Build bench_lli_phases when LLVM C ORC APIs are available" ON)
 find_program(LLVM_CONFIG_EXE llvm-config)
-if(LLVM_CONFIG_EXE)
+if(LLVM_CONFIG_EXE AND WITH_BENCH_LLI_PHASES)
     execute_process(
         COMMAND ${LLVM_CONFIG_EXE} --includedir
         OUTPUT_VARIABLE LLVM_INCLUDE_DIR
@@ -133,18 +240,26 @@ if(LLVM_CONFIG_EXE)
     separate_arguments(LLVM_LIBS_LIST NATIVE_COMMAND "${LLVM_LIBS}")
     separate_arguments(LLVM_SYSTEM_LIBS_LIST NATIVE_COMMAND "${LLVM_SYSTEM_LIBS}")
 
-    add_executable(bench_lli_phases tools/bench_lli_phases.c)
-    target_include_directories(bench_lli_phases PRIVATE ${LLVM_INCLUDE_DIR})
-    target_link_options(bench_lli_phases PRIVATE ${LLVM_LDFLAGS_LIST})
-    target_link_libraries(
-        bench_lli_phases PRIVATE
-        ${LLVM_LIBS_LIST}
-        ${LLVM_SYSTEM_LIBS_LIST}
-        ${LIRIC_PLATFORM_LIBS}
-        stdc++
-    )
+    if(EXISTS "${LLVM_INCLUDE_DIR}/llvm-c/LLJIT.h")
+        add_executable(bench_lli_phases tools/bench_lli_phases.c)
+        target_include_directories(bench_lli_phases PRIVATE ${LLVM_INCLUDE_DIR})
+        target_link_options(bench_lli_phases PRIVATE ${LLVM_LDFLAGS_LIST})
+        target_link_libraries(
+            bench_lli_phases PRIVATE
+            ${LLVM_LIBS_LIST}
+            ${LLVM_SYSTEM_LIBS_LIST}
+            ${LIRIC_PLATFORM_LIBS}
+            stdc++
+        )
+    else()
+        message(STATUS "llvm-c/LLJIT.h not found: bench_lli_phases target will not be built")
+    endif()
 else()
-    message(STATUS "llvm-config not found: bench_lli_phases target will not be built")
+    if(WITH_BENCH_LLI_PHASES)
+        message(STATUS "llvm-config not found: bench_lli_phases target will not be built")
+    else()
+        message(STATUS "bench_lli_phases target disabled (WITH_BENCH_LLI_PHASES=OFF)")
+    endif()
 endif()
 
 enable_testing()
@@ -386,7 +501,7 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_nightly_mass_shell_runner.cmake
 )
 
-if(CMAKE_NM)
+if(CMAKE_NM AND NOT WITH_REAL_LLVM_BACKEND)
     add_test(
         NAME liric_static_archive_no_llvm_undef
         COMMAND ${CMAKE_COMMAND}
@@ -403,7 +518,6 @@ install(DIRECTORY include/liric DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY include/llvm DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(TARGETS liric_bin RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-option(WITH_LLVM_COMPAT "Build LLVM C++ compatibility layer tests" OFF)
 if(WITH_LLVM_COMPAT)
     enable_language(CXX)
     set(CMAKE_CXX_STANDARD 17)
@@ -412,4 +526,11 @@ if(WITH_LLVM_COMPAT)
     target_link_libraries(test_llvm_compat PRIVATE liric ${LIRIC_PLATFORM_LIBS} stdc++)
     target_compile_options(test_llvm_compat PRIVATE -Wall -Wextra -Wpedantic -Wno-unused-parameter)
     add_test(NAME llvm_compat_tests COMMAND test_llvm_compat)
+
+    if(WITH_REAL_LLVM_BACKEND)
+        add_executable(test_llvm_backend_roundtrip tests/test_llvm_backend_roundtrip.cpp)
+        target_link_libraries(test_llvm_backend_roundtrip PRIVATE liric ${LIRIC_PLATFORM_LIBS} stdc++)
+        target_compile_options(test_llvm_backend_roundtrip PRIVATE -Wall -Wextra -Wpedantic)
+        add_test(NAME llvm_backend_roundtrip_tests COMMAND test_llvm_backend_roundtrip)
+    endif()
 endif()

--- a/src/compile_mode.c
+++ b/src/compile_mode.c
@@ -1,0 +1,44 @@
+#include "compile_mode.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+int lr_compile_mode_parse(const char *text, lr_compile_mode_t *out_mode) {
+    if (!text || !out_mode)
+        return -1;
+
+    if (strcmp(text, "isel") == 0) {
+        *out_mode = LR_COMPILE_ISEL;
+        return 0;
+    }
+    if (strcmp(text, "copy_patch") == 0) {
+        *out_mode = LR_COMPILE_COPY_PATCH;
+        return 0;
+    }
+    if (strcmp(text, "llvm") == 0) {
+        *out_mode = LR_COMPILE_LLVM;
+        return 0;
+    }
+    return -1;
+}
+
+lr_compile_mode_t lr_compile_mode_from_env(void) {
+    lr_compile_mode_t mode = LR_COMPILE_ISEL;
+    const char *env = getenv("LIRIC_COMPILE_MODE");
+    if (env)
+        (void)lr_compile_mode_parse(env, &mode);
+    return mode;
+}
+
+const char *lr_compile_mode_name(lr_compile_mode_t mode) {
+    switch (mode) {
+    case LR_COMPILE_ISEL:
+        return "isel";
+    case LR_COMPILE_COPY_PATCH:
+        return "copy_patch";
+    case LR_COMPILE_LLVM:
+        return "llvm";
+    default:
+        return "unknown";
+    }
+}

--- a/src/compile_mode.h
+++ b/src/compile_mode.h
@@ -1,0 +1,14 @@
+#ifndef LIRIC_COMPILE_MODE_H
+#define LIRIC_COMPILE_MODE_H
+
+#include "target.h"
+
+/* Parse mode text into enum; returns 0 on success. */
+int lr_compile_mode_parse(const char *text, lr_compile_mode_t *out_mode);
+
+/* Parse LIRIC_COMPILE_MODE from env; defaults to LR_COMPILE_ISEL. */
+lr_compile_mode_t lr_compile_mode_from_env(void);
+
+const char *lr_compile_mode_name(lr_compile_mode_t mode);
+
+#endif

--- a/src/liric_compat.c
+++ b/src/liric_compat.c
@@ -1,10 +1,15 @@
 #include "ir.h"
 #include "arena.h"
+#include "compile_mode.h"
 #include "jit.h"
+#include "llvm_backend.h"
 #include "objfile.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#if defined(__unix__) || defined(__APPLE__)
+#include <unistd.h>
+#endif
 
 /* Guard: lr_opcode_t (ir.h) must stay in sync with lr_op_t (liric_session.h). */
 _Static_assert(LR_OP_INSERTVALUE == 43,
@@ -217,6 +222,27 @@ static void ensure_cache_owner(lc_module_compat_t *mod) {
     if (mod->cache_owner_mod != mod->mod)
         clear_symbol_caches(mod);
 }
+
+#if defined(__unix__) || defined(__APPLE__)
+static int copy_file_to_stream(const char *path, FILE *out) {
+    FILE *in = NULL;
+    uint8_t buf[8192];
+    size_t n = 0;
+    if (!path || !out)
+        return -1;
+    in = fopen(path, "rb");
+    if (!in)
+        return -1;
+    while ((n = fread(buf, 1, sizeof(buf), in)) > 0) {
+        if (fwrite(buf, 1, n, out) != n) {
+            fclose(in);
+            return -1;
+        }
+    }
+    fclose(in);
+    return ferror(out) ? -1 : 0;
+}
+#endif
 
 static int ensure_symbol_cache_cap(lc_module_compat_t *mod, uint32_t min_cap) {
     if (!mod) return -1;
@@ -2239,14 +2265,46 @@ int lc_module_add_to_jit(lc_module_compat_t *mod, lr_jit_t *jit) {
 }
 
 int lc_module_emit_object_to_file(lc_module_compat_t *mod, FILE *out) {
+    lr_compile_mode_t mode;
+    const lr_target_t *target;
     if (!mod || !out) return -1;
-    const lr_target_t *target = lr_target_host();
+    target = lr_target_host();
     if (!target) return -1;
+    mode = lr_compile_mode_from_env();
+    if (mode == LR_COMPILE_LLVM) {
+#if defined(__unix__) || defined(__APPLE__)
+        char tmp_tpl[] = "/tmp/liric_compat_obj_XXXXXX";
+        char backend_err[256] = {0};
+        int fd = mkstemp(tmp_tpl);
+        int rc = -1;
+        if (fd < 0)
+            return -1;
+        close(fd);
+        rc = lr_llvm_emit_object_path(mod->mod, target, tmp_tpl,
+                                      backend_err, sizeof(backend_err));
+        if (rc == 0)
+            rc = copy_file_to_stream(tmp_tpl, out);
+        unlink(tmp_tpl);
+        return rc;
+#else
+        return -1;
+#endif
+    }
     return lr_emit_object(mod->mod, target, out);
 }
 
 int lc_module_emit_object(lc_module_compat_t *mod, const char *filename) {
+    lr_compile_mode_t mode;
+    const lr_target_t *target;
+    char backend_err[256] = {0};
     if (!mod || !filename) return -1;
+    target = lr_target_host();
+    if (!target) return -1;
+    mode = lr_compile_mode_from_env();
+    if (mode == LR_COMPILE_LLVM) {
+        return lr_llvm_emit_object_path(mod->mod, target, filename,
+                                        backend_err, sizeof(backend_err));
+    }
     FILE *f = fopen(filename, "wb");
     if (!f) return -1;
     int rc = lc_module_emit_object_to_file(mod, f);
@@ -2256,9 +2314,17 @@ int lc_module_emit_object(lc_module_compat_t *mod, const char *filename) {
 
 int lc_module_emit_executable(lc_module_compat_t *mod, const char *filename,
                                const char *runtime_ll, size_t runtime_len) {
+    lr_compile_mode_t mode;
     if (!mod || !filename || !runtime_ll || runtime_len == 0) return -1;
     const lr_target_t *target = lr_target_host();
     if (!target) return -1;
+    mode = lr_compile_mode_from_env();
+    if (mode == LR_COMPILE_LLVM) {
+        char backend_err[256] = {0};
+        return lr_llvm_emit_executable_path(mod->mod, runtime_ll, runtime_len,
+                                            target, filename, "main",
+                                            backend_err, sizeof(backend_err));
+    }
     FILE *f = fopen(filename, "wb");
     if (!f) return -1;
     int rc = lr_emit_executable_with_runtime(mod->mod, runtime_ll, runtime_len,

--- a/src/llvm_backend.c
+++ b/src/llvm_backend.c
@@ -1,0 +1,450 @@
+#include "llvm_backend.h"
+
+#include "liric.h"
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(LIRIC_HAVE_REAL_LLVM_BACKEND) && LIRIC_HAVE_REAL_LLVM_BACKEND
+
+#include <llvm-c/Analysis.h>
+#include <llvm-c/Core.h>
+#include <llvm-c/IRReader.h>
+#include <llvm-c/Target.h>
+#include <llvm-c/TargetMachine.h>
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <sys/wait.h>
+#include <unistd.h>
+#define LR_LLVM_BACKEND_CAN_LINK 1
+#else
+#define LR_LLVM_BACKEND_CAN_LINK 0
+#endif
+
+#define LR_LLVM_ERRBUF_DEFAULT 512
+
+static void set_err(char *err, size_t err_cap, const char *fmt, ...) {
+    va_list ap;
+    if (!err || err_cap == 0)
+        return;
+    va_start(ap, fmt);
+    (void)vsnprintf(err, err_cap, fmt, ap);
+    va_end(ap);
+}
+
+static char *read_file_to_buf(FILE *f, size_t *out_len) {
+    long end_pos;
+    size_t nread;
+    char *buf = NULL;
+
+    if (!f)
+        return NULL;
+    if (fseek(f, 0, SEEK_END) != 0)
+        return NULL;
+    end_pos = ftell(f);
+    if (end_pos < 0)
+        return NULL;
+    if (fseek(f, 0, SEEK_SET) != 0)
+        return NULL;
+
+    buf = (char *)malloc((size_t)end_pos + 1u);
+    if (!buf)
+        return NULL;
+    nread = fread(buf, 1, (size_t)end_pos, f);
+    if (nread != (size_t)end_pos) {
+        free(buf);
+        return NULL;
+    }
+    buf[nread] = '\0';
+    if (out_len)
+        *out_len = nread;
+    return buf;
+}
+
+static char *module_to_ll_text(lr_module_t *m, size_t *out_len) {
+    FILE *tmp = NULL;
+    char *buf = NULL;
+    if (!m)
+        return NULL;
+    tmp = tmpfile();
+    if (!tmp)
+        return NULL;
+    lr_module_dump(m, tmp);
+    fflush(tmp);
+    buf = read_file_to_buf(tmp, out_len);
+    fclose(tmp);
+    return buf;
+}
+
+static lr_module_t *clone_module(lr_module_t *m, char *err, size_t err_cap) {
+    char parse_err[256] = {0};
+    size_t ll_len = 0;
+    char *ll = module_to_ll_text(m, &ll_len);
+    lr_module_t *out = NULL;
+    if (!ll) {
+        set_err(err, err_cap, "failed to dump module to text");
+        return NULL;
+    }
+    out = lr_parse_ll(ll, ll_len, parse_err, sizeof(parse_err));
+    free(ll);
+    if (!out) {
+        set_err(err, err_cap, "failed to parse dumped module: %s",
+                parse_err[0] ? parse_err : "unknown parse error");
+        return NULL;
+    }
+    return out;
+}
+
+static int merge_runtime_into(lr_module_t *work, const char *runtime_ll,
+                              size_t runtime_len, char *err, size_t err_cap) {
+    char parse_err[256] = {0};
+    lr_module_t *rt = NULL;
+    if (!runtime_ll || runtime_len == 0)
+        return 0;
+    rt = lr_parse_ll(runtime_ll, runtime_len, parse_err, sizeof(parse_err));
+    if (!rt) {
+        set_err(err, err_cap, "failed to parse runtime ll: %s",
+                parse_err[0] ? parse_err : "unknown parse error");
+        return -1;
+    }
+    if (lr_module_merge(work, rt) != 0) {
+        lr_module_free(rt);
+        set_err(err, err_cap, "failed to merge runtime module");
+        return -1;
+    }
+    lr_module_free(rt);
+    return 0;
+}
+
+/* Emit a simple wrapper main() that calls entry_symbol() with no args. */
+static int add_entry_wrapper_if_needed(lr_module_t *work, const char *entry_symbol,
+                                       char *err, size_t err_cap) {
+    char wrapper[512];
+    char parse_err[256] = {0};
+    lr_module_t *w = NULL;
+    if (!entry_symbol || entry_symbol[0] == '\0' ||
+        strcmp(entry_symbol, "main") == 0)
+        return 0;
+
+    if (snprintf(wrapper, sizeof(wrapper),
+                 "declare i32 @%s()\n"
+                 "define i32 @main() {\n"
+                 "entry:\n"
+                 "  %%ret = call i32 @%s()\n"
+                 "  ret i32 %%ret\n"
+                 "}\n",
+                 entry_symbol, entry_symbol) >= (int)sizeof(wrapper)) {
+        set_err(err, err_cap, "entry wrapper generation failed (name too long)");
+        return -1;
+    }
+    w = lr_parse_ll(wrapper, strlen(wrapper), parse_err, sizeof(parse_err));
+    if (!w) {
+        set_err(err, err_cap, "failed to parse generated main wrapper: %s",
+                parse_err[0] ? parse_err : "unknown parse error");
+        return -1;
+    }
+    if (lr_module_merge(work, w) != 0) {
+        lr_module_free(w);
+        set_err(err, err_cap, "failed to merge main wrapper");
+        return -1;
+    }
+    lr_module_free(w);
+    return 0;
+}
+
+static int ensure_llvm_target_init(char *err, size_t err_cap) {
+    if (LLVMInitializeNativeTarget() != 0) {
+        set_err(err, err_cap, "LLVMInitializeNativeTarget failed");
+        return -1;
+    }
+    if (LLVMInitializeNativeAsmPrinter() != 0) {
+        set_err(err, err_cap, "LLVMInitializeNativeAsmPrinter failed");
+        return -1;
+    }
+    if (LLVMInitializeNativeAsmParser() != 0) {
+        set_err(err, err_cap, "LLVMInitializeNativeAsmParser failed");
+        return -1;
+    }
+    return 0;
+}
+
+static int emit_object_from_ll_text(const char *ll, size_t ll_len,
+                                    const char *path, char *err,
+                                    size_t err_cap) {
+    LLVMContextRef ctx = NULL;
+    LLVMMemoryBufferRef mem = NULL;
+    LLVMModuleRef mod = NULL;
+    LLVMTargetRef target = NULL;
+    LLVMTargetMachineRef tm = NULL;
+    LLVMTargetDataRef td = NULL;
+    char *triple = NULL;
+    char *msg = NULL;
+    char *dl = NULL;
+    int rc = -1;
+
+    if (!ll || ll_len == 0 || !path) {
+        set_err(err, err_cap, "invalid LLVM object emission arguments");
+        return -1;
+    }
+    if (ensure_llvm_target_init(err, err_cap) != 0)
+        return -1;
+
+    triple = LLVMGetDefaultTargetTriple();
+    if (!triple || triple[0] == '\0') {
+        set_err(err, err_cap, "LLVMGetDefaultTargetTriple failed");
+        goto done;
+    }
+    if (LLVMGetTargetFromTriple(triple, &target, &msg) != 0 || !target) {
+        set_err(err, err_cap, "LLVMGetTargetFromTriple failed: %s",
+                msg ? msg : "unknown error");
+        goto done;
+    }
+
+    tm = LLVMCreateTargetMachine(target, triple, "generic", "",
+                                 LLVMCodeGenLevelDefault,
+                                 LLVMRelocPIC,
+                                 LLVMCodeModelDefault);
+    if (!tm) {
+        set_err(err, err_cap, "LLVMCreateTargetMachine failed");
+        goto done;
+    }
+
+    ctx = LLVMContextCreate();
+    if (!ctx) {
+        set_err(err, err_cap, "LLVMContextCreate failed");
+        goto done;
+    }
+    mem = LLVMCreateMemoryBufferWithMemoryRangeCopy(ll, ll_len, "liric_module");
+    if (!mem) {
+        set_err(err, err_cap, "LLVMCreateMemoryBufferWithMemoryRangeCopy failed");
+        goto done;
+    }
+
+    if (LLVMParseIRInContext(ctx, mem, &mod, &msg) != 0 || !mod) {
+        set_err(err, err_cap, "LLVMParseIRInContext failed: %s",
+                msg ? msg : "unknown parse error");
+        goto done;
+    }
+    /* Ownership transfers to the module on parse success. */
+    mem = NULL;
+
+    LLVMSetTarget(mod, triple);
+    td = LLVMCreateTargetDataLayout(tm);
+    if (!td) {
+        set_err(err, err_cap, "LLVMCreateTargetDataLayout failed");
+        goto done;
+    }
+    dl = LLVMCopyStringRepOfTargetData(td);
+    if (!dl) {
+        set_err(err, err_cap, "LLVMCopyStringRepOfTargetData failed");
+        goto done;
+    }
+    LLVMSetDataLayout(mod, dl);
+
+    if (LLVMVerifyModule(mod, LLVMReturnStatusAction, &msg) != 0) {
+        set_err(err, err_cap, "LLVMVerifyModule failed: %s",
+                msg ? msg : "verify failure");
+        goto done;
+    }
+
+    if (LLVMTargetMachineEmitToFile(tm, mod, (char *)path,
+                                    LLVMObjectFile, &msg) != 0) {
+        set_err(err, err_cap, "LLVMTargetMachineEmitToFile failed: %s",
+                msg ? msg : "emit failure");
+        goto done;
+    }
+
+    rc = 0;
+
+done:
+    if (msg)
+        LLVMDisposeMessage(msg);
+    if (dl)
+        LLVMDisposeMessage(dl);
+    if (td)
+        LLVMDisposeTargetData(td);
+    if (mod)
+        LLVMDisposeModule(mod);
+    if (mem)
+        LLVMDisposeMemoryBuffer(mem);
+    if (ctx)
+        LLVMContextDispose(ctx);
+    if (tm)
+        LLVMDisposeTargetMachine(tm);
+    if (triple)
+        LLVMDisposeMessage(triple);
+    return rc;
+}
+
+#if LR_LLVM_BACKEND_CAN_LINK
+static int link_executable_from_object(const char *obj_path, const char *out_path,
+                                       char *err, size_t err_cap) {
+    const char *cc_env = getenv("CC");
+    const char *cc = (cc_env && cc_env[0]) ? cc_env : "cc";
+    pid_t pid;
+    int status = 0;
+    char *const argv[] = {
+        (char *)cc,
+        (char *)"-o",
+        (char *)out_path,
+        (char *)obj_path,
+        NULL
+    };
+
+    pid = fork();
+    if (pid < 0) {
+        set_err(err, err_cap, "fork failed while linking executable");
+        return -1;
+    }
+    if (pid == 0) {
+        execvp(cc, argv);
+        _exit(127);
+    }
+    if (waitpid(pid, &status, 0) < 0) {
+        set_err(err, err_cap, "waitpid failed while linking executable");
+        return -1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        set_err(err, err_cap, "linker failed with status=%d", status);
+        return -1;
+    }
+    return 0;
+}
+#endif
+
+int lr_llvm_backend_is_available(void) {
+    return 1;
+}
+
+int lr_llvm_emit_object_path(lr_module_t *m, const lr_target_t *target,
+                             const char *path, char *err, size_t err_cap) {
+    const lr_target_t *host = lr_target_host();
+    size_t ll_len = 0;
+    char *ll = NULL;
+    int rc;
+
+    if (!err_cap)
+        err_cap = LR_LLVM_ERRBUF_DEFAULT;
+    if (err && err_cap)
+        err[0] = '\0';
+
+    if (!m || !path || !target) {
+        set_err(err, err_cap, "invalid object emission inputs");
+        return -1;
+    }
+    if (!host || strcmp(host->name, target->name) != 0) {
+        set_err(err, err_cap, "llvm backend currently supports host target only");
+        return -1;
+    }
+
+    ll = module_to_ll_text(m, &ll_len);
+    if (!ll) {
+        set_err(err, err_cap, "failed to materialize module text");
+        return -1;
+    }
+    rc = emit_object_from_ll_text(ll, ll_len, path, err, err_cap);
+    free(ll);
+    return rc;
+}
+
+int lr_llvm_emit_executable_path(lr_module_t *m, const char *runtime_ll,
+                                 size_t runtime_len,
+                                 const lr_target_t *target,
+                                 const char *path,
+                                 const char *entry_symbol,
+                                 char *err, size_t err_cap) {
+#if !LR_LLVM_BACKEND_CAN_LINK
+    (void)m;
+    (void)runtime_ll;
+    (void)runtime_len;
+    (void)target;
+    (void)path;
+    (void)entry_symbol;
+    set_err(err, err_cap, "llvm backend executable linking is unsupported on this platform");
+    return -1;
+#else
+    char obj_tpl[] = "/tmp/liric_llvm_obj_XXXXXX";
+    int obj_fd = -1;
+    lr_module_t *work = NULL;
+    int rc = -1;
+
+    if (!err_cap)
+        err_cap = LR_LLVM_ERRBUF_DEFAULT;
+    if (err && err_cap)
+        err[0] = '\0';
+
+    if (!m || !path || !target) {
+        set_err(err, err_cap, "invalid executable emission inputs");
+        return -1;
+    }
+
+    work = clone_module(m, err, err_cap);
+    if (!work)
+        return -1;
+    if (merge_runtime_into(work, runtime_ll, runtime_len, err, err_cap) != 0)
+        goto done;
+    if (add_entry_wrapper_if_needed(work, entry_symbol, err, err_cap) != 0)
+        goto done;
+
+    obj_fd = mkstemp(obj_tpl);
+    if (obj_fd < 0) {
+        set_err(err, err_cap, "mkstemp failed for temporary object");
+        goto done;
+    }
+    close(obj_fd);
+    obj_fd = -1;
+
+    if (lr_llvm_emit_object_path(work, target, obj_tpl, err, err_cap) != 0)
+        goto done;
+    if (link_executable_from_object(obj_tpl, path, err, err_cap) != 0)
+        goto done;
+
+    rc = 0;
+
+done:
+    if (obj_fd >= 0)
+        close(obj_fd);
+    unlink(obj_tpl);
+    if (work)
+        lr_module_free(work);
+    return rc;
+#endif
+}
+
+#else
+
+int lr_llvm_backend_is_available(void) {
+    return 0;
+}
+
+int lr_llvm_emit_object_path(lr_module_t *m, const lr_target_t *target,
+                             const char *path, char *err, size_t err_cap) {
+    (void)m;
+    (void)target;
+    (void)path;
+    if (err && err_cap > 0)
+        (void)snprintf(err, err_cap, "real llvm backend is not enabled");
+    return -1;
+}
+
+int lr_llvm_emit_executable_path(lr_module_t *m, const char *runtime_ll,
+                                 size_t runtime_len,
+                                 const lr_target_t *target,
+                                 const char *path,
+                                 const char *entry_symbol,
+                                 char *err, size_t err_cap) {
+    (void)m;
+    (void)runtime_ll;
+    (void)runtime_len;
+    (void)target;
+    (void)path;
+    (void)entry_symbol;
+    if (err && err_cap > 0)
+        (void)snprintf(err, err_cap, "real llvm backend is not enabled");
+    return -1;
+}
+
+#endif

--- a/src/llvm_backend.h
+++ b/src/llvm_backend.h
@@ -1,0 +1,20 @@
+#ifndef LIRIC_LLVM_BACKEND_H
+#define LIRIC_LLVM_BACKEND_H
+
+#include "ir.h"
+#include "target.h"
+#include <stddef.h>
+
+int lr_llvm_backend_is_available(void);
+
+int lr_llvm_emit_object_path(lr_module_t *m, const lr_target_t *target,
+                             const char *path, char *err, size_t err_cap);
+
+int lr_llvm_emit_executable_path(lr_module_t *m, const char *runtime_ll,
+                                 size_t runtime_len,
+                                 const lr_target_t *target,
+                                 const char *path,
+                                 const char *entry_symbol,
+                                 char *err, size_t err_cap);
+
+#endif

--- a/src/llvm_stubs.c
+++ b/src/llvm_stubs.c
@@ -1,3 +1,4 @@
+#if !defined(LIRIC_HAVE_REAL_LLVM_BACKEND) || !LIRIC_HAVE_REAL_LLVM_BACKEND
 void LLVMInitializeAArch64Target(void) {}
 void LLVMInitializeAArch64TargetInfo(void) {}
 void LLVMInitializeAArch64TargetMC(void) {}
@@ -8,3 +9,6 @@ void LLVMInitializeX86TargetInfo(void) {}
 void LLVMInitializeX86TargetMC(void) {}
 void LLVMInitializeX86AsmPrinter(void) {}
 void LLVMInitializeX86AsmParser(void) {}
+#else
+int liric_real_llvm_backend_uses_system_target_init_symbols = 1;
+#endif

--- a/tests/test_llvm_backend_roundtrip.cpp
+++ b/tests/test_llvm_backend_roundtrip.cpp
@@ -1,0 +1,214 @@
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <system_error>
+
+#include <liric/liric_compat.h>
+
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+#include <llvm/Support/CodeGen.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Target/TargetMachine.h>
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST_ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "  FAIL: %s (line %d)\n", msg, __LINE__); \
+        return 1; \
+    } \
+} while (0)
+
+#define TEST_ASSERT_EQ(a, b, msg) do { \
+    long long _a = (long long)(a), _b = (long long)(b); \
+    if (_a != _b) { \
+        std::fprintf(stderr, "  FAIL: %s: got %lld, expected %lld (line %d)\n", \
+                     msg, _a, _b, __LINE__); \
+        return 1; \
+    } \
+} while (0)
+
+#define RUN_TEST(fn) do { \
+    tests_run++; \
+    std::fprintf(stderr, "  %s...", #fn); \
+    if (fn() == 0) { \
+        tests_passed++; \
+        std::fprintf(stderr, " ok\n"); \
+    } else { \
+        tests_failed++; \
+        std::fprintf(stderr, "\n"); \
+    } \
+} while (0)
+
+static std::string make_temp_path(const char *prefix) {
+#if defined(__unix__) || defined(__APPLE__)
+    char path[] = "/tmp/liric_llvm_roundtrip_XXXXXX";
+    int fd = mkstemp(path);
+    if (fd >= 0) {
+        close(fd);
+        unlink(path);
+        std::string out = std::string(path) + "_" + prefix;
+        return out;
+    }
+#endif
+    return std::string("./") + prefix;
+}
+
+static void restore_mode_env(const char *prev) {
+#if defined(_WIN32)
+    if (prev && prev[0]) {
+        (void)_putenv_s("LIRIC_COMPILE_MODE", prev);
+    } else {
+        (void)_putenv_s("LIRIC_COMPILE_MODE", "");
+    }
+#else
+    if (prev && prev[0]) {
+        (void)setenv("LIRIC_COMPILE_MODE", prev, 1);
+    } else {
+        (void)unsetenv("LIRIC_COMPILE_MODE");
+    }
+#endif
+}
+
+static void set_mode_env(const char *value) {
+#if defined(_WIN32)
+    (void)_putenv_s("LIRIC_COMPILE_MODE", value ? value : "");
+#else
+    if (value)
+        (void)setenv("LIRIC_COMPILE_MODE", value, 1);
+    else
+        (void)unsetenv("LIRIC_COMPILE_MODE");
+#endif
+}
+
+static int run_exe_expect(const std::string &path, int expect_rc) {
+#if defined(__unix__) || defined(__APPLE__)
+    pid_t pid = fork();
+    int status = 0;
+    if (pid < 0) {
+        std::fprintf(stderr, "fork failed: %s\n", std::strerror(errno));
+        return 1;
+    }
+    if (pid == 0) {
+        execl(path.c_str(), path.c_str(), (char *)NULL);
+        _exit(127);
+    }
+    if (waitpid(pid, &status, 0) < 0) {
+        std::fprintf(stderr, "waitpid failed: %s\n", std::strerror(errno));
+        return 1;
+    }
+    if (!WIFEXITED(status))
+        return 1;
+    return (WEXITSTATUS(status) == expect_rc) ? 0 : 1;
+#else
+    (void)path;
+    (void)expect_rc;
+    return 0;
+#endif
+}
+
+static void build_main_ret42_module(llvm::Module &mod, llvm::LLVMContext &ctx) {
+    llvm::Type *i32 = llvm::Type::getInt32Ty(ctx);
+    llvm::FunctionType *fty = llvm::FunctionType::get(i32, false);
+    llvm::Function *main_fn = llvm::Function::Create(
+        fty, llvm::GlobalValue::ExternalLinkage, "main", mod);
+    llvm::BasicBlock *entry = llvm::BasicBlock::Create(ctx, "entry", main_fn);
+    llvm::IRBuilder<> b(entry, ctx);
+    b.CreateRet(llvm::ConstantInt::get(i32, 42));
+}
+
+static int test_wrapper_object_emit_mode_llvm(void) {
+    const char *old_mode = std::getenv("LIRIC_COMPILE_MODE");
+    char old_copy[64] = {0};
+    if (old_mode)
+        std::snprintf(old_copy, sizeof(old_copy), "%s", old_mode);
+    set_mode_env("llvm");
+
+    llvm::LLVMContext ctx;
+    llvm::Module mod("roundtrip_obj", ctx);
+    build_main_ret42_module(mod, ctx);
+    std::string obj_path = make_temp_path("obj.o");
+    std::error_code ec;
+    llvm::raw_fd_ostream out(obj_path, ec);
+    TEST_ASSERT(!ec, "open object output");
+
+    llvm::legacy::PassManager pm;
+    llvm::TargetMachine tm;
+    bool cannot_emit = tm.addPassesToEmitFile(pm, out, nullptr,
+                                              llvm::CodeGenFileType::ObjectFile);
+    TEST_ASSERT(!cannot_emit, "target machine accepts object emission");
+    bool ok = pm.run(mod);
+    TEST_ASSERT(ok, "pass manager run");
+    out.flush();
+
+#if defined(__unix__) || defined(__APPLE__)
+    struct stat st;
+    std::memset(&st, 0, sizeof(st));
+    TEST_ASSERT_EQ(stat(obj_path.c_str(), &st), 0, "object stat");
+    TEST_ASSERT(st.st_size > 0, "object non-empty");
+#endif
+
+    std::remove(obj_path.c_str());
+    restore_mode_env(old_copy);
+    return 0;
+}
+
+static int test_wrapper_to_api_executable_roundtrip(void) {
+    const char *old_mode = std::getenv("LIRIC_COMPILE_MODE");
+    char old_copy[64] = {0};
+    if (old_mode)
+        std::snprintf(old_copy, sizeof(old_copy), "%s", old_mode);
+    set_mode_env("llvm");
+
+    llvm::LLVMContext ctx;
+    llvm::Module mod("roundtrip_exe", ctx);
+    build_main_ret42_module(mod, ctx);
+    std::string exe_path = make_temp_path("exe");
+
+    static const char *runtime_ll =
+        "define i32 @__lfortran_rt_dummy() {\n"
+        "entry:\n"
+        "  ret i32 0\n"
+        "}\n";
+    int rc = lc_module_emit_executable(mod.getCompat(), exe_path.c_str(),
+                                       runtime_ll, std::strlen(runtime_ll));
+    TEST_ASSERT_EQ(rc, 0, "compat executable emission");
+
+#if defined(__unix__) || defined(__APPLE__)
+    rc = run_exe_expect(exe_path, 42);
+    TEST_ASSERT_EQ(rc, 0, "emitted executable exits with 42");
+#endif
+
+    std::remove(exe_path.c_str());
+    restore_mode_env(old_copy);
+    return 0;
+}
+
+int main(void) {
+    std::fprintf(stderr, "llvm backend roundtrip tests\n");
+    std::fprintf(stderr, "============================\n\n");
+
+    RUN_TEST(test_wrapper_object_emit_mode_llvm);
+    RUN_TEST(test_wrapper_to_api_executable_roundtrip);
+
+    std::fprintf(stderr, "\nSummary: %d/%d passed, %d failed\n",
+                 tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -181,6 +181,7 @@ int test_session_select(void);
 int test_session_ir_print(void);
 int test_session_ll_compile(void);
 int test_session_multiple_functions(void);
+int test_session_emit_object_llvm_mode_contract(void);
 int test_merge_two_independent_functions(void);
 int test_merge_declaration_replaced_by_definition(void);
 int test_merge_global_definition(void);
@@ -396,6 +397,7 @@ int main(void) {
     RUN_TEST(test_session_ir_print);
     RUN_TEST(test_session_ll_compile);
     RUN_TEST(test_session_multiple_functions);
+    RUN_TEST(test_session_emit_object_llvm_mode_contract);
 
 #if defined(__linux__)
     fprintf(stderr, "\nSession IR exe tests:\n");

--- a/tools/llvm_backend_environment.yml
+++ b/tools/llvm_backend_environment.yml
@@ -1,0 +1,11 @@
+name: liric-llvm-backend
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - cmake>=3.29
+  - ninja
+  - make
+  - c-compiler
+  - cxx-compiler
+  - zlib

--- a/tools/llvm_backend_matrix.sh
+++ b/tools/llvm_backend_matrix.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Run LLVM backend compatibility matrix in isolated temporary directories.
+
+Usage:
+  tools/llvm_backend_matrix.sh [--versions "7 8 ... 21"] [--keep]
+
+Options:
+  --versions LIST   Space-separated LLVM major versions (default: 7..21)
+  --keep            Keep temporary work directory for debugging
+  -h, --help        Show this help
+EOF
+}
+
+versions="7 8 9 10 11 12 13 14 15 16 17 18 19 20 21"
+keep=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --versions)
+      shift
+      versions="${1:-}"
+      ;;
+    --keep)
+      keep=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if ! command -v micromamba >/dev/null 2>&1; then
+  echo "micromamba is required" >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+env_file="${repo_root}/tools/llvm_backend_environment.yml"
+if [[ ! -f "${env_file}" ]]; then
+  echo "Missing environment file: ${env_file}" >&2
+  exit 1
+fi
+
+work_root="$(mktemp -d /tmp/liric_llvm_matrix_XXXXXX)"
+cleanup() {
+  if [[ "${keep}" -eq 0 ]]; then
+    rm -rf "${work_root}"
+  else
+    echo "kept work directory: ${work_root}"
+  fi
+}
+trap cleanup EXIT
+
+echo "work root: ${work_root}"
+
+for ver in ${versions}; do
+  env_prefix="${work_root}/env-${ver}"
+  build_dir="${work_root}/build-${ver}"
+  with_compat="OFF"
+  if [[ "${ver}" -ge 11 ]]; then
+    with_compat="ON"
+  fi
+  echo
+  echo "=== LLVM ${ver} (WITH_LLVM_COMPAT=${with_compat}) ==="
+  micromamba create -y -p "${env_prefix}" -f "${env_file}" "llvmdev=${ver}" >/dev/null
+
+  micromamba run -p "${env_prefix}" bash -lc "
+    set -euo pipefail
+    llvm_config=\$(command -v llvm-config)
+    if [[ -z \"\${llvm_config}\" ]]; then
+      echo 'llvm-config not found in environment' >&2
+      exit 1
+    fi
+    cmake -S '${repo_root}' -B '${build_dir}' -G Ninja \
+      -DWITH_REAL_LLVM_BACKEND=ON \
+      -DWITH_LLVM_COMPAT=${with_compat} \
+      -DWITH_BENCH_TCC=OFF \
+      -DWITH_BENCH_LLI_PHASES=OFF \
+      -DLIRIC_LLVM_CONFIG_EXE=\"\${llvm_config}\"
+    cmake --build '${build_dir}' -j\$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+    ctest --test-dir '${build_dir}' --output-on-failure
+  "
+done
+
+echo
+echo "LLVM backend matrix finished successfully for versions: ${versions}"


### PR DESCRIPTION
## Summary
- implement real LLVM mode-C backend entry points for object/executable emission using LLVM C API
- route session and compat emit paths through mode parser (`LIRIC_COMPILE_MODE`) and backend dispatch
- centralize compile mode parsing in a shared helper module
- make JIT fail-fast for mode `llvm` (no silent fallback)
- avoid stub symbol collision when real backend is enabled
- add llvm-mode contract tests and wrapper roundtrip tests
- add matrix tooling + CI workflow for LLVM `7..21`
- gate LLVM C++ compat tests to LLVM `>=11` when real backend is enabled (backend itself is still validated on `7..21`)

## Testing
- `cmake -S . -B build -G Ninja && cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure`
- `cmake -S . -B build-real-llvm -G Ninja -DWITH_REAL_LLVM_BACKEND=ON -DWITH_LLVM_COMPAT=ON -DWITH_BENCH_TCC=OFF -DWITH_BENCH_LLI_PHASES=OFF -DLIRIC_LLVM_CONFIG_EXE=$(command -v llvm-config) && cmake --build build-real-llvm -j$(nproc) && ctest --test-dir build-real-llvm --output-on-failure`
- `tools/llvm_backend_matrix.sh` (full pass over `7 8 9 10 11 12 13 14 15 16 17 18 19 20 21`)

## Note on LLVM 7-10 compat
When real backend linking pulls in full LLVM C++ static archives, llvmdev `7..10` can collide with header-wrapper C++ symbols at link/runtime in compat tests. For now the PR keeps backend validation across `7..21`, and enables C++ compat/roundtrip tests on `>=11` where they are stable.
