### PR TITLE
fix: Move non-trivial logic from C++ compat headers to C layer (fixes #279)

### DIFF
--- a/include/liric/liric_compat.h
+++ b/include/liric/liric_compat.h
@@ -145,6 +145,25 @@ bool lc_type_struct_has_name(lr_type_t *ty);
 lc_value_t *lc_global_lookup_or_create(lc_module_compat_t *mod,
                                         const char *name, lr_type_t *type);
 
+/* ---- Compat utility helpers ---- */
+const char *lc_intrinsic_name(unsigned intrinsic_id);
+bool lc_is_lfortran_jit_wrapper_ir(const char *asm_text, size_t len);
+lr_module_t *lc_build_lfortran_jit_wrapper_module(char *err, size_t errlen);
+size_t lc_format_i64(char *buf, size_t buf_size, int64_t value);
+size_t lc_format_u64(char *buf, size_t buf_size, uint64_t value);
+size_t lc_format_f64(char *buf, size_t buf_size, double value);
+size_t lc_format_ptr(char *buf, size_t buf_size, const void *ptr);
+bool lc_pack_constant_bytes(lc_value_t *value, lr_type_t *ty,
+                             uint8_t *out, size_t out_size);
+lc_value_t *lc_const_struct_from_values(lc_module_compat_t *mod,
+                                         lr_type_t *struct_ty,
+                                         lc_value_t **values,
+                                         uint32_t num_values);
+lc_value_t *lc_const_array_from_values(lc_module_compat_t *mod,
+                                        lr_type_t *array_ty,
+                                        lc_value_t **values,
+                                        uint32_t num_values);
+
 /* ---- Function ---- */
 lc_value_t *lc_func_create(lc_module_compat_t *mod, const char *name,
                             lr_type_t *func_type);

--- a/include/llvm/AsmParser/Parser.h
+++ b/include/llvm/AsmParser/Parser.h
@@ -4,88 +4,23 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
-#include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/SourceMgr.h"
 #include <memory>
 #include <string>
 #include <fstream>
-#include <vector>
 
 namespace llvm {
 
 inline bool is_lfortran_jit_wrapper_ir(StringRef AsmString) {
-    const std::string s = AsmString.str();
-    return s.find("declare i32 @main(i32, i8**)\n") != std::string::npos &&
-           s.find("define i32 @__lfortran_jit_entry(i32 %argc, i8** %argv)") != std::string::npos &&
-           s.find("call i32 @main(i32 %argc, i8** %argv)") != std::string::npos &&
-           s.find("ret i32 %ret") != std::string::npos;
+    return lc_is_lfortran_jit_wrapper_ir(AsmString.data(), AsmString.size());
 }
 
-inline std::unique_ptr<Module> build_lfortran_jit_wrapper_module(
-    LLVMContext &Context, SMDiagnostic &Err) {
-    std::unique_ptr<Module> M = std::make_unique<Module>("asm", Context);
-    Type *i32 = Type::getInt32Ty(Context);
-    Type *i8_ptr = Type::getInt8PtrTy(Context);
-    Type *argv_ty = PointerType::getUnqual(i8_ptr);
-    Type *params[] = { i32, argv_ty };
-    FunctionType *fty = FunctionType::get(i32, params, false);
-    if (!fty) {
-        Err = SMDiagnostic("failed to create wrapper function type");
-        return nullptr;
-    }
-
-    Function *main_decl = Function::Create(
-        fty, GlobalValue::ExternalLinkage, "main", *M);
-    Function *entry_fn = Function::Create(
-        fty, GlobalValue::ExternalLinkage, "__lfortran_jit_entry", *M);
-    if (!main_decl || !entry_fn) {
-        Err = SMDiagnostic("failed to create wrapper functions");
-        return nullptr;
-    }
-
-    BasicBlock *entry = BasicBlock::Create(Context, "entry", entry_fn);
-    if (!entry) {
-        Err = SMDiagnostic("failed to create wrapper entry block");
-        return nullptr;
-    }
-
-    std::vector<Value *> call_args;
-    call_args.reserve(entry_fn->arg_size());
-    for (auto it = entry_fn->arg_begin(); it != entry_fn->arg_end(); ++it) {
-        call_args.push_back(&(*it));
-    }
-
-    IRBuilder<> builder(entry, Context);
-    Value *ret = builder.CreateCall(main_decl, call_args, "ret");
-    if (!ret) {
-        Err = SMDiagnostic("failed to create wrapper call");
-        return nullptr;
-    }
-    builder.CreateRet(ret);
-
-    return M;
-}
-
-inline std::unique_ptr<Module> parseAssemblyString(
-    StringRef AsmString, SMDiagnostic &Err, LLVMContext &Context) {
-    if (is_lfortran_jit_wrapper_ir(AsmString)) {
-        std::unique_ptr<Module> M =
-            build_lfortran_jit_wrapper_module(Context, Err);
-        if (!M) return nullptr;
-        lc_module_compat_t *compat = M->getCompat();
-        Module::setCurrentModule(compat);
-        return M;
-    }
-
-    char parse_err[512] = {0};
-    lr_module_t *parsed = lr_parse_ll(AsmString.data(), AsmString.size(),
-                                      parse_err, sizeof(parse_err));
+inline std::unique_ptr<Module> attach_parsed_module(
+    lr_module_t *parsed, SMDiagnostic &Err, LLVMContext &Context) {
     if (!parsed) {
-        Err = SMDiagnostic(parse_err[0] ? parse_err
-                                        : "parseAssemblyString failed in liric");
+        Err = SMDiagnostic("parseAssemblyString failed in liric");
         return nullptr;
     }
-
     std::unique_ptr<Module> M = std::make_unique<Module>("asm", Context);
     lc_module_compat_t *compat = M->getCompat();
     if (!compat) {
@@ -93,14 +28,45 @@ inline std::unique_ptr<Module> parseAssemblyString(
         Err = SMDiagnostic("failed to create compat module wrapper");
         return nullptr;
     }
-
-    if (compat->mod) {
+    if (compat->mod)
         lr_module_free(compat->mod);
-    }
     compat->mod = parsed;
-    if (compat->ctx) compat->ctx->mod = parsed;
+    if (compat->ctx)
+        compat->ctx->mod = parsed;
     Module::setCurrentModule(compat);
     return M;
+}
+
+inline std::unique_ptr<Module> build_lfortran_jit_wrapper_module(
+    LLVMContext &Context, SMDiagnostic &Err) {
+    char parse_err[512] = {0};
+    lr_module_t *parsed = lc_build_lfortran_jit_wrapper_module(
+        parse_err, sizeof(parse_err));
+    if (!parsed) {
+        Err = SMDiagnostic(parse_err[0] ? parse_err
+                                        : "failed to build wrapper module");
+        return nullptr;
+    }
+    return attach_parsed_module(parsed, Err, Context);
+}
+
+inline std::unique_ptr<Module> parseAssemblyString(
+    StringRef AsmString, SMDiagnostic &Err, LLVMContext &Context) {
+    char parse_err[512] = {0};
+    lr_module_t *parsed = nullptr;
+    if (lc_is_lfortran_jit_wrapper_ir(AsmString.data(), AsmString.size())) {
+        parsed = lc_build_lfortran_jit_wrapper_module(parse_err,
+                                                      sizeof(parse_err));
+    } else {
+        parsed = lr_parse_ll(AsmString.data(), AsmString.size(),
+                             parse_err, sizeof(parse_err));
+    }
+    if (!parsed) {
+        Err = SMDiagnostic(parse_err[0] ? parse_err
+                                        : "parseAssemblyString failed in liric");
+        return nullptr;
+    }
+    return attach_parsed_module(parsed, Err, Context);
 }
 
 inline std::unique_ptr<Module> parseAssemblyFile(

--- a/include/llvm/IR/Constants.h
+++ b/include/llvm/IR/Constants.h
@@ -8,8 +8,6 @@
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <liric/liric_compat.h>
-#include <algorithm>
-#include <cstring>
 #include <string>
 #include <vector>
 
@@ -21,142 +19,6 @@ class BasicBlock;
 class Constant;
 
 lc_module_compat_t *liric_get_current_module();
-
-namespace detail {
-
-inline size_t liric_type_align(const lr_type_t *t) {
-    if (!t) return 1;
-    switch (t->kind) {
-    case LR_TYPE_VOID:   return 1;
-    case LR_TYPE_I1:     return 1;
-    case LR_TYPE_I8:     return 1;
-    case LR_TYPE_I16:    return 2;
-    case LR_TYPE_I32:    return 4;
-    case LR_TYPE_I64:    return 8;
-    case LR_TYPE_FLOAT:  return 4;
-    case LR_TYPE_DOUBLE: return 8;
-    case LR_TYPE_PTR:    return 8;
-    case LR_TYPE_ARRAY:  return liric_type_align(t->array.elem);
-    case LR_TYPE_STRUCT: {
-        if (t->struc.packed) return 1;
-        size_t max_align = 1;
-        for (uint32_t i = 0; i < t->struc.num_fields; i++) {
-            size_t a = liric_type_align(t->struc.fields[i]);
-            if (a > max_align) max_align = a;
-        }
-        return max_align;
-    }
-    case LR_TYPE_FUNC:   return 1;
-    }
-    return 1;
-}
-
-inline size_t liric_type_size(const lr_type_t *t) {
-    if (!t) return 0;
-    switch (t->kind) {
-    case LR_TYPE_VOID:   return 0;
-    case LR_TYPE_I1:     return 1;
-    case LR_TYPE_I8:     return 1;
-    case LR_TYPE_I16:    return 2;
-    case LR_TYPE_I32:    return 4;
-    case LR_TYPE_I64:    return 8;
-    case LR_TYPE_FLOAT:  return 4;
-    case LR_TYPE_DOUBLE: return 8;
-    case LR_TYPE_PTR:    return 8;
-    case LR_TYPE_ARRAY:
-        return liric_type_size(t->array.elem) * t->array.count;
-    case LR_TYPE_STRUCT: {
-        size_t sz = 0;
-        for (uint32_t i = 0; i < t->struc.num_fields; i++) {
-            size_t fsz = liric_type_size(t->struc.fields[i]);
-            if (!t->struc.packed) {
-                size_t fa = liric_type_align(t->struc.fields[i]);
-                sz = (sz + fa - 1) & ~(fa - 1);
-            }
-            sz += fsz;
-        }
-        if (!t->struc.packed && t->struc.num_fields > 0) {
-            size_t sa = liric_type_align(t);
-            sz = (sz + sa - 1) & ~(sa - 1);
-        }
-        return sz;
-    }
-    case LR_TYPE_FUNC:
-        return 0;
-    }
-    return 0;
-}
-
-inline size_t liric_struct_field_offset(const lr_type_t *st, uint32_t field_idx) {
-    size_t off = 0;
-    if (!st || st->kind != LR_TYPE_STRUCT)
-        return 0;
-    for (uint32_t i = 0; i < st->struc.num_fields && i < field_idx; i++) {
-        if (!st->struc.packed) {
-            size_t fa = liric_type_align(st->struc.fields[i]);
-            off = (off + fa - 1) & ~(fa - 1);
-        }
-        off += liric_type_size(st->struc.fields[i]);
-    }
-    if (field_idx < st->struc.num_fields && !st->struc.packed) {
-        size_t fa = liric_type_align(st->struc.fields[field_idx]);
-        off = (off + fa - 1) & ~(fa - 1);
-    }
-    return off;
-}
-
-inline bool liric_pack_constant_bytes(Value *C, const lr_type_t *ty,
-                                      std::vector<uint8_t> &out) {
-    size_t sz = liric_type_size(ty);
-    out.assign(sz, 0);
-    if (!C || !C->impl() || !ty)
-        return false;
-
-    lc_value_t *v = C->impl();
-    switch (v->kind) {
-    case LC_VAL_CONST_NULL:
-    case LC_VAL_CONST_UNDEF:
-        return true;
-    case LC_VAL_CONST_INT: {
-        if (sz == 0)
-            return true;
-        if (ty->kind == LR_TYPE_I1) {
-            out[0] = v->const_int.val ? 1u : 0u;
-            return true;
-        }
-        uint64_t raw = static_cast<uint64_t>(v->const_int.val);
-        size_t n = std::min(sz, sizeof(raw));
-        for (size_t i = 0; i < n; i++)
-            out[i] = static_cast<uint8_t>((raw >> (8u * i)) & 0xffu);
-        return true;
-    }
-    case LC_VAL_CONST_FP:
-        if (ty->kind == LR_TYPE_FLOAT) {
-            float f = static_cast<float>(v->const_fp.val);
-            size_t n = std::min(sz, sizeof(f));
-            std::memcpy(out.data(), &f, n);
-        } else {
-            double d = v->const_fp.val;
-            size_t n = std::min(sz, sizeof(d));
-            std::memcpy(out.data(), &d, n);
-        }
-        return true;
-    case LC_VAL_CONST_AGGREGATE:
-        if (v->aggregate.data && v->aggregate.size > 0) {
-            size_t n = std::min(sz, v->aggregate.size);
-            std::memcpy(out.data(), v->aggregate.data, n);
-        }
-        return true;
-    case LC_VAL_GLOBAL:
-        /* Keep zero bytes. Pointer relocations are handled when the global
-           itself is used directly as an initializer. */
-        return true;
-    default:
-        return false;
-    }
-}
-
-} // namespace detail
 
 class Constant : public Value {
 public:
@@ -360,45 +222,14 @@ public:
 class ConstantStruct : public Constant {
 public:
     static Constant *get(StructType *T, ArrayRef<Constant *> V) {
-        struct RelocRef {
-            size_t offset;
-            const char *symbol;
-        };
         lc_module_compat_t *mod = liric_get_current_module();
         if (!mod || !T || !T->impl()) return nullptr;
-        const lr_type_t *sty = T->impl();
-        std::vector<uint8_t> bytes(detail::liric_type_size(sty), 0);
-        std::vector<RelocRef> relocs;
-        if (sty->kind == LR_TYPE_STRUCT) {
-            uint32_t nfields = sty->struc.num_fields;
-            uint32_t nvals = static_cast<uint32_t>(V.size());
-            for (uint32_t i = 0; i < nfields && i < nvals; i++) {
-                std::vector<uint8_t> field;
-                detail::liric_pack_constant_bytes(V[i], sty->struc.fields[i], field);
-                size_t off = detail::liric_struct_field_offset(sty, i);
-                lc_value_t *elem = V[i] ? V[i]->impl() : nullptr;
-                if (elem && elem->kind == LC_VAL_GLOBAL &&
-                        sty->struc.fields[i] &&
-                        sty->struc.fields[i]->kind == LR_TYPE_PTR &&
-                        elem->global.name) {
-                    relocs.push_back({off, elem->global.name});
-                }
-                if (off >= bytes.size())
-                    continue;
-                size_t ncopy = std::min(field.size(), bytes.size() - off);
-                if (ncopy > 0)
-                    std::memcpy(bytes.data() + off, field.data(), ncopy);
-            }
-        }
-        lc_value_t *agg = lc_value_const_aggregate(mod, T->impl(),
-                                                   bytes.empty() ? nullptr : bytes.data(),
-                                                   bytes.size());
-        if (agg) {
-            for (const RelocRef &r : relocs) {
-                (void)lc_value_const_aggregate_add_reloc(mod, agg, r.offset,
-                                                         r.symbol, 0);
-            }
-        }
+        std::vector<lc_value_t *> values(V.size(), nullptr);
+        for (size_t i = 0; i < V.size(); i++)
+            values[i] = V[i] ? V[i]->impl() : nullptr;
+        lc_value_t *agg = lc_const_struct_from_values(
+            mod, T->impl(), values.empty() ? nullptr : values.data(),
+            static_cast<uint32_t>(values.size()));
         return static_cast<Constant *>(Value::wrap(agg));
     }
 };
@@ -406,47 +237,14 @@ public:
 class ConstantArray : public Constant {
 public:
     static Constant *get(ArrayType *T, ArrayRef<Constant *> V) {
-        struct RelocRef {
-            size_t offset;
-            const char *symbol;
-        };
         lc_module_compat_t *mod = liric_get_current_module();
         if (!mod || !T || !T->impl()) return nullptr;
-        const lr_type_t *aty = T->impl();
-        std::vector<uint8_t> bytes(detail::liric_type_size(aty), 0);
-        std::vector<RelocRef> relocs;
-        if (aty->kind == LR_TYPE_ARRAY) {
-            const lr_type_t *elem_ty = aty->array.elem;
-            size_t elem_sz = detail::liric_type_size(elem_ty);
-            uint64_t nvals = std::min<uint64_t>(aty->array.count, V.size());
-            for (uint64_t i = 0; i < nvals; i++) {
-                std::vector<uint8_t> elem;
-                detail::liric_pack_constant_bytes(V[static_cast<size_t>(i)],
-                                                  elem_ty, elem);
-                size_t off = static_cast<size_t>(i) * elem_sz;
-                lc_value_t *elem_val = V[static_cast<size_t>(i)]
-                    ? V[static_cast<size_t>(i)]->impl() : nullptr;
-                if (elem_val && elem_val->kind == LC_VAL_GLOBAL &&
-                        elem_ty && elem_ty->kind == LR_TYPE_PTR &&
-                        elem_val->global.name) {
-                    relocs.push_back({off, elem_val->global.name});
-                }
-                if (off >= bytes.size())
-                    continue;
-                size_t ncopy = std::min(elem.size(), bytes.size() - off);
-                if (ncopy > 0)
-                    std::memcpy(bytes.data() + off, elem.data(), ncopy);
-            }
-        }
-        lc_value_t *agg = lc_value_const_aggregate(mod, T->impl(),
-                                                   bytes.empty() ? nullptr : bytes.data(),
-                                                   bytes.size());
-        if (agg) {
-            for (const RelocRef &r : relocs) {
-                (void)lc_value_const_aggregate_add_reloc(mod, agg, r.offset,
-                                                         r.symbol, 0);
-            }
-        }
+        std::vector<lc_value_t *> values(V.size(), nullptr);
+        for (size_t i = 0; i < V.size(); i++)
+            values[i] = V[i] ? V[i]->impl() : nullptr;
+        lc_value_t *agg = lc_const_array_from_values(
+            mod, T->impl(), values.empty() ? nullptr : values.data(),
+            static_cast<uint32_t>(values.size()));
         return static_cast<Constant *>(Value::wrap(agg));
     }
 };

--- a/include/llvm/IR/IRBuilder.h
+++ b/include/llvm/IR/IRBuilder.h
@@ -882,7 +882,8 @@ public:
     Value *CreateIntrinsic(Intrinsic::ID ID, ArrayRef<Type *> Types,
                            ArrayRef<Value *> Args,
                            const Twine &Name = "") {
-        const char *intrinsic_name = intrinsic_id_to_name(ID);
+        const char *intrinsic_name = lc_intrinsic_name(
+            static_cast<unsigned>(ID));
         if (!intrinsic_name) return nullptr;
 
         lc_module_compat_t *mod = M();
@@ -924,43 +925,6 @@ public:
                                 const Twine &Name = "") {
         Type *ty = V->getType();
         return CreateIntrinsic(ID, {ty}, {V}, Name);
-    }
-
-private:
-    static const char *intrinsic_id_to_name(Intrinsic::ID ID) {
-        switch (ID) {
-        case Intrinsic::abs:       return "abs";
-        case Intrinsic::copysign:  return "copysign";
-        case Intrinsic::cos:       return "cos";
-        case Intrinsic::ctlz:      return "ctlz";
-        case Intrinsic::ctpop:     return "ctpop";
-        case Intrinsic::cttz:      return "cttz";
-        case Intrinsic::exp:       return "exp";
-        case Intrinsic::exp2:      return "exp2";
-        case Intrinsic::fabs:      return "fabs";
-        case Intrinsic::floor:     return "floor";
-        case Intrinsic::ceil:      return "ceil";
-        case Intrinsic::round:     return "round";
-        case Intrinsic::trunc:     return "trunc";
-        case Intrinsic::fma:       return "fma";
-        case Intrinsic::fmuladd:   return "fma";
-        case Intrinsic::log:       return "log";
-        case Intrinsic::log2:      return "log2";
-        case Intrinsic::log10:     return "log10";
-        case Intrinsic::maximum:   return "fmax";
-        case Intrinsic::maxnum:    return "fmax";
-        case Intrinsic::minimum:   return "fmin";
-        case Intrinsic::minnum:    return "fmin";
-        case Intrinsic::memcpy:    return "memcpy";
-        case Intrinsic::memmove:   return "memmove";
-        case Intrinsic::memset:    return "memset";
-        case Intrinsic::pow:       return "pow";
-        case Intrinsic::powi:      return "powi";
-        case Intrinsic::sin:       return "sin";
-        case Intrinsic::sqrt:      return "sqrt";
-        case Intrinsic::trap:      return "abort";
-        default: return nullptr;
-        }
     }
 };
 

--- a/include/llvm/Support/raw_ostream.h
+++ b/include/llvm/Support/raw_ostream.h
@@ -3,7 +3,9 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include <liric/liric_compat.h>
 #include <cstdio>
+#include <cstring>
 #include <string>
 #include <system_error>
 #include <type_traits>
@@ -38,37 +40,44 @@ public:
         return write(s.data(), s.size());
     }
     raw_ostream &operator<<(int v) {
-        std::string s = std::to_string(v);
-        return write(s.data(), s.size());
+        char buf[32];
+        size_t n = lc_format_i64(buf, sizeof(buf), static_cast<int64_t>(v));
+        return n ? write(buf, n) : *this;
     }
     raw_ostream &operator<<(unsigned v) {
-        std::string s = std::to_string(v);
-        return write(s.data(), s.size());
+        char buf[32];
+        size_t n = lc_format_u64(buf, sizeof(buf), static_cast<uint64_t>(v));
+        return n ? write(buf, n) : *this;
     }
     raw_ostream &operator<<(long v) {
-        std::string s = std::to_string(v);
-        return write(s.data(), s.size());
+        char buf[32];
+        size_t n = lc_format_i64(buf, sizeof(buf), static_cast<int64_t>(v));
+        return n ? write(buf, n) : *this;
     }
     raw_ostream &operator<<(unsigned long v) {
-        std::string s = std::to_string(v);
-        return write(s.data(), s.size());
+        char buf[32];
+        size_t n = lc_format_u64(buf, sizeof(buf), static_cast<uint64_t>(v));
+        return n ? write(buf, n) : *this;
     }
     raw_ostream &operator<<(long long v) {
-        std::string s = std::to_string(v);
-        return write(s.data(), s.size());
+        char buf[32];
+        size_t n = lc_format_i64(buf, sizeof(buf), static_cast<int64_t>(v));
+        return n ? write(buf, n) : *this;
     }
     raw_ostream &operator<<(unsigned long long v) {
-        std::string s = std::to_string(v);
-        return write(s.data(), s.size());
+        char buf[32];
+        size_t n = lc_format_u64(buf, sizeof(buf), static_cast<uint64_t>(v));
+        return n ? write(buf, n) : *this;
     }
     raw_ostream &operator<<(double v) {
-        std::string s = std::to_string(v);
-        return write(s.data(), s.size());
+        char buf[64];
+        size_t n = lc_format_f64(buf, sizeof(buf), v);
+        return n ? write(buf, n) : *this;
     }
     raw_ostream &operator<<(const void *p) {
         char buf[32];
-        snprintf(buf, sizeof(buf), "%p", p);
-        return write(buf, std::strlen(buf));
+        size_t n = lc_format_ptr(buf, sizeof(buf), p);
+        return n ? write(buf, n) : *this;
     }
 
     virtual void flush() {}


### PR DESCRIPTION
## Summary
- moved non-trivial compat logic from C++ headers into `src/liric_compat.c` with new C helpers for intrinsic mapping, wrapper IR detection/build, raw formatting, and constant aggregate packing
- refactored `Constants.h`, `IRBuilder.h`, `AsmParser/Parser.h`, and `raw_ostream.h` into thin adapters over the C helpers
- added LLVM compat tests for intrinsic mapping, wrapper parse fast path, aggregate constant byte packing, and numeric/raw pointer stream formatting

## Verification
- `cmake -S . -B build-issue279 -G Ninja -DWITH_LLVM_COMPAT=ON`
- `cmake --build build-issue279 -j$(nproc)`
- `ctest --test-dir build-issue279 --output-on-failure 2>&1 | tee /tmp/test.log`

Output excerpt:
- `100% tests passed, 0 tests failed out of 27`
- `Total Test time (real) =   1.41 sec`

Artifacts:
- `/tmp/test.log`
