### PR TITLE
fix: Streaming WASM compiler with direct stencil emission (fixes #291)

### DIFF
--- a/src/wasm_to_ir.h
+++ b/src/wasm_to_ir.h
@@ -4,6 +4,15 @@
 #include "ir.h"
 #include "wasm_decode.h"
 
+typedef int (*lr_wasm_inst_callback_t)(lr_func_t *func, lr_block_t *block,
+                                        const lr_inst_t *inst, void *ctx);
+
+lr_module_t *lr_wasm_to_ir_streaming(const lr_wasm_module_t *wmod,
+                                     lr_arena_t *arena,
+                                     lr_wasm_inst_callback_t on_inst,
+                                     void *ctx,
+                                     char *err, size_t errlen);
+
 lr_module_t *lr_wasm_to_ir(const lr_wasm_module_t *wmod,
                             lr_arena_t *arena, char *err, size_t errlen);
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -184,6 +184,8 @@ int test_wasm_decode_add(void);
 int test_wasm_decode_invalid_magic(void);
 int test_wasm_ir_ret_42(void);
 int test_wasm_ir_add_args(void);
+int test_wasm_streaming_callback_collects_opcodes(void);
+int test_wasm_streaming_callback_abort_propagates_error(void);
 int test_wasm_jit_ret_42(void);
 int test_wasm_jit_add_args(void);
 int test_wasm_jit_branch(void);
@@ -434,6 +436,8 @@ int main(void) {
     fprintf(stderr, "\nWASM IR tests:\n");
     RUN_TEST(test_wasm_ir_ret_42);
     RUN_TEST(test_wasm_ir_add_args);
+    RUN_TEST(test_wasm_streaming_callback_collects_opcodes);
+    RUN_TEST(test_wasm_streaming_callback_abort_propagates_error);
 
     fprintf(stderr, "\nWASM JIT tests:\n");
     RUN_TEST(test_wasm_jit_ret_42);


### PR DESCRIPTION
## Summary

- add a streaming WASM-to-IR API (`lr_wasm_to_ir_streaming(...)`) with a per-instruction callback hook
- invoke the callback from a single instruction append path for every emitted WASM-lowered IR instruction
- propagate callback aborts as deterministic conversion failures with `wasm streaming callback failed`
- keep existing behavior by routing `lr_wasm_to_ir(...)` through the new streaming function with `NULL` callback
- add WASM tests for callback opcode collection and callback-abort error propagation

## Verification

- Command:
  ```bash
  cmake -S . -B build -G Ninja && cmake --build build -j$(nproc)
  ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log && rg -n "(FAIL|Failed|Error|error:)" /tmp/test.log || true
  ```
- Output excerpt:
  ```text
  100% tests passed, 0 tests failed out of 29
  Total Test time (real) =   2.56 sec
  ```
- Artifact:
  - `/tmp/test.log`
