### PR TITLE
fix: Streaming .bc decoder with direct stencil emission (fixes #290)

### DIFF
--- a/src/bc_decode.h
+++ b/src/bc_decode.h
@@ -13,6 +13,15 @@ bool lr_bc_is_bitcode(const uint8_t *data, size_t len);
 /* Native LLVM bitcode parser — always available (no LLVM dependency). */
 bool lr_bc_parser_available(void);
 
+typedef int (*lr_bc_inst_callback_t)(lr_func_t *func, lr_block_t *block,
+                                     const lr_inst_t *inst, void *ctx);
+
+/* Parses LLVM bitcode while invoking `on_inst` for each decoded instruction. */
+lr_module_t *lr_parse_bc_data_streaming(const uint8_t *data, size_t len,
+                                        lr_arena_t *arena,
+                                        lr_bc_inst_callback_t on_inst, void *ctx,
+                                        char *err, size_t errlen);
+
 /* Parses LLVM bitcode into an lr_module_t (native reader, zero dependencies). */
 lr_module_t *lr_parse_bc_data(const uint8_t *data, size_t len,
                                lr_arena_t *arena, char *err, size_t errlen);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -191,6 +191,8 @@ int test_wasm_jit_loop(void);
 int test_wasm_jit_call(void);
 int test_bc_parse_api_ret_42(void);
 int test_bc_parse_auto_loop_phi(void);
+int test_bc_streaming_callback_collects_opcodes(void);
+int test_bc_streaming_callback_abort_propagates_error(void);
 int test_session_direct_ret_42(void);
 int test_session_add_args(void);
 int test_session_arithmetic_chain(void);
@@ -443,6 +445,8 @@ int main(void) {
     fprintf(stderr, "\nBC Parser tests:\n");
     RUN_TEST(test_bc_parse_api_ret_42);
     RUN_TEST(test_bc_parse_auto_loop_phi);
+    RUN_TEST(test_bc_streaming_callback_collects_opcodes);
+    RUN_TEST(test_bc_streaming_callback_abort_propagates_error);
 
     fprintf(stderr, "\nSession API tests:\n");
     RUN_TEST(test_session_direct_ret_42);


### PR DESCRIPTION
## Summary

- add `lr_parse_bc_data_streaming(...)` to expose per-instruction callback hooks during native bitcode decode
- wire callback storage into the bitcode decoder and invoke it via a single `bc_emit_inst(...)` path for every decoded function instruction
- propagate callback failures as parse errors (`"bitcode streaming callback failed"`) to support deterministic fallback/error handling
- add BC parser tests for streaming callback opcode collection and callback-abort error propagation

## Verification

- Command:
  ```bash
  cmake -S . -B build -G Ninja && cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log && rg -n "(FAIL|Failed|Error|error:)" /tmp/test.log || true
  ```
- Output excerpt:
  ```text
  100% tests passed, 0 tests failed out of 29
  Total Test time (real) =   2.54 sec
  ```
- Artifact:
  - `/tmp/test.log`
