### PR TITLE
fix: Dynamic parser limits instead of hardcoded caps (fixes #283)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -62,6 +62,10 @@ int test_parser_boolean_literals(void);
 int test_parser_named_params_no_collision(void);
 int test_parser_unnamed_params_numeric_alias(void);
 int test_parser_high_numeric_vregs(void);
+int test_parser_dynamic_vreg_map_growth(void);
+int test_parser_dynamic_block_map_growth(void);
+int test_parser_dynamic_global_map_growth(void);
+int test_parser_dynamic_func_map_growth(void);
 int test_parser_cast_expr_in_aggregate_init(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
@@ -262,6 +266,10 @@ int main(void) {
     RUN_TEST(test_parser_named_params_no_collision);
     RUN_TEST(test_parser_unnamed_params_numeric_alias);
     RUN_TEST(test_parser_high_numeric_vregs);
+    RUN_TEST(test_parser_dynamic_vreg_map_growth);
+    RUN_TEST(test_parser_dynamic_block_map_growth);
+    RUN_TEST(test_parser_dynamic_global_map_growth);
+    RUN_TEST(test_parser_dynamic_func_map_growth);
     RUN_TEST(test_parser_cast_expr_in_aggregate_init);
 
     fprintf(stderr, "\nCodegen tests:\n");


### PR DESCRIPTION
## Summary
- replace fixed-size parser-side maps in `src/ll_parser.c` with dynamically growing heap buffers (vregs, blocks, globals, funcs, and type map)
- add dynamic index rehashing for open-addressed symbol lookups, keeping lookup behavior but removing hard caps
- initialize/clear parser work buffers explicitly per parse/function and free them on exit
- add parser stress tests that exceed previous hardcoded thresholds for vregs/blocks/globals/functions

## Verification
- `cmake --build build -j$(nproc) 2>&1 | tee /tmp/test.log`
- `ctest --test-dir build --output-on-failure 2>&1 | tee -a /tmp/test.log`
- `rg -n "(FAILED|FAIL:|error:|Assertion|segmentation fault)" /tmp/test.log || true`

Output excerpts:
- `100% tests passed, 0 tests failed out of 27`
- error scan produced no matches

Artifacts:
- `/tmp/test.log`
