### PR TITLE
fix: Supernode stencils: fused multi-instruction templates (fixes #294)

### DIFF
--- a/src/platform/cp_templates_x86_64.S
+++ b/src/platform/cp_templates_x86_64.S
@@ -74,6 +74,30 @@ lr_cp_add_i32_begin:
     mov [rbp + 0x33333333], eax
 lr_cp_add_i32_end:
 
+/* ---- add+ret i64 supernode ---- */
+
+.globl lr_cp_add_ret_i64_begin
+.globl lr_cp_add_ret_i64_end
+lr_cp_add_ret_i64_begin:
+    mov rax, [rbp + 0x11111111]
+    add rax, [rbp + 0x22222222]
+    mov rsp, rbp
+    pop rbp
+    ret
+lr_cp_add_ret_i64_end:
+
+/* ---- add+ret i32 supernode ---- */
+
+.globl lr_cp_add_ret_i32_begin
+.globl lr_cp_add_ret_i32_end
+lr_cp_add_ret_i32_begin:
+    mov eax, [rbp + 0x11111111]
+    add eax, [rbp + 0x22222222]
+    mov rsp, rbp
+    pop rbp
+    ret
+lr_cp_add_ret_i32_end:
+
 /* ---- sub i64 ---- */
 
 .globl lr_cp_sub_i64_begin

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -255,6 +255,8 @@ int test_cp_shift_ops(void);
 int test_cp_sdiv_srem(void);
 int test_cp_fallback_to_isel(void);
 int test_cp_immediate_operand(void);
+int test_cp_add_ret_supernode_i32(void);
+int test_cp_add_ret_supernode_i64(void);
 #endif
 
 #if defined(__linux__) && (defined(__x86_64__) || defined(_M_X64))
@@ -524,6 +526,8 @@ int main(void) {
     RUN_TEST(test_cp_sdiv_srem);
     RUN_TEST(test_cp_fallback_to_isel);
     RUN_TEST(test_cp_immediate_operand);
+    RUN_TEST(test_cp_add_ret_supernode_i32);
+    RUN_TEST(test_cp_add_ret_supernode_i64);
 #endif
 
 #if defined(__linux__) && (defined(__x86_64__) || defined(_M_X64))


### PR DESCRIPTION
## Summary
- Add x86_64 copy-and-patch supernode templates for fused `add+ret` on `i32` and `i64`.
- Match `add` followed by `ret` of the same vreg in `x86_64_compile_func_cp()` and emit the fused template while skipping the standalone `ret` instruction.
- Add copy-and-patch tests that validate both runtime correctness and emitted-code evidence for the new supernode path, and register them in `test_main`.

## Verification
```bash
cmake -S . -B build -G Ninja && cmake --build build -j$(nproc)
ctest --test-dir build -R liric_tests --output-on-failure 2>&1 | tee /tmp/test.log
grep -nE "FAIL:|FAILED|Errors while running" /tmp/test.log || true
```

Output excerpts:
- `1/1 Test #1: liric_tests ... Passed`
- `100% tests passed, 0 tests failed out of 1`
- `grep` produced no matches.

Artifacts:
- `/tmp/test.log`
