### PR TITLE
fix: Function-at-a-time streaming for .ll text parsing (fixes #292)

### DIFF
--- a/include/liric/liric.h
+++ b/include/liric/liric.h
@@ -19,9 +19,14 @@ typedef struct lr_type lr_type_t;
 typedef struct lr_global lr_global_t;
 typedef struct lr_jit lr_jit_t;
 
+typedef int (*lr_ll_func_cb_t)(lr_func_t *func, lr_module_t *mod, void *ctx);
+
 /* ---- Frontend: text / binary parsers ----------------------------------- */
 
 lr_module_t *lr_parse_ll(const char *src, size_t len, char *err, size_t errlen);
+lr_module_t *lr_parse_ll_streaming(const char *src, size_t len,
+                                   lr_ll_func_cb_t on_func, void *ctx,
+                                   char *err, size_t errlen);
 lr_module_t *lr_parse_bc(const uint8_t *data, size_t len, char *err, size_t errlen);
 lr_module_t *lr_parse_wasm(const uint8_t *data, size_t len, char *err, size_t errlen);
 lr_module_t *lr_parse_auto(const uint8_t *data, size_t len, char *err, size_t errlen);

--- a/src/ll_parser.h
+++ b/src/ll_parser.h
@@ -4,7 +4,14 @@
 #include "ir.h"
 #include "ll_lexer.h"
 
+typedef int (*lr_parse_ll_func_cb_t)(lr_func_t *func, lr_module_t *mod,
+                                     void *ctx);
+
 lr_module_t *lr_parse_ll_text(const char *src, size_t len,
                                lr_arena_t *arena, char *err, size_t errlen);
+lr_module_t *lr_parse_ll_text_streaming(const char *src, size_t len,
+                                        lr_arena_t *arena,
+                                        lr_parse_ll_func_cb_t on_func,
+                                        void *ctx, char *err, size_t errlen);
 
 #endif

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -67,6 +67,8 @@ int test_parser_dynamic_block_map_growth(void);
 int test_parser_dynamic_global_map_growth(void);
 int test_parser_dynamic_func_map_growth(void);
 int test_parser_cast_expr_in_aggregate_init(void);
+int test_parser_streaming_callback_order(void);
+int test_parser_streaming_callback_error_propagates(void);
 int test_codegen_ret_42(void);
 int test_codegen_add(void);
 int test_codegen_skip_redundant_immediate_reload(void);
@@ -284,6 +286,8 @@ int main(void) {
     RUN_TEST(test_parser_dynamic_global_map_growth);
     RUN_TEST(test_parser_dynamic_func_map_growth);
     RUN_TEST(test_parser_cast_expr_in_aggregate_init);
+    RUN_TEST(test_parser_streaming_callback_order);
+    RUN_TEST(test_parser_streaming_callback_error_propagates);
 
     fprintf(stderr, "\nCodegen tests:\n");
     RUN_TEST(test_codegen_ret_42);


### PR DESCRIPTION
## Summary
- add `lr_parse_ll_streaming()` public API with per-function callback support
- refactor LL parser entrypoint to support callback dispatch via `lr_parse_ll_text_streaming()`
- make `lr_parse_ll()` a thin wrapper over the streaming entrypoint
- add parser tests for callback order/global availability and callback error propagation

## Verification
- `cmake --build build -j$(nproc)`
- `./build/test_liric 2>&1 | tee /tmp/test.log`
- `grep -nE "FAIL:|error:|FAILED|\\bfailed\\b" /tmp/test.log || true`

Output excerpts:
- `199 tests: 199 passed, 0 failed`

Artifact paths:
- `/tmp/test.log`
