### PR TITLE
fix: Reduce ISel to 2 passes (TPDE-style single analysis + codegen) (fixes #293)

### DIFF
--- a/src/target_aarch64.c
+++ b/src/target_aarch64.c
@@ -81,40 +81,6 @@ static void set_cached_reg_vreg_a64(a64_compile_ctx_t *ctx, uint8_t reg, uint32_
     if (reg == A64_X10) ctx->x10_holds_vreg = vreg;
 }
 
-static void count_vreg_use(uint32_t *counts, uint32_t num_counts,
-                           const lr_operand_t *op) {
-    if (!counts || !op || op->kind != LR_VAL_VREG)
-        return;
-    if (op->vreg < num_counts)
-        counts[op->vreg]++;
-}
-
-static uint32_t *build_vreg_use_counts(lr_arena_t *arena, lr_func_t *func,
-                                       lr_block_phi_copies_t *phi_copies) {
-    if (!arena || !func || func->next_vreg == 0)
-        return NULL;
-
-    uint32_t *counts = lr_arena_array(arena, uint32_t, func->next_vreg);
-    for (uint32_t i = 0; i < func->next_vreg; i++)
-        counts[i] = 0;
-
-    for (uint32_t ii = 0; ii < func->num_linear_insts; ii++) {
-        lr_inst_t *inst = func->linear_inst_array[ii];
-        for (uint32_t oi = 0; oi < inst->num_operands; oi++)
-            count_vreg_use(counts, func->next_vreg, &inst->operands[oi]);
-    }
-
-    if (phi_copies) {
-        for (uint32_t bi = 0; bi < func->num_blocks; bi++) {
-            for (uint32_t ci = 0; ci < phi_copies[bi].count; ci++)
-                count_vreg_use(counts, func->next_vreg,
-                               &phi_copies[bi].copies[ci].src_op);
-        }
-    }
-
-    return counts;
-}
-
 static bool inst_produces_elidable_x9_value(const lr_inst_t *inst) {
     if (!inst)
         return false;
@@ -924,12 +890,8 @@ static int32_t ensure_static_alloca_offset_cb(void *ctx, const lr_inst_t *inst) 
     return ensure_static_alloca_offset((a64_compile_ctx_t *)ctx, inst);
 }
 
-static void reserve_phi_dest_slots(a64_compile_ctx_t *ctx, lr_block_phi_copies_t *phi_copies,
-                                   uint32_t num_blocks) {
-    for (uint32_t bi = 0; bi < num_blocks; bi++) {
-        for (uint32_t ci = 0; ci < phi_copies[bi].count; ci++)
-            alloc_slot(ctx, phi_copies[bi].copies[ci].dest_vreg, 8);
-    }
+static void reserve_phi_dest_slot_cb(void *ctx, uint32_t dest_vreg) {
+    (void)alloc_slot((a64_compile_ctx_t *)ctx, dest_vreg, 8);
 }
 
 static size_t emit_prologue_a64(a64_compile_ctx_t *ctx) {
@@ -962,6 +924,7 @@ static int aarch64_compile_func(lr_func_t *func, lr_module_t *mod,
                                  uint8_t *buf, size_t buflen, size_t *out_len,
                                  lr_arena_t *arena) {
     lr_arena_t *layout_arena = (mod && mod->arena) ? mod->arena : arena;
+    lr_target_func_analysis_t analysis;
 
     uint32_t nb = func->num_blocks > 0 ? func->num_blocks : 1;
     uint32_t fc = nb * 2;
@@ -999,11 +962,13 @@ static int aarch64_compile_func(lr_func_t *func, lr_module_t *mod,
     lr_block_phi_copies_t *phi_copies = lr_build_phi_copies(ctx.arena, func);
     if (!phi_copies)
         return -1;
-    ctx.vreg_use_counts = build_vreg_use_counts(ctx.arena, func, phi_copies);
-    ctx.num_vreg_use_counts = func->next_vreg;
-    reserve_phi_dest_slots(&ctx, phi_copies, nb);
-    lr_target_prescan_static_alloca_offsets(func, layout_arena, &ctx,
-                                            ensure_static_alloca_offset_cb);
+    if (lr_target_analyze_function(func, layout_arena, phi_copies,
+                                   &ctx, ensure_static_alloca_offset_cb,
+                                   &ctx, reserve_phi_dest_slot_cb,
+                                   &analysis) != 0)
+        return -1;
+    ctx.vreg_use_counts = analysis.vreg_use_counts;
+    ctx.num_vreg_use_counts = analysis.num_vregs;
 
     size_t prologue_stack_patch_pos = emit_prologue_a64(&ctx);
 

--- a/src/target_shared.c
+++ b/src/target_shared.c
@@ -2,6 +2,17 @@
 #include "target_common.h"
 #include <string.h>
 
+static void lr_target_count_vreg_use(uint32_t *counts,
+                                     uint32_t num_counts,
+                                     const lr_operand_t *op) {
+    if (!counts || !op || op->kind != LR_VAL_VREG) {
+        return;
+    }
+    if (op->vreg < num_counts) {
+        counts[op->vreg]++;
+    }
+}
+
 int32_t lr_target_lookup_static_alloca_offset(const int32_t *offsets,
                                               uint32_t num_offsets,
                                               uint32_t vreg) {
@@ -66,4 +77,69 @@ void lr_target_prescan_static_alloca_offsets(lr_func_t *func,
         }
         (void)ensure(ctx, inst);
     }
+}
+
+int lr_target_analyze_function(lr_func_t *func,
+                               lr_arena_t *arena,
+                               lr_block_phi_copies_t *phi_copies,
+                               void *alloca_ctx,
+                               lr_target_static_alloca_ensure_fn ensure_static_alloca,
+                               void *phi_ctx,
+                               lr_target_phi_dest_slot_fn reserve_phi_dest_slot,
+                               lr_target_func_analysis_t *out) {
+    uint32_t num_vregs;
+
+    if (!func || !arena || !out) {
+        return -1;
+    }
+
+    memset(out, 0, sizeof(*out));
+
+    if (!lr_func_is_finalized(func) && lr_func_finalize(func, arena) != 0) {
+        return -1;
+    }
+
+    num_vregs = func->next_vreg;
+    out->num_vregs = num_vregs;
+    if (num_vregs > 0) {
+        out->vreg_use_counts = lr_arena_array(arena, uint32_t, num_vregs);
+        for (uint32_t i = 0; i < num_vregs; i++) {
+            out->vreg_use_counts[i] = 0;
+        }
+    }
+
+    for (uint32_t ii = 0; ii < func->num_linear_insts; ii++) {
+        const lr_inst_t *inst = func->linear_inst_array[ii];
+        if (inst->op == LR_OP_CALL) {
+            out->has_calls = true;
+        }
+        for (uint32_t oi = 0; oi < inst->num_operands; oi++) {
+            lr_target_count_vreg_use(out->vreg_use_counts, num_vregs,
+                                     &inst->operands[oi]);
+        }
+        if (inst->op == LR_OP_ALLOCA && lr_target_alloca_uses_static_storage(inst)) {
+            if (ensure_static_alloca) {
+                (void)ensure_static_alloca(alloca_ctx, inst);
+            }
+            out->num_static_allocas++;
+        }
+    }
+
+    if (!phi_copies) {
+        return 0;
+    }
+
+    for (uint32_t bi = 0; bi < func->num_blocks; bi++) {
+        for (uint32_t ci = 0; ci < phi_copies[bi].count; ci++) {
+            const lr_phi_copy_t *copy = &phi_copies[bi].copies[ci];
+            lr_target_count_vreg_use(out->vreg_use_counts, num_vregs,
+                                     &copy->src_op);
+            if (reserve_phi_dest_slot) {
+                reserve_phi_dest_slot(phi_ctx, copy->dest_vreg);
+            }
+            out->num_phi_copies++;
+        }
+    }
+
+    return 0;
 }

--- a/src/target_shared.h
+++ b/src/target_shared.h
@@ -5,6 +5,15 @@
 
 typedef int32_t (*lr_target_static_alloca_ensure_fn)(void *ctx,
                                                       const lr_inst_t *inst);
+typedef void (*lr_target_phi_dest_slot_fn)(void *ctx, uint32_t dest_vreg);
+
+typedef struct lr_target_func_analysis {
+    uint32_t num_vregs;
+    uint32_t *vreg_use_counts;
+    uint32_t num_static_allocas;
+    uint32_t num_phi_copies;
+    bool has_calls;
+} lr_target_func_analysis_t;
 
 int32_t lr_target_lookup_static_alloca_offset(const int32_t *offsets,
                                               uint32_t num_offsets,
@@ -18,5 +27,13 @@ void lr_target_prescan_static_alloca_offsets(lr_func_t *func,
                                              lr_arena_t *arena,
                                              void *ctx,
                                              lr_target_static_alloca_ensure_fn ensure);
+int lr_target_analyze_function(lr_func_t *func,
+                               lr_arena_t *arena,
+                               lr_block_phi_copies_t *phi_copies,
+                               void *alloca_ctx,
+                               lr_target_static_alloca_ensure_fn ensure_static_alloca,
+                               void *phi_ctx,
+                               lr_target_phi_dest_slot_fn reserve_phi_dest_slot,
+                               lr_target_func_analysis_t *out);
 
 #endif

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -87,6 +87,8 @@ int test_parse_auto_selects_bc_frontend(void);
 int test_symbol_provider_prefers_jit_table(void);
 int test_target_shared_static_alloca_table(void);
 int test_target_shared_prescan_filters_dynamic_alloca(void);
+int test_target_shared_analyze_function_merges_prescans(void);
+int test_target_shared_analyze_function_handles_empty(void);
 int test_ir_finalize_builds_dense_arrays(void);
 int test_ir_finalize_peephole_constant_identity_and_branch(void);
 int test_ir_finalize_redundant_load_elimination(void);
@@ -298,6 +300,8 @@ int main(void) {
     RUN_TEST(test_symbol_provider_prefers_jit_table);
     RUN_TEST(test_target_shared_static_alloca_table);
     RUN_TEST(test_target_shared_prescan_filters_dynamic_alloca);
+    RUN_TEST(test_target_shared_analyze_function_merges_prescans);
+    RUN_TEST(test_target_shared_analyze_function_handles_empty);
     RUN_TEST(test_ir_finalize_builds_dense_arrays);
     RUN_TEST(test_ir_finalize_peephole_constant_identity_and_branch);
     RUN_TEST(test_ir_finalize_redundant_load_elimination);

--- a/tests/test_target_shared.c
+++ b/tests/test_target_shared.c
@@ -24,6 +24,11 @@ typedef struct {
     uint32_t dests[8];
 } prescan_capture_t;
 
+typedef struct {
+    uint32_t count;
+    uint32_t vregs[16];
+} slot_capture_t;
+
 static int32_t capture_static_alloca(void *ctx, const lr_inst_t *inst) {
     prescan_capture_t *capture = (prescan_capture_t *)ctx;
     if (capture->count < 8) {
@@ -31,6 +36,14 @@ static int32_t capture_static_alloca(void *ctx, const lr_inst_t *inst) {
     }
     capture->count++;
     return -(int32_t)capture->count;
+}
+
+static void capture_phi_slot(void *ctx, uint32_t dest_vreg) {
+    slot_capture_t *capture = (slot_capture_t *)ctx;
+    if (capture->count < 16) {
+        capture->vregs[capture->count] = dest_vreg;
+    }
+    capture->count++;
 }
 
 static uint32_t count_block_opcode(const lr_block_t *block, lr_opcode_t op) {
@@ -106,6 +119,149 @@ int test_target_shared_prescan_filters_dynamic_alloca(void) {
     TEST_ASSERT_EQ(capture.dests[0], static_dest0, "first static alloca visited");
     TEST_ASSERT_EQ(capture.dests[1], static_dest1, "second static alloca visited");
     TEST_ASSERT_EQ(capture.dests[2], static_dest2, "third static alloca visited");
+
+    lr_arena_destroy(arena);
+    return 0;
+}
+
+int test_target_shared_analyze_function_merges_prescans(void) {
+    lr_arena_t *arena = lr_arena_create(0);
+    lr_module_t *mod = lr_module_create(arena);
+    lr_type_t *params[2] = { mod->type_i1, mod->type_i64 };
+    lr_func_t *callee = lr_func_declare(mod, "callee", mod->type_i64, NULL, 0, false);
+    uint32_t callee_sym = lr_module_intern_symbol(mod, "callee");
+    lr_func_t *func = lr_func_create(mod, "analyze", mod->type_i64, params, 2, false);
+    lr_block_t *entry = lr_block_create(func, arena, "entry");
+    lr_block_t *left = lr_block_create(func, arena, "left");
+    lr_block_t *right = lr_block_create(func, arena, "right");
+    lr_block_t *merge = lr_block_create(func, arena, "merge");
+    prescan_capture_t alloca_capture = {0};
+    slot_capture_t phi_slot_capture = {0};
+    lr_target_func_analysis_t analysis;
+
+    uint32_t static_alloca_dest = lr_vreg_new(func);
+    uint32_t dynamic_alloca_dest = lr_vreg_new(func);
+    uint32_t left_value_dest = lr_vreg_new(func);
+    uint32_t call_value_dest = lr_vreg_new(func);
+    uint32_t phi_dest = lr_vreg_new(func);
+    uint32_t sum_dest = lr_vreg_new(func);
+
+    lr_operand_t dyn_alloca_ops[1] = {
+        lr_op_vreg(func->param_vregs[1], mod->type_i64),
+    };
+    lr_operand_t condbr_ops[3] = {
+        lr_op_vreg(func->param_vregs[0], mod->type_i1),
+        lr_op_block(left->id),
+        lr_op_block(right->id),
+    };
+    lr_operand_t left_add_ops[2] = {
+        lr_op_vreg(func->param_vregs[1], mod->type_i64),
+        lr_op_imm_i64(3, mod->type_i64),
+    };
+    lr_operand_t right_call_ops[1] = {
+        lr_op_global(callee_sym, callee->type),
+    };
+    lr_operand_t br_merge_ops[1] = { lr_op_block(merge->id) };
+    lr_operand_t phi_ops[4] = {
+        lr_op_vreg(left_value_dest, mod->type_i64),
+        lr_op_block(left->id),
+        lr_op_vreg(call_value_dest, mod->type_i64),
+        lr_op_block(right->id),
+    };
+    lr_operand_t sum_ops[2] = {
+        lr_op_vreg(phi_dest, mod->type_i64),
+        lr_op_vreg(func->param_vregs[1], mod->type_i64),
+    };
+    lr_operand_t ret_ops[1] = {
+        lr_op_vreg(sum_dest, mod->type_i64),
+    };
+
+    lr_block_append(entry, lr_inst_create(arena, LR_OP_ALLOCA, mod->type_i64,
+                                          static_alloca_dest, NULL, 0));
+    lr_block_append(entry, lr_inst_create(arena, LR_OP_ALLOCA, mod->type_i64,
+                                          dynamic_alloca_dest, dyn_alloca_ops, 1));
+    lr_block_append(entry, lr_inst_create(arena, LR_OP_CONDBR, mod->type_void, 0,
+                                          condbr_ops, 3));
+
+    lr_block_append(left, lr_inst_create(arena, LR_OP_ADD, mod->type_i64,
+                                         left_value_dest, left_add_ops, 2));
+    lr_block_append(left, lr_inst_create(arena, LR_OP_BR, mod->type_void, 0,
+                                         br_merge_ops, 1));
+
+    lr_block_append(right, lr_inst_create(arena, LR_OP_CALL, mod->type_i64,
+                                          call_value_dest, right_call_ops, 1));
+    lr_block_append(right, lr_inst_create(arena, LR_OP_BR, mod->type_void, 0,
+                                          br_merge_ops, 1));
+
+    lr_block_append(merge, lr_inst_create(arena, LR_OP_PHI, mod->type_i64,
+                                          phi_dest, phi_ops, 4));
+    lr_block_append(merge, lr_inst_create(arena, LR_OP_ADD, mod->type_i64,
+                                          sum_dest, sum_ops, 2));
+    lr_block_append(merge, lr_inst_create(arena, LR_OP_RET, mod->type_i64, 0,
+                                          ret_ops, 1));
+
+    {
+        lr_block_phi_copies_t *phi_copies = lr_build_phi_copies(arena, func);
+        TEST_ASSERT(phi_copies != NULL, "phi copies build for analysis test");
+        TEST_ASSERT_EQ(lr_target_analyze_function(func, arena, phi_copies,
+                                                  &alloca_capture, capture_static_alloca,
+                                                  &phi_slot_capture, capture_phi_slot,
+                                                  &analysis),
+                       0, "analysis succeeds");
+    }
+
+    TEST_ASSERT(analysis.vreg_use_counts != NULL, "analysis returns vreg use table");
+    TEST_ASSERT_EQ(analysis.num_vregs, func->next_vreg, "analysis tracks vreg count");
+    TEST_ASSERT(analysis.has_calls, "analysis detects call instructions");
+    TEST_ASSERT_EQ(analysis.num_static_allocas, 1, "only static allocas counted");
+    TEST_ASSERT_EQ(analysis.num_phi_copies, 2, "phi copies counted per predecessor");
+    TEST_ASSERT_EQ(alloca_capture.count, 1, "static alloca callback called once");
+    TEST_ASSERT_EQ(alloca_capture.dests[0], static_alloca_dest,
+                   "static alloca callback receives static destination");
+    TEST_ASSERT_EQ(phi_slot_capture.count, 2, "phi slot callback called for each copy");
+    TEST_ASSERT_EQ(phi_slot_capture.vregs[0], phi_dest,
+                   "first phi slot callback destination matches phi");
+    TEST_ASSERT_EQ(phi_slot_capture.vregs[1], phi_dest,
+                   "second phi slot callback destination matches phi");
+    TEST_ASSERT_EQ(analysis.vreg_use_counts[func->param_vregs[0]], 1,
+                   "condition parameter has one use");
+    TEST_ASSERT_EQ(analysis.vreg_use_counts[func->param_vregs[1]], 3,
+                   "dynamic alloca and arithmetic uses are counted");
+    TEST_ASSERT_EQ(analysis.vreg_use_counts[left_value_dest], 2,
+                   "left value counted in phi and phi copy");
+    TEST_ASSERT_EQ(analysis.vreg_use_counts[call_value_dest], 2,
+                   "call result counted in phi and phi copy");
+    TEST_ASSERT_EQ(analysis.vreg_use_counts[phi_dest], 1,
+                   "phi destination used by add");
+    TEST_ASSERT_EQ(analysis.vreg_use_counts[sum_dest], 1,
+                   "sum destination used by return");
+
+    lr_arena_destroy(arena);
+    return 0;
+}
+
+int test_target_shared_analyze_function_handles_empty(void) {
+    lr_arena_t *arena = lr_arena_create(0);
+    lr_module_t *mod = lr_module_create(arena);
+    lr_func_t *func = lr_func_create(mod, "empty", mod->type_void, NULL, 0, false);
+    lr_block_t *entry = lr_block_create(func, arena, "entry");
+    lr_target_func_analysis_t analysis;
+
+    lr_block_append(entry, lr_inst_create(arena, LR_OP_RET_VOID, mod->type_void, 0, NULL, 0));
+
+    {
+        lr_block_phi_copies_t *phi_copies = lr_build_phi_copies(arena, func);
+        TEST_ASSERT(phi_copies != NULL, "phi copies build for empty function");
+        TEST_ASSERT_EQ(lr_target_analyze_function(func, arena, phi_copies,
+                                                  NULL, NULL, NULL, NULL, &analysis),
+                       0, "empty analysis succeeds");
+    }
+
+    TEST_ASSERT_EQ(analysis.num_vregs, 0, "empty function has no vregs");
+    TEST_ASSERT(analysis.vreg_use_counts == NULL, "empty function has no use table");
+    TEST_ASSERT(!analysis.has_calls, "empty function has no calls");
+    TEST_ASSERT_EQ(analysis.num_static_allocas, 0, "empty function has no allocas");
+    TEST_ASSERT_EQ(analysis.num_phi_copies, 0, "empty function has no phi copies");
 
     lr_arena_destroy(arena);
     return 0;


### PR DESCRIPTION
## Summary
- add `lr_target_analyze_function()` in `src/target_shared.c` and expose it in `src/target_shared.h` to merge vreg-use counting, static alloca prescan, PHI-destination slot reservation callbacks, and call detection into one shared analysis pass
- switch both backends (`src/target_x86_64.c`, `src/target_aarch64.c`) to consume the shared analysis result and remove duplicated backend-local pre-scan helpers
- add focused tests in `tests/test_target_shared.c` and register them in `tests/test_main.c`

## Verification
- `cmake --build build -j$(nproc)`
  - build succeeds
- `ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
  - initial run exposed one failing assertion in the newly added analysis test
- adjusted test expectation to match existing PHI counting semantics (PHI sources counted in both PHI operands and PHI-copy sources)
- `ctest --test-dir build --output-on-failure -R '^liric_tests$' 2>&1 | tee /tmp/test_rerun.log`
  - `1/1 Test #1: liric_tests ... Passed`
- `grep -nE "FAIL:|\*\*\*Failed|Errors while running" /tmp/test_rerun.log || true`
  - no matches

Artifacts:
- `/tmp/test.log`
- `/tmp/test_rerun.log`
