### PR TITLE
fix: Complete aarch64 intrinsic blobs (sin/cos/log/floor/fma/etc.) (fixes #281)

### DIFF
--- a/src/platform/platform_intrinsic_stubs_aarch64_linux.S
+++ b/src/platform/platform_intrinsic_stubs_aarch64_linux.S
@@ -456,3 +456,738 @@ lr_stub_llvm_memmove_i64_begin:
 54:
     ret
 lr_stub_llvm_memmove_i64_end:
+
+.globl lr_stub_llvm_floor_f64_begin
+.globl lr_stub_llvm_floor_f64_end
+lr_stub_llvm_floor_f64_begin:
+    frintm d0, d0
+    ret
+lr_stub_llvm_floor_f64_end:
+
+.globl lr_stub_llvm_floor_f32_begin
+.globl lr_stub_llvm_floor_f32_end
+lr_stub_llvm_floor_f32_begin:
+    frintm s0, s0
+    ret
+lr_stub_llvm_floor_f32_end:
+
+.globl lr_stub_llvm_ceil_f64_begin
+.globl lr_stub_llvm_ceil_f64_end
+lr_stub_llvm_ceil_f64_begin:
+    frintp d0, d0
+    ret
+lr_stub_llvm_ceil_f64_end:
+
+.globl lr_stub_llvm_ceil_f32_begin
+.globl lr_stub_llvm_ceil_f32_end
+lr_stub_llvm_ceil_f32_begin:
+    frintp s0, s0
+    ret
+lr_stub_llvm_ceil_f32_end:
+
+.globl lr_stub_llvm_trunc_f64_begin
+.globl lr_stub_llvm_trunc_f64_end
+lr_stub_llvm_trunc_f64_begin:
+    frintz d0, d0
+    ret
+lr_stub_llvm_trunc_f64_end:
+
+.globl lr_stub_llvm_trunc_f32_begin
+.globl lr_stub_llvm_trunc_f32_end
+lr_stub_llvm_trunc_f32_begin:
+    frintz s0, s0
+    ret
+lr_stub_llvm_trunc_f32_end:
+
+.globl lr_stub_llvm_round_f64_begin
+.globl lr_stub_llvm_round_f64_end
+lr_stub_llvm_round_f64_begin:
+    frinta d0, d0
+    ret
+lr_stub_llvm_round_f64_end:
+
+.globl lr_stub_llvm_round_f32_begin
+.globl lr_stub_llvm_round_f32_end
+lr_stub_llvm_round_f32_begin:
+    frinta s0, s0
+    ret
+lr_stub_llvm_round_f32_end:
+
+.globl lr_stub_llvm_rint_f64_begin
+.globl lr_stub_llvm_rint_f64_end
+lr_stub_llvm_rint_f64_begin:
+    frintx d0, d0
+    ret
+lr_stub_llvm_rint_f64_end:
+
+.globl lr_stub_llvm_rint_f32_begin
+.globl lr_stub_llvm_rint_f32_end
+lr_stub_llvm_rint_f32_begin:
+    frintx s0, s0
+    ret
+lr_stub_llvm_rint_f32_end:
+
+.globl lr_stub_llvm_nearbyint_f64_begin
+.globl lr_stub_llvm_nearbyint_f64_end
+lr_stub_llvm_nearbyint_f64_begin:
+    frinti d0, d0
+    ret
+lr_stub_llvm_nearbyint_f64_end:
+
+.globl lr_stub_llvm_nearbyint_f32_begin
+.globl lr_stub_llvm_nearbyint_f32_end
+lr_stub_llvm_nearbyint_f32_begin:
+    frinti s0, s0
+    ret
+lr_stub_llvm_nearbyint_f32_end:
+
+.globl lr_stub_llvm_fma_f64_begin
+.globl lr_stub_llvm_fma_f64_end
+lr_stub_llvm_fma_f64_begin:
+    fmadd d0, d0, d1, d2
+    ret
+lr_stub_llvm_fma_f64_end:
+
+.globl lr_stub_llvm_fma_f32_begin
+.globl lr_stub_llvm_fma_f32_end
+lr_stub_llvm_fma_f32_begin:
+    fmadd s0, s0, s1, s2
+    ret
+lr_stub_llvm_fma_f32_end:
+
+.globl lr_stub_llvm_minnum_f64_begin
+.globl lr_stub_llvm_minnum_f64_end
+lr_stub_llvm_minnum_f64_begin:
+    fminnm d0, d0, d1
+    ret
+lr_stub_llvm_minnum_f64_end:
+
+.globl lr_stub_llvm_minnum_f32_begin
+.globl lr_stub_llvm_minnum_f32_end
+lr_stub_llvm_minnum_f32_begin:
+    fminnm s0, s0, s1
+    ret
+lr_stub_llvm_minnum_f32_end:
+
+.globl lr_stub_llvm_maxnum_f64_begin
+.globl lr_stub_llvm_maxnum_f64_end
+lr_stub_llvm_maxnum_f64_begin:
+    fmaxnm d0, d0, d1
+    ret
+lr_stub_llvm_maxnum_f64_end:
+
+.globl lr_stub_llvm_maxnum_f32_begin
+.globl lr_stub_llvm_maxnum_f32_end
+lr_stub_llvm_maxnum_f32_begin:
+    fmaxnm s0, s0, s1
+    ret
+lr_stub_llvm_maxnum_f32_end:
+
+.globl lr_stub_llvm_abs_i32_begin
+.globl lr_stub_llvm_abs_i32_end
+lr_stub_llvm_abs_i32_begin:
+    cmp w0, #0
+    cneg w0, w0, lt
+    ret
+lr_stub_llvm_abs_i32_end:
+
+.globl lr_stub_llvm_abs_i64_begin
+.globl lr_stub_llvm_abs_i64_end
+lr_stub_llvm_abs_i64_begin:
+    cmp x0, #0
+    cneg x0, x0, lt
+    ret
+lr_stub_llvm_abs_i64_end:
+
+.globl lr_stub_llvm_exp2_f64_begin
+.globl lr_stub_llvm_exp2_f64_end
+lr_stub_llvm_exp2_f64_begin:
+    adr x11, .Lexp2_f64_ln2
+    ldr d1, [x11]
+    fmul d0, d0, d1
+
+    fmov d2, #1.0
+    fmov d3, #1.0
+    mov x9, #1
+    mov x10, #24
+.Lexp2_f64_loop:
+    scvtf d4, x9
+    fmul d2, d2, d0
+    fdiv d2, d2, d4
+    fadd d3, d3, d2
+    add x9, x9, #1
+    cmp x9, x10
+    ble .Lexp2_f64_loop
+    fmov d0, d3
+    ret
+    .p2align 3
+.Lexp2_f64_ln2:
+    .double 0.69314718055994530942
+lr_stub_llvm_exp2_f64_end:
+
+.globl lr_stub_llvm_exp2_f32_begin
+.globl lr_stub_llvm_exp2_f32_end
+lr_stub_llvm_exp2_f32_begin:
+    fcvt d0, s0
+    adr x11, .Lexp2_f32_ln2
+    ldr d1, [x11]
+    fmul d0, d0, d1
+
+    fmov d2, #1.0
+    fmov d3, #1.0
+    mov x9, #1
+    mov x10, #20
+.Lexp2_f32_loop:
+    scvtf d4, x9
+    fmul d2, d2, d0
+    fdiv d2, d2, d4
+    fadd d3, d3, d2
+    add x9, x9, #1
+    cmp x9, x10
+    ble .Lexp2_f32_loop
+    fcvt s0, d3
+    ret
+    .p2align 3
+.Lexp2_f32_ln2:
+    .double 0.69314718055994530942
+lr_stub_llvm_exp2_f32_end:
+
+.globl lr_stub_llvm_log_f64_begin
+.globl lr_stub_llvm_log_f64_end
+lr_stub_llvm_log_f64_begin:
+    fcmp d0, #0.0
+    b.le .Llog_f64_nonpos
+
+    fmov d1, #1.0
+    fsub d2, d0, d1
+    fadd d3, d0, d1
+    fdiv d4, d2, d3
+    fmul d5, d4, d4
+    fmov d6, d4
+    fmov d7, d4
+
+    mov x9, #3
+    mov x10, #39
+.Llog_f64_loop:
+    fmul d6, d6, d5
+    scvtf d8, x9
+    fdiv d8, d6, d8
+    fadd d7, d7, d8
+    add x9, x9, #2
+    cmp x9, x10
+    ble .Llog_f64_loop
+
+    fmov d8, #2.0
+    fmul d0, d7, d8
+    ret
+.Llog_f64_nonpos:
+    fmov d0, xzr
+    ret
+lr_stub_llvm_log_f64_end:
+
+.globl lr_stub_llvm_log_f32_begin
+.globl lr_stub_llvm_log_f32_end
+lr_stub_llvm_log_f32_begin:
+    fcvt d0, s0
+    fcmp d0, #0.0
+    b.le .Llog_f32_nonpos
+
+    fmov d1, #1.0
+    fsub d2, d0, d1
+    fadd d3, d0, d1
+    fdiv d4, d2, d3
+    fmul d5, d4, d4
+    fmov d6, d4
+    fmov d7, d4
+
+    mov x9, #3
+    mov x10, #31
+.Llog_f32_loop:
+    fmul d6, d6, d5
+    scvtf d8, x9
+    fdiv d8, d6, d8
+    fadd d7, d7, d8
+    add x9, x9, #2
+    cmp x9, x10
+    ble .Llog_f32_loop
+
+    fmov d8, #2.0
+    fmul d0, d7, d8
+    fcvt s0, d0
+    ret
+.Llog_f32_nonpos:
+    fmov s0, wzr
+    ret
+lr_stub_llvm_log_f32_end:
+
+.globl lr_stub_llvm_log2_f64_begin
+.globl lr_stub_llvm_log2_f64_end
+lr_stub_llvm_log2_f64_begin:
+    fcmp d0, #0.0
+    b.le .Llog2_f64_nonpos
+
+    fmov d1, #1.0
+    fsub d2, d0, d1
+    fadd d3, d0, d1
+    fdiv d4, d2, d3
+    fmul d5, d4, d4
+    fmov d6, d4
+    fmov d7, d4
+
+    mov x9, #3
+    mov x10, #39
+.Llog2_f64_loop:
+    fmul d6, d6, d5
+    scvtf d8, x9
+    fdiv d8, d6, d8
+    fadd d7, d7, d8
+    add x9, x9, #2
+    cmp x9, x10
+    ble .Llog2_f64_loop
+
+    fmov d8, #2.0
+    fmul d7, d7, d8
+    adr x11, .Llog2_f64_inv_ln2
+    ldr d8, [x11]
+    fmul d0, d7, d8
+    ret
+.Llog2_f64_nonpos:
+    fmov d0, xzr
+    ret
+    .p2align 3
+.Llog2_f64_inv_ln2:
+    .double 1.44269504088896340736
+lr_stub_llvm_log2_f64_end:
+
+.globl lr_stub_llvm_log2_f32_begin
+.globl lr_stub_llvm_log2_f32_end
+lr_stub_llvm_log2_f32_begin:
+    fcvt d0, s0
+    fcmp d0, #0.0
+    b.le .Llog2_f32_nonpos
+
+    fmov d1, #1.0
+    fsub d2, d0, d1
+    fadd d3, d0, d1
+    fdiv d4, d2, d3
+    fmul d5, d4, d4
+    fmov d6, d4
+    fmov d7, d4
+
+    mov x9, #3
+    mov x10, #31
+.Llog2_f32_loop:
+    fmul d6, d6, d5
+    scvtf d8, x9
+    fdiv d8, d6, d8
+    fadd d7, d7, d8
+    add x9, x9, #2
+    cmp x9, x10
+    ble .Llog2_f32_loop
+
+    fmov d8, #2.0
+    fmul d7, d7, d8
+    adr x11, .Llog2_f32_inv_ln2
+    ldr d8, [x11]
+    fmul d0, d7, d8
+    fcvt s0, d0
+    ret
+.Llog2_f32_nonpos:
+    fmov s0, wzr
+    ret
+    .p2align 3
+.Llog2_f32_inv_ln2:
+    .double 1.44269504088896340736
+lr_stub_llvm_log2_f32_end:
+
+.globl lr_stub_llvm_log10_f64_begin
+.globl lr_stub_llvm_log10_f64_end
+lr_stub_llvm_log10_f64_begin:
+    fcmp d0, #0.0
+    b.le .Llog10_f64_nonpos
+
+    fmov d1, #1.0
+    fsub d2, d0, d1
+    fadd d3, d0, d1
+    fdiv d4, d2, d3
+    fmul d5, d4, d4
+    fmov d6, d4
+    fmov d7, d4
+
+    mov x9, #3
+    mov x10, #39
+.Llog10_f64_loop:
+    fmul d6, d6, d5
+    scvtf d8, x9
+    fdiv d8, d6, d8
+    fadd d7, d7, d8
+    add x9, x9, #2
+    cmp x9, x10
+    ble .Llog10_f64_loop
+
+    fmov d8, #2.0
+    fmul d7, d7, d8
+    adr x11, .Llog10_f64_inv_ln10
+    ldr d8, [x11]
+    fmul d0, d7, d8
+    ret
+.Llog10_f64_nonpos:
+    fmov d0, xzr
+    ret
+    .p2align 3
+.Llog10_f64_inv_ln10:
+    .double 0.43429448190325182765
+lr_stub_llvm_log10_f64_end:
+
+.globl lr_stub_llvm_log10_f32_begin
+.globl lr_stub_llvm_log10_f32_end
+lr_stub_llvm_log10_f32_begin:
+    fcvt d0, s0
+    fcmp d0, #0.0
+    b.le .Llog10_f32_nonpos
+
+    fmov d1, #1.0
+    fsub d2, d0, d1
+    fadd d3, d0, d1
+    fdiv d4, d2, d3
+    fmul d5, d4, d4
+    fmov d6, d4
+    fmov d7, d4
+
+    mov x9, #3
+    mov x10, #31
+.Llog10_f32_loop:
+    fmul d6, d6, d5
+    scvtf d8, x9
+    fdiv d8, d6, d8
+    fadd d7, d7, d8
+    add x9, x9, #2
+    cmp x9, x10
+    ble .Llog10_f32_loop
+
+    fmov d8, #2.0
+    fmul d7, d7, d8
+    adr x11, .Llog10_f32_inv_ln10
+    ldr d8, [x11]
+    fmul d0, d7, d8
+    fcvt s0, d0
+    ret
+.Llog10_f32_nonpos:
+    fmov s0, wzr
+    ret
+    .p2align 3
+.Llog10_f32_inv_ln10:
+    .double 0.43429448190325182765
+lr_stub_llvm_log10_f32_end:
+
+.globl lr_stub_llvm_sin_f64_begin
+.globl lr_stub_llvm_sin_f64_end
+lr_stub_llvm_sin_f64_begin:
+    adr x11, .Lsin_f64_inv_two_pi
+    ldr d10, [x11]
+    fmul d11, d0, d10
+    frintn d11, d11
+    adr x11, .Lsin_f64_two_pi
+    ldr d10, [x11]
+    fmul d12, d11, d10
+    fsub d0, d0, d12
+
+    fmul d1, d0, d0
+
+    adr x11, .Lsin_f64_c11
+    ldr d2, [x11]
+    fmul d2, d2, d1
+    adr x11, .Lsin_f64_c9
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lsin_f64_c7
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lsin_f64_c5
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lsin_f64_c3
+    ldr d3, [x11]
+    fadd d2, d2, d3
+
+    fmul d2, d2, d1
+    fmul d2, d2, d0
+    fadd d0, d0, d2
+    ret
+    .p2align 3
+.Lsin_f64_inv_two_pi:
+    .double 0.15915494309189533577
+.Lsin_f64_two_pi:
+    .double 6.28318530717958647692
+.Lsin_f64_c3:
+    .double -0.16666666666666666667
+.Lsin_f64_c5:
+    .double 0.00833333333333333333
+.Lsin_f64_c7:
+    .double -0.00019841269841269841
+.Lsin_f64_c9:
+    .double 0.00000275573192239859
+.Lsin_f64_c11:
+    .double -0.00000002505210838544
+lr_stub_llvm_sin_f64_end:
+
+.globl lr_stub_llvm_sin_f32_begin
+.globl lr_stub_llvm_sin_f32_end
+lr_stub_llvm_sin_f32_begin:
+    fcvt d0, s0
+    adr x11, .Lsin_f32_inv_two_pi
+    ldr d10, [x11]
+    fmul d11, d0, d10
+    frintn d11, d11
+    adr x11, .Lsin_f32_two_pi
+    ldr d10, [x11]
+    fmul d12, d11, d10
+    fsub d0, d0, d12
+
+    fmul d1, d0, d0
+
+    adr x11, .Lsin_f32_c11
+    ldr d2, [x11]
+    fmul d2, d2, d1
+    adr x11, .Lsin_f32_c9
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lsin_f32_c7
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lsin_f32_c5
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lsin_f32_c3
+    ldr d3, [x11]
+    fadd d2, d2, d3
+
+    fmul d2, d2, d1
+    fmul d2, d2, d0
+    fadd d0, d0, d2
+    fcvt s0, d0
+    ret
+    .p2align 3
+.Lsin_f32_inv_two_pi:
+    .double 0.15915494309189533577
+.Lsin_f32_two_pi:
+    .double 6.28318530717958647692
+.Lsin_f32_c3:
+    .double -0.16666666666666666667
+.Lsin_f32_c5:
+    .double 0.00833333333333333333
+.Lsin_f32_c7:
+    .double -0.00019841269841269841
+.Lsin_f32_c9:
+    .double 0.00000275573192239859
+.Lsin_f32_c11:
+    .double -0.00000002505210838544
+lr_stub_llvm_sin_f32_end:
+
+.globl lr_stub_llvm_cos_f64_begin
+.globl lr_stub_llvm_cos_f64_end
+lr_stub_llvm_cos_f64_begin:
+    adr x11, .Lcos_f64_inv_two_pi
+    ldr d10, [x11]
+    fmul d11, d0, d10
+    frintn d11, d11
+    adr x11, .Lcos_f64_two_pi
+    ldr d10, [x11]
+    fmul d12, d11, d10
+    fsub d0, d0, d12
+
+    fmul d1, d0, d0
+
+    adr x11, .Lcos_f64_c10
+    ldr d2, [x11]
+    fmul d2, d2, d1
+    adr x11, .Lcos_f64_c8
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lcos_f64_c6
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lcos_f64_c4
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lcos_f64_c2
+    ldr d3, [x11]
+    fadd d2, d2, d3
+
+    fmul d2, d2, d1
+    fmov d3, #1.0
+    fadd d0, d3, d2
+    ret
+    .p2align 3
+.Lcos_f64_inv_two_pi:
+    .double 0.15915494309189533577
+.Lcos_f64_two_pi:
+    .double 6.28318530717958647692
+.Lcos_f64_c2:
+    .double -0.5
+.Lcos_f64_c4:
+    .double 0.04166666666666666667
+.Lcos_f64_c6:
+    .double -0.00138888888888888889
+.Lcos_f64_c8:
+    .double 0.00002480158730158730
+.Lcos_f64_c10:
+    .double -0.00000027557319223986
+lr_stub_llvm_cos_f64_end:
+
+.globl lr_stub_llvm_cos_f32_begin
+.globl lr_stub_llvm_cos_f32_end
+lr_stub_llvm_cos_f32_begin:
+    fcvt d0, s0
+    adr x11, .Lcos_f32_inv_two_pi
+    ldr d10, [x11]
+    fmul d11, d0, d10
+    frintn d11, d11
+    adr x11, .Lcos_f32_two_pi
+    ldr d10, [x11]
+    fmul d12, d11, d10
+    fsub d0, d0, d12
+
+    fmul d1, d0, d0
+
+    adr x11, .Lcos_f32_c10
+    ldr d2, [x11]
+    fmul d2, d2, d1
+    adr x11, .Lcos_f32_c8
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lcos_f32_c6
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lcos_f32_c4
+    ldr d3, [x11]
+    fadd d2, d2, d3
+    fmul d2, d2, d1
+    adr x11, .Lcos_f32_c2
+    ldr d3, [x11]
+    fadd d2, d2, d3
+
+    fmul d2, d2, d1
+    fmov d3, #1.0
+    fadd d0, d3, d2
+    fcvt s0, d0
+    ret
+    .p2align 3
+.Lcos_f32_inv_two_pi:
+    .double 0.15915494309189533577
+.Lcos_f32_two_pi:
+    .double 6.28318530717958647692
+.Lcos_f32_c2:
+    .double -0.5
+.Lcos_f32_c4:
+    .double 0.04166666666666666667
+.Lcos_f32_c6:
+    .double -0.00138888888888888889
+.Lcos_f32_c8:
+    .double 0.00002480158730158730
+.Lcos_f32_c10:
+    .double -0.00000027557319223986
+lr_stub_llvm_cos_f32_end:
+
+.globl lr_stub_llvm_is_fpclass_f64_begin
+.globl lr_stub_llvm_is_fpclass_f64_end
+lr_stub_llvm_is_fpclass_f64_begin:
+    fmov x1, d0
+    lsr x2, x1, #63
+    lsr x3, x1, #52
+    and x3, x3, #0x7ff
+    and x4, x1, #0x000fffffffffffff
+
+    cmp x3, #0x7ff
+    b.ne .Lfpc64_not_special
+    cbnz x4, .Lfpc64_nan
+    mov w5, #512
+    cbz x2, .Lfpc64_check
+    mov w5, #4
+    b .Lfpc64_check
+.Lfpc64_nan:
+    tbnz x4, #51, .Lfpc64_qnan
+    mov w5, #1
+    b .Lfpc64_check
+.Lfpc64_qnan:
+    mov w5, #2
+    b .Lfpc64_check
+.Lfpc64_not_special:
+    cbnz x3, .Lfpc64_normal
+    cbnz x4, .Lfpc64_subnormal
+    mov w5, #64
+    cbz x2, .Lfpc64_check
+    mov w5, #32
+    b .Lfpc64_check
+.Lfpc64_subnormal:
+    mov w5, #128
+    cbz x2, .Lfpc64_check
+    mov w5, #16
+    b .Lfpc64_check
+.Lfpc64_normal:
+    mov w5, #256
+    cbz x2, .Lfpc64_check
+    mov w5, #8
+.Lfpc64_check:
+    and w5, w5, w0
+    cmp w5, #0
+    cset w0, ne
+    ret
+lr_stub_llvm_is_fpclass_f64_end:
+
+.globl lr_stub_llvm_is_fpclass_f32_begin
+.globl lr_stub_llvm_is_fpclass_f32_end
+lr_stub_llvm_is_fpclass_f32_begin:
+    fmov w1, s0
+    lsr w2, w1, #31
+    lsr w3, w1, #23
+    and w3, w3, #0xff
+    and w4, w1, #0x7fffff
+
+    cmp w3, #0xff
+    b.ne .Lfpc32_not_special
+    cbnz w4, .Lfpc32_nan
+    mov w5, #512
+    cbz w2, .Lfpc32_check
+    mov w5, #4
+    b .Lfpc32_check
+.Lfpc32_nan:
+    tbnz w4, #22, .Lfpc32_qnan
+    mov w5, #1
+    b .Lfpc32_check
+.Lfpc32_qnan:
+    mov w5, #2
+    b .Lfpc32_check
+.Lfpc32_not_special:
+    cbnz w3, .Lfpc32_normal
+    cbnz w4, .Lfpc32_subnormal
+    mov w5, #64
+    cbz w2, .Lfpc32_check
+    mov w5, #32
+    b .Lfpc32_check
+.Lfpc32_subnormal:
+    mov w5, #128
+    cbz w2, .Lfpc32_check
+    mov w5, #16
+    b .Lfpc32_check
+.Lfpc32_normal:
+    mov w5, #256
+    cbz w2, .Lfpc32_check
+    mov w5, #8
+.Lfpc32_check:
+    and w5, w5, w0
+    cmp w5, #0
+    cset w0, ne
+    ret
+lr_stub_llvm_is_fpclass_f32_end:

--- a/src/platform/platform_intrinsics.c
+++ b/src/platform/platform_intrinsics.c
@@ -50,12 +50,6 @@ extern const uint8_t lr_stub_llvm_memmove_i32_begin[];
 extern const uint8_t lr_stub_llvm_memmove_i32_end[];
 extern const uint8_t lr_stub_llvm_memmove_i64_begin[];
 extern const uint8_t lr_stub_llvm_memmove_i64_end[];
-#else
-#define LR_PLATFORM_HAS_INTRINSIC_BLOBS 0
-#endif
-
-#if defined(__linux__) && defined(__x86_64__)
-#define LR_PLATFORM_HAS_X86_64_BLOBS 1
 extern const uint8_t lr_stub_llvm_sin_f32_begin[];
 extern const uint8_t lr_stub_llvm_sin_f32_end[];
 extern const uint8_t lr_stub_llvm_sin_f64_begin[];
@@ -125,21 +119,13 @@ extern const uint8_t lr_stub_llvm_is_fpclass_f32_end[];
 extern const uint8_t lr_stub_llvm_is_fpclass_f64_begin[];
 extern const uint8_t lr_stub_llvm_is_fpclass_f64_end[];
 #else
-#if !defined(LR_PLATFORM_HAS_X86_64_BLOBS)
-#define LR_PLATFORM_HAS_X86_64_BLOBS 0
-#endif
+#define LR_PLATFORM_HAS_INTRINSIC_BLOBS 0
 #endif
 
 #if LR_PLATFORM_HAS_INTRINSIC_BLOBS
 #define LR_STUB_BLOB(begin, end) begin, end
 #else
 #define LR_STUB_BLOB(begin, end) NULL, NULL
-#endif
-
-#if LR_PLATFORM_HAS_X86_64_BLOBS
-#define LR_X86_BLOB(begin, end) begin, end
-#else
-#define LR_X86_BLOB(begin, end) NULL, NULL
 #endif
 
 static const lr_platform_intrinsic_desc_t g_intrinsics[] = {
@@ -171,42 +157,42 @@ static const lr_platform_intrinsic_desc_t g_intrinsics[] = {
     { "llvm.memmove.p0i8.p0i8.i64", LR_STUB_BLOB(lr_stub_llvm_memmove_i64_begin, lr_stub_llvm_memmove_i64_end) },
     { "llvm.memmove.p0.p0.i32", LR_STUB_BLOB(lr_stub_llvm_memmove_i32_begin, lr_stub_llvm_memmove_i32_end) },
     { "llvm.memmove.p0.p0.i64", LR_STUB_BLOB(lr_stub_llvm_memmove_i64_begin, lr_stub_llvm_memmove_i64_end) },
-    { "llvm.sin.f32", LR_X86_BLOB(lr_stub_llvm_sin_f32_begin, lr_stub_llvm_sin_f32_end) },
-    { "llvm.sin.f64", LR_X86_BLOB(lr_stub_llvm_sin_f64_begin, lr_stub_llvm_sin_f64_end) },
-    { "llvm.cos.f32", LR_X86_BLOB(lr_stub_llvm_cos_f32_begin, lr_stub_llvm_cos_f32_end) },
-    { "llvm.cos.f64", LR_X86_BLOB(lr_stub_llvm_cos_f64_begin, lr_stub_llvm_cos_f64_end) },
-    { "llvm.log.f32", LR_X86_BLOB(lr_stub_llvm_log_f32_begin, lr_stub_llvm_log_f32_end) },
-    { "llvm.log.f64", LR_X86_BLOB(lr_stub_llvm_log_f64_begin, lr_stub_llvm_log_f64_end) },
-    { "llvm.log2.f32", LR_X86_BLOB(lr_stub_llvm_log2_f32_begin, lr_stub_llvm_log2_f32_end) },
-    { "llvm.log2.f64", LR_X86_BLOB(lr_stub_llvm_log2_f64_begin, lr_stub_llvm_log2_f64_end) },
-    { "llvm.log10.f32", LR_X86_BLOB(lr_stub_llvm_log10_f32_begin, lr_stub_llvm_log10_f32_end) },
-    { "llvm.log10.f64", LR_X86_BLOB(lr_stub_llvm_log10_f64_begin, lr_stub_llvm_log10_f64_end) },
-    { "llvm.exp2.f32", LR_X86_BLOB(lr_stub_llvm_exp2_f32_begin, lr_stub_llvm_exp2_f32_end) },
-    { "llvm.exp2.f64", LR_X86_BLOB(lr_stub_llvm_exp2_f64_begin, lr_stub_llvm_exp2_f64_end) },
-    { "llvm.floor.f32", LR_X86_BLOB(lr_stub_llvm_floor_f32_begin, lr_stub_llvm_floor_f32_end) },
-    { "llvm.floor.f64", LR_X86_BLOB(lr_stub_llvm_floor_f64_begin, lr_stub_llvm_floor_f64_end) },
-    { "llvm.ceil.f32", LR_X86_BLOB(lr_stub_llvm_ceil_f32_begin, lr_stub_llvm_ceil_f32_end) },
-    { "llvm.ceil.f64", LR_X86_BLOB(lr_stub_llvm_ceil_f64_begin, lr_stub_llvm_ceil_f64_end) },
-    { "llvm.trunc.f32", LR_X86_BLOB(lr_stub_llvm_trunc_f32_begin, lr_stub_llvm_trunc_f32_end) },
-    { "llvm.trunc.f64", LR_X86_BLOB(lr_stub_llvm_trunc_f64_begin, lr_stub_llvm_trunc_f64_end) },
-    { "llvm.round.f32", LR_X86_BLOB(lr_stub_llvm_round_f32_begin, lr_stub_llvm_round_f32_end) },
-    { "llvm.round.f64", LR_X86_BLOB(lr_stub_llvm_round_f64_begin, lr_stub_llvm_round_f64_end) },
-    { "llvm.rint.f32", LR_X86_BLOB(lr_stub_llvm_rint_f32_begin, lr_stub_llvm_rint_f32_end) },
-    { "llvm.rint.f64", LR_X86_BLOB(lr_stub_llvm_rint_f64_begin, lr_stub_llvm_rint_f64_end) },
-    { "llvm.nearbyint.f32", LR_X86_BLOB(lr_stub_llvm_nearbyint_f32_begin, lr_stub_llvm_nearbyint_f32_end) },
-    { "llvm.nearbyint.f64", LR_X86_BLOB(lr_stub_llvm_nearbyint_f64_begin, lr_stub_llvm_nearbyint_f64_end) },
-    { "llvm.fma.f32", LR_X86_BLOB(lr_stub_llvm_fma_f32_begin, lr_stub_llvm_fma_f32_end) },
-    { "llvm.fma.f64", LR_X86_BLOB(lr_stub_llvm_fma_f64_begin, lr_stub_llvm_fma_f64_end) },
-    { "llvm.fmuladd.f32", LR_X86_BLOB(lr_stub_llvm_fma_f32_begin, lr_stub_llvm_fma_f32_end) },
-    { "llvm.fmuladd.f64", LR_X86_BLOB(lr_stub_llvm_fma_f64_begin, lr_stub_llvm_fma_f64_end) },
-    { "llvm.minnum.f32", LR_X86_BLOB(lr_stub_llvm_minnum_f32_begin, lr_stub_llvm_minnum_f32_end) },
-    { "llvm.minnum.f64", LR_X86_BLOB(lr_stub_llvm_minnum_f64_begin, lr_stub_llvm_minnum_f64_end) },
-    { "llvm.maxnum.f32", LR_X86_BLOB(lr_stub_llvm_maxnum_f32_begin, lr_stub_llvm_maxnum_f32_end) },
-    { "llvm.maxnum.f64", LR_X86_BLOB(lr_stub_llvm_maxnum_f64_begin, lr_stub_llvm_maxnum_f64_end) },
-    { "llvm.abs.i32", LR_X86_BLOB(lr_stub_llvm_abs_i32_begin, lr_stub_llvm_abs_i32_end) },
-    { "llvm.abs.i64", LR_X86_BLOB(lr_stub_llvm_abs_i64_begin, lr_stub_llvm_abs_i64_end) },
-    { "llvm.is.fpclass.f32", LR_X86_BLOB(lr_stub_llvm_is_fpclass_f32_begin, lr_stub_llvm_is_fpclass_f32_end) },
-    { "llvm.is.fpclass.f64", LR_X86_BLOB(lr_stub_llvm_is_fpclass_f64_begin, lr_stub_llvm_is_fpclass_f64_end) },
+    { "llvm.sin.f32", LR_STUB_BLOB(lr_stub_llvm_sin_f32_begin, lr_stub_llvm_sin_f32_end) },
+    { "llvm.sin.f64", LR_STUB_BLOB(lr_stub_llvm_sin_f64_begin, lr_stub_llvm_sin_f64_end) },
+    { "llvm.cos.f32", LR_STUB_BLOB(lr_stub_llvm_cos_f32_begin, lr_stub_llvm_cos_f32_end) },
+    { "llvm.cos.f64", LR_STUB_BLOB(lr_stub_llvm_cos_f64_begin, lr_stub_llvm_cos_f64_end) },
+    { "llvm.log.f32", LR_STUB_BLOB(lr_stub_llvm_log_f32_begin, lr_stub_llvm_log_f32_end) },
+    { "llvm.log.f64", LR_STUB_BLOB(lr_stub_llvm_log_f64_begin, lr_stub_llvm_log_f64_end) },
+    { "llvm.log2.f32", LR_STUB_BLOB(lr_stub_llvm_log2_f32_begin, lr_stub_llvm_log2_f32_end) },
+    { "llvm.log2.f64", LR_STUB_BLOB(lr_stub_llvm_log2_f64_begin, lr_stub_llvm_log2_f64_end) },
+    { "llvm.log10.f32", LR_STUB_BLOB(lr_stub_llvm_log10_f32_begin, lr_stub_llvm_log10_f32_end) },
+    { "llvm.log10.f64", LR_STUB_BLOB(lr_stub_llvm_log10_f64_begin, lr_stub_llvm_log10_f64_end) },
+    { "llvm.exp2.f32", LR_STUB_BLOB(lr_stub_llvm_exp2_f32_begin, lr_stub_llvm_exp2_f32_end) },
+    { "llvm.exp2.f64", LR_STUB_BLOB(lr_stub_llvm_exp2_f64_begin, lr_stub_llvm_exp2_f64_end) },
+    { "llvm.floor.f32", LR_STUB_BLOB(lr_stub_llvm_floor_f32_begin, lr_stub_llvm_floor_f32_end) },
+    { "llvm.floor.f64", LR_STUB_BLOB(lr_stub_llvm_floor_f64_begin, lr_stub_llvm_floor_f64_end) },
+    { "llvm.ceil.f32", LR_STUB_BLOB(lr_stub_llvm_ceil_f32_begin, lr_stub_llvm_ceil_f32_end) },
+    { "llvm.ceil.f64", LR_STUB_BLOB(lr_stub_llvm_ceil_f64_begin, lr_stub_llvm_ceil_f64_end) },
+    { "llvm.trunc.f32", LR_STUB_BLOB(lr_stub_llvm_trunc_f32_begin, lr_stub_llvm_trunc_f32_end) },
+    { "llvm.trunc.f64", LR_STUB_BLOB(lr_stub_llvm_trunc_f64_begin, lr_stub_llvm_trunc_f64_end) },
+    { "llvm.round.f32", LR_STUB_BLOB(lr_stub_llvm_round_f32_begin, lr_stub_llvm_round_f32_end) },
+    { "llvm.round.f64", LR_STUB_BLOB(lr_stub_llvm_round_f64_begin, lr_stub_llvm_round_f64_end) },
+    { "llvm.rint.f32", LR_STUB_BLOB(lr_stub_llvm_rint_f32_begin, lr_stub_llvm_rint_f32_end) },
+    { "llvm.rint.f64", LR_STUB_BLOB(lr_stub_llvm_rint_f64_begin, lr_stub_llvm_rint_f64_end) },
+    { "llvm.nearbyint.f32", LR_STUB_BLOB(lr_stub_llvm_nearbyint_f32_begin, lr_stub_llvm_nearbyint_f32_end) },
+    { "llvm.nearbyint.f64", LR_STUB_BLOB(lr_stub_llvm_nearbyint_f64_begin, lr_stub_llvm_nearbyint_f64_end) },
+    { "llvm.fma.f32", LR_STUB_BLOB(lr_stub_llvm_fma_f32_begin, lr_stub_llvm_fma_f32_end) },
+    { "llvm.fma.f64", LR_STUB_BLOB(lr_stub_llvm_fma_f64_begin, lr_stub_llvm_fma_f64_end) },
+    { "llvm.fmuladd.f32", LR_STUB_BLOB(lr_stub_llvm_fma_f32_begin, lr_stub_llvm_fma_f32_end) },
+    { "llvm.fmuladd.f64", LR_STUB_BLOB(lr_stub_llvm_fma_f64_begin, lr_stub_llvm_fma_f64_end) },
+    { "llvm.minnum.f32", LR_STUB_BLOB(lr_stub_llvm_minnum_f32_begin, lr_stub_llvm_minnum_f32_end) },
+    { "llvm.minnum.f64", LR_STUB_BLOB(lr_stub_llvm_minnum_f64_begin, lr_stub_llvm_minnum_f64_end) },
+    { "llvm.maxnum.f32", LR_STUB_BLOB(lr_stub_llvm_maxnum_f32_begin, lr_stub_llvm_maxnum_f32_end) },
+    { "llvm.maxnum.f64", LR_STUB_BLOB(lr_stub_llvm_maxnum_f64_begin, lr_stub_llvm_maxnum_f64_end) },
+    { "llvm.abs.i32", LR_STUB_BLOB(lr_stub_llvm_abs_i32_begin, lr_stub_llvm_abs_i32_end) },
+    { "llvm.abs.i64", LR_STUB_BLOB(lr_stub_llvm_abs_i64_begin, lr_stub_llvm_abs_i64_end) },
+    { "llvm.is.fpclass.f32", LR_STUB_BLOB(lr_stub_llvm_is_fpclass_f32_begin, lr_stub_llvm_is_fpclass_f32_end) },
+    { "llvm.is.fpclass.f64", LR_STUB_BLOB(lr_stub_llvm_is_fpclass_f64_begin, lr_stub_llvm_is_fpclass_f64_end) },
 };
 
 static const lr_platform_intrinsic_desc_t *lookup_intrinsic(const char *name) {

--- a/tests/test_jit.c
+++ b/tests/test_jit.c
@@ -2142,6 +2142,35 @@ int test_jit_llvm_intrinsic_fabs_f32(void) {
     return 0;
 }
 
+int test_jit_llvm_intrinsic_extended_blob_coverage(void) {
+#if defined(__linux__) && (defined(__x86_64__) || defined(__aarch64__))
+    static const char *names[] = {
+        "llvm.sin.f32", "llvm.sin.f64",
+        "llvm.cos.f32", "llvm.cos.f64",
+        "llvm.log.f32", "llvm.log.f64",
+        "llvm.log2.f32", "llvm.log2.f64",
+        "llvm.log10.f32", "llvm.log10.f64",
+        "llvm.exp2.f32", "llvm.exp2.f64",
+        "llvm.floor.f32", "llvm.floor.f64",
+        "llvm.ceil.f32", "llvm.ceil.f64",
+        "llvm.trunc.f32", "llvm.trunc.f64",
+        "llvm.round.f32", "llvm.round.f64",
+        "llvm.rint.f32", "llvm.rint.f64",
+        "llvm.nearbyint.f32", "llvm.nearbyint.f64",
+        "llvm.fma.f32", "llvm.fma.f64",
+        "llvm.fmuladd.f32", "llvm.fmuladd.f64",
+        "llvm.minnum.f32", "llvm.minnum.f64",
+        "llvm.maxnum.f32", "llvm.maxnum.f64",
+        "llvm.abs.i32", "llvm.abs.i64",
+        "llvm.is.fpclass.f32", "llvm.is.fpclass.f64",
+    };
+    for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); i++) {
+        TEST_ASSERT(lr_platform_intrinsic_supported(names[i]), names[i]);
+    }
+#endif
+    return 0;
+}
+
 int test_jit_llvm_intrinsic_powi_f32_i32(void) {
     if (!require_intrinsic_blob("llvm.powi.f32.i32"))
         return 0;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -142,6 +142,7 @@ int test_jit_varargs_declared_signature_call(void);
 int test_jit_varargs_undeclared_signature_call(void);
 int test_jit_const_gep_vtable_function_ptr(void);
 int test_jit_llvm_intrinsic_fabs_f32(void);
+int test_jit_llvm_intrinsic_extended_blob_coverage(void);
 int test_jit_llvm_intrinsic_powi_f32_i32(void);
 int test_jit_llvm_intrinsic_memcpy_memset(void);
 int test_jit_llvm_intrinsic_memmove(void);
@@ -367,6 +368,7 @@ int main(void) {
     RUN_TEST(test_jit_varargs_undeclared_signature_call);
     RUN_TEST(test_jit_const_gep_vtable_function_ptr);
     RUN_TEST(test_jit_llvm_intrinsic_fabs_f32);
+    RUN_TEST(test_jit_llvm_intrinsic_extended_blob_coverage);
     RUN_TEST(test_jit_llvm_intrinsic_powi_f32_i32);
     RUN_TEST(test_jit_llvm_intrinsic_memcpy_memset);
     RUN_TEST(test_jit_llvm_intrinsic_memmove);


### PR DESCRIPTION
## Summary
- add missing aarch64 intrinsic stubs in `src/platform/platform_intrinsic_stubs_aarch64_linux.S` for:
  - `sin/cos/log/log2/log10/exp2` (`f32/f64`)
  - `floor/ceil/trunc/round/rint/nearbyint` (`f32/f64`)
  - `fma/fmuladd` (`f32/f64`), `minnum/maxnum` (`f32/f64`)
  - `abs` (`i32/i64`), `is.fpclass` (`f32/f64`)
- wire these stubs into the intrinsic table on Linux `x86_64` and `aarch64` by using shared blob declarations and `LR_STUB_BLOB` mappings in `src/platform/platform_intrinsics.c`
- add `test_jit_llvm_intrinsic_extended_blob_coverage` to assert all extended intrinsic blobs are registered (`tests/test_jit.c`, `tests/test_main.c`)

## Verification
- Full post-change build and test (single run):
  - `cmake -S . -B build -G Ninja && cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
  - excerpt: `100% tests passed, 0 tests failed out of 27`
  - artifact: `/tmp/test.log`
- AArch64 stub assembly validation on x86 host:
  - `clang --target=aarch64-unknown-linux-gnu -c src/platform/platform_intrinsic_stubs_aarch64_linux.S -o /tmp/liric_aarch64_intrinsic_stubs.o`
  - `nm -g /tmp/liric_aarch64_intrinsic_stubs.o` symbol check script result: `all expected symbols present`
  - artifacts: `/tmp/liric_aarch64_intrinsic_stubs.o`, `/tmp/aarch64_symbols.txt`, `/tmp/aarch64_expected.txt`
