### PR TITLE
fix: streaming: add global_offset to lr_operand_desc_t and lr_phi_cop (fixes #319)

### DIFF
--- a/include/liric/liric.h
+++ b/include/liric/liric.h
@@ -45,13 +45,20 @@ lr_type_t *lr_type_func_new(lr_module_t *m, lr_type_t *ret,
                               lr_type_t **params, uint32_t num_params,
                               bool vararg);
 
-#define LR_VREG(v, t)    ((lr_operand_desc_t){ .kind = LR_OP_KIND_VREG, .vreg = (v), .type = (t) })
-#define LR_IMM(v, t)     ((lr_operand_desc_t){ .kind = LR_OP_KIND_IMM_I64, .imm_i64 = (v), .type = (t) })
-#define LR_IMM_F(v, t)   ((lr_operand_desc_t){ .kind = LR_OP_KIND_IMM_F64, .imm_f64 = (v), .type = (t) })
-#define LR_BLOCK(id)     ((lr_operand_desc_t){ .kind = LR_OP_KIND_BLOCK, .block_id = (id), .type = NULL })
-#define LR_GLOBAL(id, t) ((lr_operand_desc_t){ .kind = LR_OP_KIND_GLOBAL, .global_id = (id), .type = (t) })
-#define LR_NULL(t)       ((lr_operand_desc_t){ .kind = LR_OP_KIND_NULL, .type = (t) })
-#define LR_UNDEF(t)      ((lr_operand_desc_t){ .kind = LR_OP_KIND_UNDEF, .type = (t) })
+#define LR_VREG(v, t) \
+    ((lr_operand_desc_t){ .kind = LR_OP_KIND_VREG, .vreg = (v), .type = (t), .global_offset = 0 })
+#define LR_IMM(v, t) \
+    ((lr_operand_desc_t){ .kind = LR_OP_KIND_IMM_I64, .imm_i64 = (v), .type = (t), .global_offset = 0 })
+#define LR_IMM_F(v, t) \
+    ((lr_operand_desc_t){ .kind = LR_OP_KIND_IMM_F64, .imm_f64 = (v), .type = (t), .global_offset = 0 })
+#define LR_BLOCK(id) \
+    ((lr_operand_desc_t){ .kind = LR_OP_KIND_BLOCK, .block_id = (id), .type = NULL, .global_offset = 0 })
+#define LR_GLOBAL(id, t) \
+    ((lr_operand_desc_t){ .kind = LR_OP_KIND_GLOBAL, .global_id = (id), .type = (t), .global_offset = 0 })
+#define LR_NULL(t) \
+    ((lr_operand_desc_t){ .kind = LR_OP_KIND_NULL, .type = (t), .global_offset = 0 })
+#define LR_UNDEF(t) \
+    ((lr_operand_desc_t){ .kind = LR_OP_KIND_UNDEF, .type = (t), .global_offset = 0 })
 
 /* Comparison predicates */
 enum {

--- a/include/liric/liric_ir_shared.h
+++ b/include/liric/liric_ir_shared.h
@@ -71,7 +71,13 @@ typedef struct lr_operand_desc {
         uint32_t global_id;
     };
     struct lr_type *type;
+    int64_t global_offset;
 } lr_operand_desc_t;
+
+typedef struct lr_phi_copy_desc {
+    uint32_t dest_vreg;
+    lr_operand_desc_t src_op;
+} lr_phi_copy_desc_t;
 
 enum {
     LR_OP_KIND_VREG    = 0,

--- a/src/session.c
+++ b/src/session.c
@@ -150,6 +150,7 @@ static lr_operand_t desc_to_op(const lr_operand_desc_t *d) {
     }
     op.kind = (lr_operand_kind_t)d->kind;
     op.type = d->type;
+    op.global_offset = d->global_offset;
     switch (d->kind) {
     case LR_OP_KIND_VREG:
         op.vreg = d->vreg;

--- a/tests/test_header_shared.c
+++ b/tests/test_header_shared.c
@@ -23,6 +23,8 @@ int test_headers_share_opcode_and_operand_types(void) {
     lr_operand_desc_t lhs = LR_VREG(7, NULL);
     lr_operand_desc_t rhs = LR_IMM(9, NULL);
     lr_operand_desc_t ops[2] = { lhs, rhs };
+    lr_operand_desc_t g = LR_GLOBAL(3, NULL);
+    lr_phi_copy_desc_t phi_copy = { .dest_vreg = 11, .src_op = g };
     lr_inst_desc_t inst = {0};
     lr_op_t public_op = LR_OP_ADD;
     lr_opcode_t internal_op = (lr_opcode_t)public_op;
@@ -34,6 +36,11 @@ int test_headers_share_opcode_and_operand_types(void) {
 
     TEST_ASSERT_EQ(lhs.kind, LR_OP_KIND_VREG, "LR_VREG sets operand kind");
     TEST_ASSERT_EQ(rhs.kind, LR_OP_KIND_IMM_I64, "LR_IMM sets operand kind");
+    TEST_ASSERT_EQ(lhs.global_offset, 0, "LR_VREG zero-initializes global_offset");
+    TEST_ASSERT_EQ(rhs.global_offset, 0, "LR_IMM zero-initializes global_offset");
+    TEST_ASSERT_EQ(g.global_offset, 0, "LR_GLOBAL zero-initializes global_offset");
+    TEST_ASSERT_EQ(phi_copy.dest_vreg, 11, "phi copy desc stores destination vreg");
+    TEST_ASSERT_EQ(phi_copy.src_op.kind, LR_OP_KIND_GLOBAL, "phi copy desc stores source operand");
     TEST_ASSERT_EQ(inst.op, LR_OP_ADD, "session instruction uses shared opcode enum");
     TEST_ASSERT_EQ(internal_op, LR_OP_ADD, "public lr_op_t aliases internal opcode enum");
     TEST_ASSERT(pred == LR_FCMP_UEQ, "floating predicate enum is shared");

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -207,6 +207,7 @@ int test_session_icmp_branch(void);
 int test_session_alloca_load_store(void);
 int test_session_loop_phi(void);
 int test_session_call(void);
+int test_session_operand_global_offset_propagates_to_ir(void);
 int test_session_select(void);
 int test_session_ir_print(void);
 int test_session_ll_compile(void);
@@ -472,6 +473,7 @@ int main(void) {
     RUN_TEST(test_session_alloca_load_store);
     RUN_TEST(test_session_loop_phi);
     RUN_TEST(test_session_call);
+    RUN_TEST(test_session_operand_global_offset_propagates_to_ir);
     RUN_TEST(test_session_select);
     RUN_TEST(test_session_ir_print);
     RUN_TEST(test_session_ll_compile);


### PR DESCRIPTION
## Summary
- add `global_offset` to `lr_operand_desc_t` in `include/liric/liric_ir_shared.h`
- add shared `lr_phi_copy_desc_t` (`dest_vreg` + `src_op`) in `include/liric/liric_ir_shared.h`
- make operand descriptor macros in `include/liric/liric.h` explicitly zero-initialize `global_offset`
- propagate descriptor offsets in `src/session.c` via `desc_to_op()`
- extend coverage in `tests/test_header_shared.c` and `tests/test_session.c` (registered in `tests/test_main.c`)

## Verification
- Command:
```bash
{ cmake -S . -B build -G Ninja && cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure; } 2>&1 | tee /tmp/test.log
grep -nEi "error:|failed|fail" /tmp/test.log || true
```
- Output excerpts:
```text
100% tests passed, 0 tests failed out of 29
117:100% tests passed, 0 tests failed out of 29
```
- Artifact:
  - `/tmp/test.log`
