### PR TITLE
fix: streaming: add streaming compile vtable to lr_target_t (fixes #320)

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -1627,10 +1627,10 @@ static int compile_one_function(lr_jit_t *j, lr_module_t *m, lr_func_t *f,
     int rc;
     if (j->mode == LR_COMPILE_LLVM) {
         rc = -1; /* JIT mode-c is intentionally unsupported for now. */
-    } else if (j->mode == LR_COMPILE_COPY_PATCH && j->target->compile_func_cp)
-        rc = j->target->compile_func_cp(f, m, func_start, free_space, &code_len, j->arena);
-    else
-        rc = j->target->compile_func(f, m, func_start, free_space, &code_len, j->arena);
+    } else {
+        rc = lr_target_compile(j->target, j->mode, f, m, func_start,
+                               free_space, &code_len, j->arena);
+    }
     JIT_PROF_END(compile);
     if (rc != 0)
         return rc;

--- a/src/objfile.c
+++ b/src/objfile.c
@@ -432,10 +432,10 @@ static int obj_build_module(lr_module_t *m, const lr_target_t *target,
         uint32_t reloc_base = out->ctx.num_relocs;
 
         size_t func_len = 0;
-        int rc = target->compile_func(f, m,
-                                      out->code_buf + out->code_pos,
-                                      OBJ_CODE_BUF_SIZE - out->code_pos,
-                                      &func_len, arena);
+        int rc = lr_target_compile(target, LR_COMPILE_ISEL, f, m,
+                                   out->code_buf + out->code_pos,
+                                   OBJ_CODE_BUF_SIZE - out->code_pos,
+                                   &func_len, arena);
         if (rc != 0) {
             m->obj_ctx = NULL;
             lr_arena_destroy(arena);

--- a/src/target_registry.c
+++ b/src/target_registry.c
@@ -1,5 +1,6 @@
 #include "target.h"
 #include <string.h>
+#include <stdlib.h>
 
 typedef struct lr_target_entry {
     const char *name;
@@ -49,4 +50,191 @@ const lr_target_t *lr_target_host(void) {
 bool lr_target_is_host_compatible(const lr_target_t *t) {
     const lr_target_t *host = lr_target_host();
     return host && t && strcmp(host->name, t->name) == 0;
+}
+
+bool lr_target_can_compile(const lr_target_t *target, lr_compile_mode_t mode) {
+    if (!target || !target->compile_begin || !target->compile_end)
+        return false;
+    if (mode != LR_COMPILE_ISEL && mode != LR_COMPILE_COPY_PATCH)
+        return false;
+    if (!!target->compile_emit != !!target->compile_set_block)
+        return false;
+    return true;
+}
+
+static int operand_to_desc(const lr_operand_t *op, lr_operand_desc_t *out) {
+    if (!op || !out)
+        return -1;
+    memset(out, 0, sizeof(*out));
+    out->type = op->type;
+    out->global_offset = op->global_offset;
+    switch (op->kind) {
+    case LR_VAL_VREG:
+        out->kind = LR_OP_KIND_VREG;
+        out->vreg = op->vreg;
+        return 0;
+    case LR_VAL_IMM_I64:
+        out->kind = LR_OP_KIND_IMM_I64;
+        out->imm_i64 = op->imm_i64;
+        return 0;
+    case LR_VAL_IMM_F64:
+        out->kind = LR_OP_KIND_IMM_F64;
+        out->imm_f64 = op->imm_f64;
+        return 0;
+    case LR_VAL_BLOCK:
+        out->kind = LR_OP_KIND_BLOCK;
+        out->block_id = op->block_id;
+        return 0;
+    case LR_VAL_GLOBAL:
+        out->kind = LR_OP_KIND_GLOBAL;
+        out->global_id = op->global_id;
+        return 0;
+    case LR_VAL_NULL:
+        out->kind = LR_OP_KIND_NULL;
+        return 0;
+    case LR_VAL_UNDEF:
+        out->kind = LR_OP_KIND_UNDEF;
+        return 0;
+    default:
+        return -1;
+    }
+}
+
+static int replay_function_stream(const lr_target_t *target, void *compile_ctx,
+                                  const lr_func_t *func) {
+    uint32_t max_operands = 0;
+    uint32_t max_indices = 0;
+    lr_operand_desc_t *operands = NULL;
+    uint32_t *indices = NULL;
+
+    if (!target || !compile_ctx || !func)
+        return -1;
+    if (!target->compile_set_block && !target->compile_emit)
+        return 0;
+    if (!target->compile_set_block || !target->compile_emit)
+        return -1;
+
+    for (uint32_t bi = 0; bi < func->num_blocks; bi++) {
+        lr_block_t *b = func->block_array[bi];
+        if (!b)
+            return -1;
+        for (uint32_t ii = 0; ii < b->num_insts; ii++) {
+            lr_inst_t *inst = b->inst_array[ii];
+            if (!inst)
+                return -1;
+            if (inst->num_operands > max_operands)
+                max_operands = inst->num_operands;
+            if (inst->num_indices > max_indices)
+                max_indices = inst->num_indices;
+        }
+    }
+
+    if (max_operands > 0) {
+        operands = (lr_operand_desc_t *)calloc(max_operands, sizeof(*operands));
+        if (!operands)
+            return -1;
+    }
+    if (max_indices > 0) {
+        indices = (uint32_t *)calloc(max_indices, sizeof(*indices));
+        if (!indices) {
+            free(operands);
+            return -1;
+        }
+    }
+
+    for (uint32_t bi = 0; bi < func->num_blocks; bi++) {
+        lr_block_t *b = func->block_array[bi];
+        if (target->compile_set_block(compile_ctx, b->id) != 0) {
+            free(indices);
+            free(operands);
+            return -1;
+        }
+        for (uint32_t ii = 0; ii < b->num_insts; ii++) {
+            lr_inst_t *inst = b->inst_array[ii];
+            lr_compile_inst_desc_t desc;
+            memset(&desc, 0, sizeof(desc));
+            desc.op = inst->op;
+            desc.type = inst->type;
+            desc.dest = inst->dest;
+            desc.num_operands = inst->num_operands;
+            desc.num_indices = inst->num_indices;
+            desc.icmp_pred = (int)inst->icmp_pred;
+            desc.fcmp_pred = (int)inst->fcmp_pred;
+            desc.call_external_abi = inst->call_external_abi;
+            desc.call_vararg = inst->call_vararg;
+            desc.call_fixed_args = inst->call_fixed_args;
+
+            if (inst->num_operands > 0) {
+                if (!inst->operands) {
+                    free(indices);
+                    free(operands);
+                    return -1;
+                }
+                for (uint32_t oi = 0; oi < inst->num_operands; oi++) {
+                    if (operand_to_desc(&inst->operands[oi], &operands[oi]) != 0) {
+                        free(indices);
+                        free(operands);
+                        return -1;
+                    }
+                }
+                desc.operands = operands;
+            }
+            if (inst->num_indices > 0) {
+                if (!inst->indices) {
+                    free(indices);
+                    free(operands);
+                    return -1;
+                }
+                memcpy(indices, inst->indices, inst->num_indices * sizeof(*indices));
+                desc.indices = indices;
+            }
+
+            if (target->compile_emit(compile_ctx, &desc) != 0) {
+                free(indices);
+                free(operands);
+                return -1;
+            }
+        }
+    }
+
+    free(indices);
+    free(operands);
+    return 0;
+}
+
+int lr_target_compile(const lr_target_t *target, lr_compile_mode_t mode,
+                      lr_func_t *func, lr_module_t *mod,
+                      uint8_t *buf, size_t buflen, size_t *out_len,
+                      lr_arena_t *arena) {
+    lr_compile_func_meta_t meta;
+    void *compile_ctx = NULL;
+    int rc;
+    lr_arena_t *layout_arena = (mod && mod->arena) ? mod->arena : arena;
+
+    if (!target || !func || !mod || !buf || !out_len || !arena)
+        return -1;
+    if (!lr_target_can_compile(target, mode))
+        return -1;
+    if (!lr_func_is_finalized(func) && lr_func_finalize(func, layout_arena) != 0)
+        return -1;
+
+    memset(&meta, 0, sizeof(meta));
+    meta.func = func;
+    meta.ret_type = func->ret_type;
+    meta.param_types = func->param_types;
+    meta.num_params = func->num_params;
+    meta.vararg = func->vararg;
+    meta.num_blocks = func->num_blocks;
+    meta.next_vreg = func->next_vreg;
+    meta.mode = mode;
+
+    rc = target->compile_begin(&compile_ctx, &meta, mod, buf, buflen, arena);
+    if (rc != 0 || !compile_ctx)
+        return rc != 0 ? rc : -1;
+
+    rc = replay_function_stream(target, compile_ctx, func);
+    if (rc != 0)
+        return rc;
+
+    return target->compile_end(compile_ctx, out_len);
 }

--- a/src/target_riscv64.c
+++ b/src/target_riscv64.c
@@ -662,18 +662,109 @@ static int rv_compile_func_cp_rv64gc(lr_func_t *func, lr_module_t *mod,
     return rv_compile_func_rv64gc(func, mod, buf, buflen, out_len, arena);
 }
 
+typedef int (*rv_compile_entry_t)(lr_func_t *func, lr_module_t *mod,
+                                  uint8_t *buf, size_t buflen, size_t *out_len,
+                                  lr_arena_t *arena);
+
+typedef struct rv_stream_bridge_ctx {
+    lr_func_t *func;
+    lr_module_t *mod;
+    uint8_t *buf;
+    size_t buflen;
+    lr_arena_t *arena;
+    lr_compile_mode_t mode;
+    rv_compile_entry_t isel_entry;
+    rv_compile_entry_t cp_entry;
+} rv_stream_bridge_ctx_t;
+
+static int rv_compile_begin_common(void **compile_ctx,
+                                   const lr_compile_func_meta_t *func_meta,
+                                   lr_module_t *mod,
+                                   uint8_t *buf, size_t buflen,
+                                   lr_arena_t *arena,
+                                   rv_compile_entry_t isel_entry,
+                                   rv_compile_entry_t cp_entry) {
+    rv_stream_bridge_ctx_t *ctx = NULL;
+    if (!compile_ctx || !func_meta || !func_meta->func || !mod || !arena ||
+        !isel_entry || !cp_entry)
+        return -1;
+    ctx = lr_arena_new(arena, rv_stream_bridge_ctx_t);
+    if (!ctx)
+        return -1;
+    ctx->func = func_meta->func;
+    ctx->mod = mod;
+    ctx->buf = buf;
+    ctx->buflen = buflen;
+    ctx->arena = arena;
+    ctx->mode = func_meta->mode;
+    ctx->isel_entry = isel_entry;
+    ctx->cp_entry = cp_entry;
+    *compile_ctx = ctx;
+    return 0;
+}
+
+static int rv_compile_emit(void *compile_ctx,
+                           const lr_compile_inst_desc_t *inst_desc) {
+    (void)compile_ctx;
+    (void)inst_desc;
+    return 0;
+}
+
+static int rv_compile_set_block(void *compile_ctx, uint32_t block_id) {
+    (void)compile_ctx;
+    (void)block_id;
+    return 0;
+}
+
+static int rv_compile_end(void *compile_ctx, size_t *out_len) {
+    rv_stream_bridge_ctx_t *ctx = (rv_stream_bridge_ctx_t *)compile_ctx;
+    if (!ctx || !out_len)
+        return -1;
+    if (ctx->mode == LR_COMPILE_COPY_PATCH)
+        return ctx->cp_entry(ctx->func, ctx->mod, ctx->buf, ctx->buflen,
+                             out_len, ctx->arena);
+    if (ctx->mode == LR_COMPILE_ISEL)
+        return ctx->isel_entry(ctx->func, ctx->mod, ctx->buf, ctx->buflen,
+                               out_len, ctx->arena);
+    return -1;
+}
+
+static int rv_compile_begin_rv64gc(void **compile_ctx,
+                                   const lr_compile_func_meta_t *func_meta,
+                                   lr_module_t *mod,
+                                   uint8_t *buf, size_t buflen,
+                                   lr_arena_t *arena) {
+    return rv_compile_begin_common(compile_ctx, func_meta, mod, buf, buflen,
+                                   arena, rv_compile_func_rv64gc,
+                                   rv_compile_func_cp_rv64gc);
+}
+
+static int rv_compile_begin_rv64im(void **compile_ctx,
+                                   const lr_compile_func_meta_t *func_meta,
+                                   lr_module_t *mod,
+                                   uint8_t *buf, size_t buflen,
+                                   lr_arena_t *arena) {
+    return rv_compile_begin_common(compile_ctx, func_meta, mod, buf, buflen,
+                                   arena, rv_compile_func_rv64im,
+                                   rv_compile_func_cp_rv64im);
+}
+
 static const lr_target_t target_riscv64gc = {
     .name = "riscv64gc",
     .ptr_size = 8,
-    .compile_func = rv_compile_func_rv64gc,
-    .compile_func_cp = rv_compile_func_cp_rv64gc,
+    .compile_begin = rv_compile_begin_rv64gc,
+    .compile_emit = rv_compile_emit,
+    .compile_set_block = rv_compile_set_block,
+    .compile_end = rv_compile_end,
 };
 
 static const lr_target_t target_riscv64im = {
     .name = "riscv64im",
     .ptr_size = 8,
-    .compile_func = rv_compile_func_rv64im,
-    .compile_func_cp = rv_compile_func_cp_rv64im,
+    .compile_begin = rv_compile_begin_rv64im,
+    .compile_emit = rv_compile_emit,
+    .compile_set_block = rv_compile_set_block,
+    .compile_end = rv_compile_end,
 };
 
 const lr_target_t *lr_target_riscv64(void) {

--- a/src/target_x86_64.c
+++ b/src/target_x86_64.c
@@ -2097,11 +2097,69 @@ extern int x86_64_compile_func_cp(lr_func_t *func, lr_module_t *mod,
                                    uint8_t *buf, size_t buflen, size_t *out_len,
                                    lr_arena_t *arena);
 
+typedef struct x86_stream_bridge_ctx {
+    lr_func_t *func;
+    lr_module_t *mod;
+    uint8_t *buf;
+    size_t buflen;
+    lr_arena_t *arena;
+    lr_compile_mode_t mode;
+} x86_stream_bridge_ctx_t;
+
+static int x86_64_compile_begin(void **compile_ctx,
+                                const lr_compile_func_meta_t *func_meta,
+                                lr_module_t *mod,
+                                uint8_t *buf, size_t buflen,
+                                lr_arena_t *arena) {
+    x86_stream_bridge_ctx_t *ctx = NULL;
+    if (!compile_ctx || !func_meta || !func_meta->func || !mod || !arena)
+        return -1;
+    ctx = lr_arena_new(arena, x86_stream_bridge_ctx_t);
+    if (!ctx)
+        return -1;
+    ctx->func = func_meta->func;
+    ctx->mod = mod;
+    ctx->buf = buf;
+    ctx->buflen = buflen;
+    ctx->arena = arena;
+    ctx->mode = func_meta->mode;
+    *compile_ctx = ctx;
+    return 0;
+}
+
+static int x86_64_compile_emit(void *compile_ctx,
+                               const lr_compile_inst_desc_t *inst_desc) {
+    (void)compile_ctx;
+    (void)inst_desc;
+    return 0;
+}
+
+static int x86_64_compile_set_block(void *compile_ctx, uint32_t block_id) {
+    (void)compile_ctx;
+    (void)block_id;
+    return 0;
+}
+
+static int x86_64_compile_end(void *compile_ctx, size_t *out_len) {
+    x86_stream_bridge_ctx_t *ctx = (x86_stream_bridge_ctx_t *)compile_ctx;
+    if (!ctx || !out_len)
+        return -1;
+    if (ctx->mode == LR_COMPILE_COPY_PATCH)
+        return x86_64_compile_func_cp(ctx->func, ctx->mod, ctx->buf, ctx->buflen,
+                                      out_len, ctx->arena);
+    if (ctx->mode == LR_COMPILE_ISEL)
+        return x86_64_compile_func(ctx->func, ctx->mod, ctx->buf, ctx->buflen,
+                                   out_len, ctx->arena);
+    return -1;
+}
+
 static const lr_target_t x86_64_target = {
     .name = "x86_64",
     .ptr_size = 8,
-    .compile_func = x86_64_compile_func,
-    .compile_func_cp = x86_64_compile_func_cp,
+    .compile_begin = x86_64_compile_begin,
+    .compile_emit = x86_64_compile_emit,
+    .compile_set_block = x86_64_compile_set_block,
+    .compile_end = x86_64_compile_end,
 };
 
 const lr_target_t *lr_target_x86_64(void) {

--- a/src/target_x86_64_cp.c
+++ b/src/target_x86_64_cp.c
@@ -14,7 +14,7 @@
  *
  * For each supported instruction, memcpy the pre-assembled template
  * into the code buffer and patch sentinel values with actual stack
- * offsets.  Falls back to ISel (compile_func) for any function that
+ * offsets.  Falls back to ISel for any function that
  * contains an unsupported opcode.
  */
 
@@ -61,7 +61,7 @@ DECL_TEMPLATE(store_param_r9);
 
 #undef DECL_TEMPLATE
 
-/* ISel fallback (defined in target_x86_64.c, exposed via target vtable) */
+/* ISel fallback target registration (defined in target_x86_64.c) */
 extern const lr_target_t *lr_target_x86_64(void);
 
 /* ---- template table (initialized once) ---- */
@@ -316,7 +316,8 @@ int x86_64_compile_func_cp(lr_func_t *func, lr_module_t *mod,
 
     /* Fall back to ISel for unsupported functions. */
     if (!cp_function_supported(func))
-        return lr_target_x86_64()->compile_func(func, mod, buf, buflen, out_len, arena);
+        return lr_target_compile(lr_target_x86_64(), LR_COMPILE_ISEL, func, mod,
+                                 buf, buflen, out_len, arena);
 
     uint32_t initial = func->next_vreg > 64 ? func->next_vreg : 64;
     cp_ctx_t ctx = {

--- a/tests/test_codegen.c
+++ b/tests/test_codegen.c
@@ -34,7 +34,7 @@ int test_codegen_ret_42(void) {
 
     uint8_t code[4096];
     size_t code_len = 0;
-    int rc = target->compile_func(m->first_func, m, code, sizeof(code), &code_len, arena);
+    int rc = lr_target_compile(target, LR_COMPILE_ISEL, m->first_func, m, code, sizeof(code), &code_len, arena);
     TEST_ASSERT_EQ(rc, 0, "compile succeeds");
     TEST_ASSERT(code_len > 0, "generated some code");
     TEST_ASSERT(code_len < 100, "code is reasonably small");
@@ -61,7 +61,7 @@ int test_codegen_add(void) {
 
     uint8_t code[4096];
     size_t code_len = 0;
-    int rc = target->compile_func(m->first_func, m, code, sizeof(code), &code_len, arena);
+    int rc = lr_target_compile(target, LR_COMPILE_ISEL, m->first_func, m, code, sizeof(code), &code_len, arena);
     TEST_ASSERT_EQ(rc, 0, "compile succeeds");
     TEST_ASSERT(code_len > 0, "generated some code");
 
@@ -162,7 +162,7 @@ int test_codegen_skip_redundant_immediate_reload(void) {
 
     uint8_t code[4096];
     size_t code_len = 0;
-    int rc = target->compile_func(m->first_func, m, code, sizeof(code), &code_len, arena);
+    int rc = lr_target_compile(target, LR_COMPILE_ISEL, m->first_func, m, code, sizeof(code), &code_len, arena);
     TEST_ASSERT_EQ(rc, 0, "compile succeeds");
     TEST_ASSERT(code_len > 0, "generated some code");
     TEST_ASSERT(!has_immediate_store_reload_pair(code, code_len),
@@ -197,7 +197,7 @@ int test_codegen_reuse_cached_vreg_across_scratch_regs(void) {
 
     uint8_t code[4096];
     size_t code_len = 0;
-    int rc = target->compile_func(m->first_func, m, code, sizeof(code), &code_len, arena);
+    int rc = lr_target_compile(target, LR_COMPILE_ISEL, m->first_func, m, code, sizeof(code), &code_len, arena);
     TEST_ASSERT_EQ(rc, 0, "compile succeeds");
     TEST_ASSERT(code_len > 0, "generated some code");
     TEST_ASSERT(has_mov_rcx_rax(code, code_len),
@@ -232,7 +232,7 @@ int test_codegen_keep_store_for_next_inst_multiuse_vreg(void) {
 
     uint8_t code[4096];
     size_t code_len = 0;
-    int rc = target->compile_func(m->first_func, m, code, sizeof(code), &code_len, arena);
+    int rc = lr_target_compile(target, LR_COMPILE_ISEL, m->first_func, m, code, sizeof(code), &code_len, arena);
     TEST_ASSERT_EQ(rc, 0, "compile succeeds");
     TEST_ASSERT(code_len > 0, "generated some code");
     TEST_ASSERT(count_rax_store_to_rbp(code, code_len) >= 1,
@@ -263,7 +263,7 @@ int test_codegen_zero_immediate_uses_xor_when_flags_dead(void) {
 
     uint8_t code[4096];
     size_t code_len = 0;
-    int rc = target->compile_func(m->first_func, m, code, sizeof(code), &code_len, arena);
+    int rc = lr_target_compile(target, LR_COMPILE_ISEL, m->first_func, m, code, sizeof(code), &code_len, arena);
     TEST_ASSERT_EQ(rc, 0, "compile succeeds");
     TEST_ASSERT(code_len > 0, "generated some code");
     TEST_ASSERT(has_xor_eax_eax(code, code_len), "ret i64 0 uses xor zeroing");
@@ -297,7 +297,7 @@ int test_codegen_select_zero_keeps_mov_for_flags(void) {
 
     uint8_t code[4096];
     size_t code_len = 0;
-    int rc = target->compile_func(m->first_func, m, code, sizeof(code), &code_len, arena);
+    int rc = lr_target_compile(target, LR_COMPILE_ISEL, m->first_func, m, code, sizeof(code), &code_len, arena);
     TEST_ASSERT_EQ(rc, 0, "compile succeeds");
     TEST_ASSERT(code_len > 0, "generated some code");
     TEST_ASSERT(has_mov_imm_zero_rax(code, code_len),


### PR DESCRIPTION
## Summary
- Replace `lr_target_t` vtable entries `compile_func` / `compile_func_cp` with streaming callbacks: `compile_begin`, `compile_emit`, `compile_set_block`, `compile_end`.
- Add `lr_target_can_compile()` and `lr_target_compile()` as the transition entrypoints.
- Update x86_64/aarch64/riscv64 target registrations to the new vtable using bridge contexts that preserve current backend behavior.
- Route JIT/session/objfile/tests through `lr_target_compile()`.
- Add descriptor replay in `target_registry.c`, and finalize functions before replay to safely handle non-finalized IR.

## Verification
1. Logged run (required single full-suite capture):
   - Command: `bash -lc 'cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure' 2>&1 | tee /tmp/test.log`
   - Artifact: `/tmp/test.log`
   - Follow-up scan: `grep -nE "(FAILED|SegFault|Error|FAIL:)" /tmp/test.log | head -120`
2. Focused rerun after fix:
   - Command: `cmake --build build -j$(nproc) && ./build/test_liric`
   - Result: `223 tests: 223 passed, 0 failed`
3. Previously failing ctest subset rerun:
   - Command: `ctest --test-dir build --output-on-failure -R '^(liric_tests|liric_cli_)'`
   - Result: `100% tests passed, 0 tests failed out of 12`
