### PR TITLE
fix: Clean up ir.h / liric.h enum clash and duplicated type declarati (fixes #282)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,7 @@ add_executable(test_liric
     tests/test_codegen.c
     tests/test_targets.c
     tests/test_target_shared.c
+    tests/test_header_shared.c
     tests/test_jit.c
     tests/test_e2e.c
     tests/test_bc.c

--- a/include/liric/liric.h
+++ b/include/liric/liric.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <liric/liric_ir_shared.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,30 +40,6 @@ lr_type_t *lr_type_func_new(lr_module_t *m, lr_type_t *ret,
                               lr_type_t **params, uint32_t num_params,
                               bool vararg);
 
-/* ---- Operand descriptors ----------------------------------------------- */
-
-typedef struct lr_operand_desc {
-    int kind;
-    union {
-        uint32_t vreg;
-        int64_t imm_i64;
-        double imm_f64;
-        uint32_t block_id;
-        uint32_t global_id;
-    };
-    lr_type_t *type;
-} lr_operand_desc_t;
-
-enum {
-    LR_OP_KIND_VREG    = 0,
-    LR_OP_KIND_IMM_I64 = 1,
-    LR_OP_KIND_IMM_F64 = 2,
-    LR_OP_KIND_BLOCK   = 3,
-    LR_OP_KIND_GLOBAL  = 4,
-    LR_OP_KIND_NULL    = 5,
-    LR_OP_KIND_UNDEF   = 6,
-};
-
 #define LR_VREG(v, t)    ((lr_operand_desc_t){ .kind = LR_OP_KIND_VREG, .vreg = (v), .type = (t) })
 #define LR_IMM(v, t)     ((lr_operand_desc_t){ .kind = LR_OP_KIND_IMM_I64, .imm_i64 = (v), .type = (t) })
 #define LR_IMM_F(v, t)   ((lr_operand_desc_t){ .kind = LR_OP_KIND_IMM_F64, .imm_f64 = (v), .type = (t) })
@@ -76,14 +53,6 @@ enum {
     LR_CMP_EQ = 0, LR_CMP_NE,
     LR_CMP_SGT, LR_CMP_SGE, LR_CMP_SLT, LR_CMP_SLE,
     LR_CMP_UGT, LR_CMP_UGE, LR_CMP_ULT, LR_CMP_ULE,
-};
-enum {
-    LR_FCMP_FALSE = 0,
-    LR_FCMP_OEQ, LR_FCMP_OGT, LR_FCMP_OGE, LR_FCMP_OLT, LR_FCMP_OLE,
-    LR_FCMP_ONE, LR_FCMP_ORD,
-    LR_FCMP_UEQ, LR_FCMP_UGT, LR_FCMP_UGE, LR_FCMP_ULT, LR_FCMP_ULE,
-    LR_FCMP_UNE, LR_FCMP_UNO,
-    LR_FCMP_TRUE,
 };
 
 /* ---- JIT --------------------------------------------------------------- */

--- a/include/liric/liric_ir_shared.h
+++ b/include/liric/liric_ir_shared.h
@@ -1,0 +1,90 @@
+#ifndef LIRIC_IR_SHARED_H
+#define LIRIC_IR_SHARED_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum lr_opcode {
+    LR_OP_RET,
+    LR_OP_RET_VOID,
+    LR_OP_BR,
+    LR_OP_CONDBR,
+    LR_OP_UNREACHABLE,
+    LR_OP_ADD,
+    LR_OP_SUB,
+    LR_OP_MUL,
+    LR_OP_SDIV,
+    LR_OP_SREM,
+    LR_OP_AND,
+    LR_OP_OR,
+    LR_OP_XOR,
+    LR_OP_SHL,
+    LR_OP_LSHR,
+    LR_OP_ASHR,
+    LR_OP_FADD,
+    LR_OP_FSUB,
+    LR_OP_FMUL,
+    LR_OP_FDIV,
+    LR_OP_FNEG,
+    LR_OP_ICMP,
+    LR_OP_FCMP,
+    LR_OP_ALLOCA,
+    LR_OP_LOAD,
+    LR_OP_STORE,
+    LR_OP_GEP,
+    LR_OP_CALL,
+    LR_OP_PHI,
+    LR_OP_SELECT,
+    LR_OP_SEXT,
+    LR_OP_ZEXT,
+    LR_OP_TRUNC,
+    LR_OP_BITCAST,
+    LR_OP_PTRTOINT,
+    LR_OP_INTTOPTR,
+    LR_OP_SITOFP,
+    LR_OP_UITOFP,
+    LR_OP_FPTOSI,
+    LR_OP_FPTOUI,
+    LR_OP_FPEXT,
+    LR_OP_FPTRUNC,
+    LR_OP_EXTRACTVALUE,
+    LR_OP_INSERTVALUE,
+} lr_opcode_t;
+
+typedef enum lr_fcmp_pred {
+    LR_FCMP_FALSE,
+    LR_FCMP_OEQ, LR_FCMP_OGT, LR_FCMP_OGE, LR_FCMP_OLT, LR_FCMP_OLE, LR_FCMP_ONE, LR_FCMP_ORD,
+    LR_FCMP_UEQ, LR_FCMP_UGT, LR_FCMP_UGE, LR_FCMP_ULT, LR_FCMP_ULE, LR_FCMP_UNE, LR_FCMP_UNO,
+    LR_FCMP_TRUE,
+} lr_fcmp_pred_t;
+
+typedef struct lr_operand_desc {
+    int kind;
+    union {
+        uint32_t vreg;
+        int64_t imm_i64;
+        double imm_f64;
+        uint32_t block_id;
+        uint32_t global_id;
+    };
+    struct lr_type *type;
+} lr_operand_desc_t;
+
+enum {
+    LR_OP_KIND_VREG    = 0,
+    LR_OP_KIND_IMM_I64 = 1,
+    LR_OP_KIND_IMM_F64 = 2,
+    LR_OP_KIND_BLOCK   = 3,
+    LR_OP_KIND_GLOBAL  = 4,
+    LR_OP_KIND_NULL    = 5,
+    LR_OP_KIND_UNDEF   = 6,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/liric/liric_session.h
+++ b/include/liric/liric_session.h
@@ -45,54 +45,9 @@ enum {
     LR_ERR_PARSE,
 };
 
-/* ---- Opcodes (public mirror of internal lr_opcode_t) ------------------- */
+/* ---- Opcodes ------------------------------------------------------------ */
 
-typedef enum lr_op {
-    LR_OP_RET,
-    LR_OP_RET_VOID,
-    LR_OP_BR,
-    LR_OP_CONDBR,
-    LR_OP_UNREACHABLE,
-    LR_OP_ADD,
-    LR_OP_SUB,
-    LR_OP_MUL,
-    LR_OP_SDIV,
-    LR_OP_SREM,
-    LR_OP_AND,
-    LR_OP_OR,
-    LR_OP_XOR,
-    LR_OP_SHL,
-    LR_OP_LSHR,
-    LR_OP_ASHR,
-    LR_OP_FADD,
-    LR_OP_FSUB,
-    LR_OP_FMUL,
-    LR_OP_FDIV,
-    LR_OP_FNEG,
-    LR_OP_ICMP,
-    LR_OP_FCMP,
-    LR_OP_ALLOCA,
-    LR_OP_LOAD,
-    LR_OP_STORE,
-    LR_OP_GEP,
-    LR_OP_CALL,
-    LR_OP_PHI,
-    LR_OP_SELECT,
-    LR_OP_SEXT,
-    LR_OP_ZEXT,
-    LR_OP_TRUNC,
-    LR_OP_BITCAST,
-    LR_OP_PTRTOINT,
-    LR_OP_INTTOPTR,
-    LR_OP_SITOFP,
-    LR_OP_UITOFP,
-    LR_OP_FPTOSI,
-    LR_OP_FPTOUI,
-    LR_OP_FPEXT,
-    LR_OP_FPTRUNC,
-    LR_OP_EXTRACTVALUE,
-    LR_OP_INSERTVALUE,
-} lr_op_t;
+typedef lr_opcode_t lr_op_t;
 
 /* ---- Instruction descriptor -------------------------------------------- */
 

--- a/src/ir.h
+++ b/src/ir.h
@@ -4,6 +4,7 @@
 #include "arena.h"
 #include <stdbool.h>
 #include <stdio.h>
+#include <liric/liric_ir_shared.h>
 
 typedef enum lr_type_kind {
     LR_TYPE_VOID,
@@ -29,65 +30,11 @@ typedef struct lr_type {
     };
 } lr_type_t;
 
-typedef enum lr_opcode {
-    LR_OP_RET,
-    LR_OP_RET_VOID,
-    LR_OP_BR,
-    LR_OP_CONDBR,
-    LR_OP_UNREACHABLE,
-    LR_OP_ADD,
-    LR_OP_SUB,
-    LR_OP_MUL,
-    LR_OP_SDIV,
-    LR_OP_SREM,
-    LR_OP_AND,
-    LR_OP_OR,
-    LR_OP_XOR,
-    LR_OP_SHL,
-    LR_OP_LSHR,
-    LR_OP_ASHR,
-    LR_OP_FADD,
-    LR_OP_FSUB,
-    LR_OP_FMUL,
-    LR_OP_FDIV,
-    LR_OP_FNEG,
-    LR_OP_ICMP,
-    LR_OP_FCMP,
-    LR_OP_ALLOCA,
-    LR_OP_LOAD,
-    LR_OP_STORE,
-    LR_OP_GEP,
-    LR_OP_CALL,
-    LR_OP_PHI,
-    LR_OP_SELECT,
-    LR_OP_SEXT,
-    LR_OP_ZEXT,
-    LR_OP_TRUNC,
-    LR_OP_BITCAST,
-    LR_OP_PTRTOINT,
-    LR_OP_INTTOPTR,
-    LR_OP_SITOFP,
-    LR_OP_UITOFP,
-    LR_OP_FPTOSI,
-    LR_OP_FPTOUI,
-    LR_OP_FPEXT,
-    LR_OP_FPTRUNC,
-    LR_OP_EXTRACTVALUE,
-    LR_OP_INSERTVALUE,
-} lr_opcode_t;
-
 typedef enum lr_icmp_pred {
     LR_ICMP_EQ, LR_ICMP_NE,
     LR_ICMP_SGT, LR_ICMP_SGE, LR_ICMP_SLT, LR_ICMP_SLE,
     LR_ICMP_UGT, LR_ICMP_UGE, LR_ICMP_ULT, LR_ICMP_ULE,
 } lr_icmp_pred_t;
-
-typedef enum lr_fcmp_pred {
-    LR_FCMP_FALSE,
-    LR_FCMP_OEQ, LR_FCMP_OGT, LR_FCMP_OGE, LR_FCMP_OLT, LR_FCMP_OLE, LR_FCMP_ONE, LR_FCMP_ORD,
-    LR_FCMP_UEQ, LR_FCMP_UGT, LR_FCMP_UGE, LR_FCMP_ULT, LR_FCMP_ULE, LR_FCMP_UNE, LR_FCMP_UNO,
-    LR_FCMP_TRUE,
-} lr_fcmp_pred_t;
 
 typedef enum lr_operand_kind {
     LR_VAL_VREG,

--- a/src/liric_compat.c
+++ b/src/liric_compat.c
@@ -11,34 +11,6 @@
 #include <unistd.h>
 #endif
 
-/* Guard: lr_opcode_t (ir.h) must stay in sync with lr_op_t (liric_session.h). */
-_Static_assert(LR_OP_INSERTVALUE == 43,
-               "lr_opcode_t changed: update lr_op_t in liric_session.h");
-
-/* Replicate the public operand descriptor type and kind constants.
-   We cannot include liric.h alongside ir.h due to enum redeclarations. */
-typedef struct lr_operand_desc {
-    int kind;
-    union {
-        uint32_t vreg;
-        int64_t imm_i64;
-        double imm_f64;
-        uint32_t block_id;
-        uint32_t global_id;
-    };
-    lr_type_t *type;
-} lr_operand_desc_t;
-
-enum {
-    LR_OP_KIND_VREG    = 0,
-    LR_OP_KIND_IMM_I64 = 1,
-    LR_OP_KIND_IMM_F64 = 2,
-    LR_OP_KIND_BLOCK   = 3,
-    LR_OP_KIND_GLOBAL  = 4,
-    LR_OP_KIND_NULL    = 5,
-    LR_OP_KIND_UNDEF   = 6,
-};
-
 /* ---- Compat types (must match the public header exactly) ---- */
 
 typedef enum lc_value_kind {

--- a/src/session.c
+++ b/src/session.c
@@ -13,34 +13,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Guard: lr_opcode_t (ir.h) must stay in sync with lr_op_t (liric_session.h).
-   If this fires, a new opcode was added to ir.h without updating the session header. */
-_Static_assert(LR_OP_INSERTVALUE == 43,
-               "lr_opcode_t changed: update lr_op_t in liric_session.h");
-
-/* Replicate public operand descriptor to avoid ir.h/liric.h enum clashes. */
-typedef struct lr_operand_desc {
-    int kind;
-    union {
-        uint32_t vreg;
-        int64_t imm_i64;
-        double imm_f64;
-        uint32_t block_id;
-        uint32_t global_id;
-    };
-    lr_type_t *type;
-} lr_operand_desc_t;
-
-enum {
-    LR_OP_KIND_VREG = 0,
-    LR_OP_KIND_IMM_I64 = 1,
-    LR_OP_KIND_IMM_F64 = 2,
-    LR_OP_KIND_BLOCK = 3,
-    LR_OP_KIND_GLOBAL = 4,
-    LR_OP_KIND_NULL = 5,
-    LR_OP_KIND_UNDEF = 6,
-};
-
 /* Session mode mirrors the public lr_session_mode_t. */
 typedef enum session_mode {
     SESSION_MODE_DIRECT = 0,

--- a/tests/test_header_shared.c
+++ b/tests/test_header_shared.c
@@ -1,0 +1,42 @@
+#include "../src/ir.h"
+#include <liric/liric.h>
+#include <liric/liric_session.h>
+#include <stdio.h>
+
+#define TEST_ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "  FAIL: %s (line %d)\n", msg, __LINE__); \
+        return 1; \
+    } \
+} while (0)
+
+#define TEST_ASSERT_EQ(a, b, msg) do { \
+    long long _a = (long long)(a), _b = (long long)(b); \
+    if (_a != _b) { \
+        fprintf(stderr, "  FAIL: %s: got %lld, expected %lld (line %d)\n", \
+                msg, _a, _b, __LINE__); \
+        return 1; \
+    } \
+} while (0)
+
+int test_headers_share_opcode_and_operand_types(void) {
+    lr_operand_desc_t lhs = LR_VREG(7, NULL);
+    lr_operand_desc_t rhs = LR_IMM(9, NULL);
+    lr_operand_desc_t ops[2] = { lhs, rhs };
+    lr_inst_desc_t inst = {0};
+    lr_op_t public_op = LR_OP_ADD;
+    lr_opcode_t internal_op = (lr_opcode_t)public_op;
+    lr_fcmp_pred_t pred = LR_FCMP_UEQ;
+
+    inst.op = public_op;
+    inst.operands = ops;
+    inst.num_operands = 2;
+
+    TEST_ASSERT_EQ(lhs.kind, LR_OP_KIND_VREG, "LR_VREG sets operand kind");
+    TEST_ASSERT_EQ(rhs.kind, LR_OP_KIND_IMM_I64, "LR_IMM sets operand kind");
+    TEST_ASSERT_EQ(inst.op, LR_OP_ADD, "session instruction uses shared opcode enum");
+    TEST_ASSERT_EQ(internal_op, LR_OP_ADD, "public lr_op_t aliases internal opcode enum");
+    TEST_ASSERT(pred == LR_FCMP_UEQ, "floating predicate enum is shared");
+
+    return 0;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -86,6 +86,7 @@ int test_target_shared_prescan_filters_dynamic_alloca(void);
 int test_ir_finalize_builds_dense_arrays(void);
 int test_ir_inst_create_packs_operands_in_single_allocation(void);
 int test_ir_phi_copies_flat_arrays_preserve_emission_order(void);
+int test_headers_share_opcode_and_operand_types(void);
 int test_jit_add_symbol_updates_cached_lookup(void);
 int test_jit_ret_42(void);
 int test_jit_lazy_repeated_lookup_returns_ready_symbol(void);
@@ -287,6 +288,7 @@ int main(void) {
     RUN_TEST(test_ir_finalize_builds_dense_arrays);
     RUN_TEST(test_ir_inst_create_packs_operands_in_single_allocation);
     RUN_TEST(test_ir_phi_copies_flat_arrays_preserve_emission_order);
+    RUN_TEST(test_headers_share_opcode_and_operand_types);
 
     fprintf(stderr, "\nJIT tests:\n");
     RUN_TEST(test_jit_add_symbol_updates_cached_lookup);


### PR DESCRIPTION
## Summary
- Introduce a shared public IR descriptor header at `include/liric/liric_ir_shared.h` for `lr_opcode_t`, `lr_fcmp_pred_t`, and `lr_operand_desc_t`.
- Remove duplicated local `lr_operand_desc_t` and `LR_OP_KIND_*` definitions from `src/session.c` and `src/liric_compat.c`.
- Eliminate duplicated opcode enum in `include/liric/liric_session.h` by aliasing `lr_op_t` to shared `lr_opcode_t`.
- Update internal/public headers to consume the shared definitions (`src/ir.h`, `include/liric/liric.h`) and remove brittle opcode sync guards.
- Add regression coverage in `tests/test_header_shared.c` to validate shared enum/type use across internal and public headers.

## Verification
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`

Output excerpt:
- `100% tests passed, 0 tests failed out of 26`
- `Total Test time (real) =   1.38 sec`

Artifacts:
- `/tmp/test.log`
