### PR TITLE
fix: streaming: aarch64 streaming backend (fixes #322)

### DIFF
--- a/src/target_aarch64.c
+++ b/src/target_aarch64.c
@@ -1719,7 +1719,173 @@ typedef struct a64_stream_bridge_ctx {
     size_t buflen;
     lr_arena_t *arena;
     lr_compile_mode_t mode;
+    lr_func_t stream_func;
+    uint32_t *owned_param_vregs;
+    struct a64_stream_block_builder **blocks;
+    uint32_t block_cap;
+    uint32_t max_block_id_plus1;
+    uint32_t current_block_id;
+    bool has_current_block;
+    bool saw_stream_input;
 } a64_stream_bridge_ctx_t;
+
+typedef struct a64_stream_block_builder {
+    lr_block_t block;
+    lr_inst_t **inst_array;
+    uint32_t inst_cap;
+} a64_stream_block_builder_t;
+
+static lr_operand_t a64_stream_operand_from_desc(const lr_operand_desc_t *desc) {
+    lr_operand_t out;
+    memset(&out, 0, sizeof(out));
+    if (!desc) {
+        out.kind = LR_VAL_UNDEF;
+        return out;
+    }
+    out.kind = (lr_operand_kind_t)desc->kind;
+    out.type = desc->type;
+    out.global_offset = desc->global_offset;
+    switch (desc->kind) {
+    case LR_OP_KIND_VREG:
+        out.vreg = desc->vreg;
+        break;
+    case LR_OP_KIND_IMM_I64:
+        out.imm_i64 = desc->imm_i64;
+        break;
+    case LR_OP_KIND_IMM_F64:
+        out.imm_f64 = desc->imm_f64;
+        break;
+    case LR_OP_KIND_BLOCK:
+        out.block_id = desc->block_id;
+        break;
+    case LR_OP_KIND_GLOBAL:
+        out.global_id = desc->global_id;
+        break;
+    default:
+        break;
+    }
+    return out;
+}
+
+static int a64_stream_ensure_block_capacity(a64_stream_bridge_ctx_t *ctx,
+                                            uint32_t need) {
+    a64_stream_block_builder_t **new_blocks = NULL;
+    uint32_t new_cap;
+    if (!ctx)
+        return -1;
+    if (need <= ctx->block_cap)
+        return 0;
+    new_cap = ctx->block_cap == 0 ? 8u : ctx->block_cap;
+    while (new_cap < need)
+        new_cap *= 2u;
+    new_blocks = lr_arena_array(ctx->arena, a64_stream_block_builder_t *, new_cap);
+    if (!new_blocks)
+        return -1;
+    if (ctx->block_cap > 0)
+        memcpy(new_blocks, ctx->blocks, sizeof(*new_blocks) * ctx->block_cap);
+    ctx->blocks = new_blocks;
+    ctx->block_cap = new_cap;
+    return 0;
+}
+
+static a64_stream_block_builder_t *a64_stream_get_or_create_block(
+        a64_stream_bridge_ctx_t *ctx, uint32_t block_id) {
+    a64_stream_block_builder_t *b = NULL;
+    char name_buf[32];
+    if (!ctx)
+        return NULL;
+    if (a64_stream_ensure_block_capacity(ctx, block_id + 1u) != 0)
+        return NULL;
+    b = ctx->blocks[block_id];
+    if (b)
+        return b;
+    b = lr_arena_new(ctx->arena, a64_stream_block_builder_t);
+    if (!b)
+        return NULL;
+    (void)snprintf(name_buf, sizeof(name_buf), "b%u", block_id);
+    b->block.id = block_id;
+    b->block.name = lr_arena_strdup(ctx->arena, name_buf, strlen(name_buf));
+    b->block.func = &ctx->stream_func;
+    if (!b->block.name)
+        return NULL;
+    ctx->blocks[block_id] = b;
+    if (ctx->max_block_id_plus1 < block_id + 1u)
+        ctx->max_block_id_plus1 = block_id + 1u;
+    return b;
+}
+
+static int a64_stream_push_inst_ref(a64_stream_bridge_ctx_t *ctx,
+                                    a64_stream_block_builder_t *block,
+                                    lr_inst_t *inst) {
+    lr_inst_t **new_refs = NULL;
+    uint32_t new_cap;
+    if (!ctx || !block || !inst)
+        return -1;
+    if (block->block.num_insts == block->inst_cap) {
+        new_cap = block->inst_cap == 0 ? 16u : block->inst_cap * 2u;
+        new_refs = lr_arena_array(ctx->arena, lr_inst_t *, new_cap);
+        if (!new_refs)
+            return -1;
+        if (block->inst_cap > 0)
+            memcpy(new_refs, block->inst_array, sizeof(*new_refs) * block->inst_cap);
+        block->inst_array = new_refs;
+        block->inst_cap = new_cap;
+    }
+    block->inst_array[block->block.num_insts++] = inst;
+    return 0;
+}
+
+static void a64_stream_note_vregs(a64_stream_bridge_ctx_t *ctx,
+                                  const lr_compile_inst_desc_t *inst_desc) {
+    if (!ctx || !inst_desc)
+        return;
+    if (inst_desc->dest >= ctx->stream_func.next_vreg &&
+        inst_desc->dest != 0) {
+        ctx->stream_func.next_vreg = inst_desc->dest + 1u;
+    }
+    for (uint32_t i = 0; i < inst_desc->num_operands; i++) {
+        const lr_operand_desc_t *op = &inst_desc->operands[i];
+        if (op->kind != LR_OP_KIND_VREG)
+            continue;
+        if (op->vreg >= ctx->stream_func.next_vreg)
+            ctx->stream_func.next_vreg = op->vreg + 1u;
+    }
+}
+
+static int a64_stream_finalize_function(a64_stream_bridge_ctx_t *ctx) {
+    lr_block_t **block_array = NULL;
+    if (!ctx || !ctx->saw_stream_input || ctx->max_block_id_plus1 == 0)
+        return -1;
+
+    block_array = lr_arena_array(ctx->arena, lr_block_t *, ctx->max_block_id_plus1);
+    if (!block_array)
+        return -1;
+
+    for (uint32_t i = 0; i < ctx->max_block_id_plus1; i++) {
+        a64_stream_block_builder_t *b = ctx->blocks ? ctx->blocks[i] : NULL;
+        if (!b)
+            return -1;
+        b->block.inst_array = b->inst_array;
+        b->block.func = &ctx->stream_func;
+        if (i + 1u < ctx->max_block_id_plus1) {
+            a64_stream_block_builder_t *next_b = ctx->blocks[i + 1u];
+            if (!next_b)
+                return -1;
+            b->block.next = &next_b->block;
+        } else {
+            b->block.next = NULL;
+        }
+        block_array[i] = &b->block;
+    }
+
+    ctx->stream_func.is_decl = false;
+    ctx->stream_func.num_blocks = ctx->max_block_id_plus1;
+    ctx->stream_func.first_block = &ctx->blocks[0]->block;
+    ctx->stream_func.last_block = &ctx->blocks[ctx->max_block_id_plus1 - 1u]->block;
+    ctx->stream_func.block_array = block_array;
+
+    return lr_func_finalize(&ctx->stream_func, ctx->arena);
+}
 
 static int aarch64_compile_begin(void **compile_ctx,
                                  const lr_compile_func_meta_t *func_meta,
@@ -1727,7 +1893,7 @@ static int aarch64_compile_begin(void **compile_ctx,
                                  uint8_t *buf, size_t buflen,
                                  lr_arena_t *arena) {
     a64_stream_bridge_ctx_t *ctx = NULL;
-    if (!compile_ctx || !func_meta || !func_meta->func || !mod || !arena)
+    if (!compile_ctx || !func_meta || !mod || !arena)
         return -1;
     ctx = lr_arena_new(arena, a64_stream_bridge_ctx_t);
     if (!ctx)
@@ -1738,32 +1904,133 @@ static int aarch64_compile_begin(void **compile_ctx,
     ctx->buflen = buflen;
     ctx->arena = arena;
     ctx->mode = func_meta->mode;
+    if (func_meta->func && func_meta->func->name) {
+        ctx->stream_func.name = func_meta->func->name;
+    } else {
+        ctx->stream_func.name = lr_arena_strdup(ctx->arena, "__liric_stream_fn",
+                                                strlen("__liric_stream_fn"));
+        if (!ctx->stream_func.name)
+            return -1;
+    }
+    ctx->stream_func.ret_type = func_meta->ret_type ? func_meta->ret_type
+                                                    : mod->type_void;
+    ctx->stream_func.param_types = func_meta->param_types;
+    ctx->stream_func.num_params = func_meta->num_params;
+    ctx->stream_func.vararg = func_meta->vararg;
+    ctx->stream_func.next_vreg = func_meta->next_vreg;
+    if (func_meta->func && func_meta->func->param_vregs) {
+        ctx->stream_func.param_vregs = func_meta->func->param_vregs;
+    } else if (func_meta->num_params > 0) {
+        ctx->owned_param_vregs = lr_arena_array(ctx->arena, uint32_t,
+                                                func_meta->num_params);
+        if (!ctx->owned_param_vregs)
+            return -1;
+        for (uint32_t i = 0; i < func_meta->num_params; i++) {
+            ctx->owned_param_vregs[i] = i + 1u;
+            if (ctx->stream_func.next_vreg <= i + 1u)
+                ctx->stream_func.next_vreg = i + 2u;
+        }
+        ctx->stream_func.param_vregs = ctx->owned_param_vregs;
+    }
     *compile_ctx = ctx;
     return 0;
 }
 
 static int aarch64_compile_emit(void *compile_ctx,
                                 const lr_compile_inst_desc_t *inst_desc) {
-    (void)compile_ctx;
-    (void)inst_desc;
+    a64_stream_bridge_ctx_t *ctx = (a64_stream_bridge_ctx_t *)compile_ctx;
+    a64_stream_block_builder_t *block = NULL;
+    lr_inst_t *inst = NULL;
+
+    if (!ctx || !inst_desc || !ctx->has_current_block)
+        return -1;
+    if (inst_desc->num_operands > 0 && !inst_desc->operands)
+        return -1;
+    if (inst_desc->num_indices > 0 && !inst_desc->indices)
+        return -1;
+
+    block = a64_stream_get_or_create_block(ctx, ctx->current_block_id);
+    if (!block)
+        return -1;
+
+    inst = lr_arena_new(ctx->arena, lr_inst_t);
+    if (!inst)
+        return -1;
+    inst->op = inst_desc->op;
+    inst->type = inst_desc->type;
+    inst->dest = inst_desc->dest;
+    inst->num_operands = inst_desc->num_operands;
+    inst->num_indices = inst_desc->num_indices;
+    inst->icmp_pred = (lr_icmp_pred_t)inst_desc->icmp_pred;
+    inst->fcmp_pred = (lr_fcmp_pred_t)inst_desc->fcmp_pred;
+    inst->call_external_abi = inst_desc->call_external_abi;
+    inst->call_vararg = inst_desc->call_vararg;
+    inst->call_fixed_args = inst_desc->call_fixed_args;
+
+    if (inst_desc->num_operands > 0) {
+        inst->operands = lr_arena_array(ctx->arena, lr_operand_t,
+                                        inst_desc->num_operands);
+        if (!inst->operands)
+            return -1;
+        for (uint32_t i = 0; i < inst_desc->num_operands; i++) {
+            inst->operands[i] = a64_stream_operand_from_desc(
+                &inst_desc->operands[i]
+            );
+        }
+    }
+    if (inst_desc->num_indices > 0) {
+        inst->indices = lr_arena_array(ctx->arena, uint32_t,
+                                       inst_desc->num_indices);
+        if (!inst->indices)
+            return -1;
+        memcpy(inst->indices, inst_desc->indices,
+               sizeof(*inst->indices) * inst_desc->num_indices);
+    }
+
+    if (!block->block.first) {
+        block->block.first = inst;
+        block->block.last = inst;
+    } else {
+        block->block.last->next = inst;
+        block->block.last = inst;
+    }
+    if (a64_stream_push_inst_ref(ctx, block, inst) != 0)
+        return -1;
+    a64_stream_note_vregs(ctx, inst_desc);
+    ctx->saw_stream_input = true;
     return 0;
 }
 
 static int aarch64_compile_set_block(void *compile_ctx, uint32_t block_id) {
-    (void)compile_ctx;
-    (void)block_id;
+    a64_stream_bridge_ctx_t *ctx = (a64_stream_bridge_ctx_t *)compile_ctx;
+    if (!ctx)
+        return -1;
+    if (!a64_stream_get_or_create_block(ctx, block_id))
+        return -1;
+    ctx->current_block_id = block_id;
+    ctx->has_current_block = true;
     return 0;
 }
 
 static int aarch64_compile_end(void *compile_ctx, size_t *out_len) {
     a64_stream_bridge_ctx_t *ctx = (a64_stream_bridge_ctx_t *)compile_ctx;
+    lr_func_t *func_to_compile = NULL;
     if (!ctx || !out_len)
         return -1;
+    if (ctx->saw_stream_input) {
+        if (a64_stream_finalize_function(ctx) != 0)
+            return -1;
+        func_to_compile = &ctx->stream_func;
+    } else {
+        func_to_compile = ctx->func;
+    }
+    if (!func_to_compile)
+        return -1;
     if (ctx->mode == LR_COMPILE_COPY_PATCH)
-        return aarch64_compile_func_cp(ctx->func, ctx->mod, ctx->buf, ctx->buflen,
+        return aarch64_compile_func_cp(func_to_compile, ctx->mod, ctx->buf, ctx->buflen,
                                        out_len, ctx->arena);
     if (ctx->mode == LR_COMPILE_ISEL)
-        return aarch64_compile_func(ctx->func, ctx->mod, ctx->buf, ctx->buflen,
+        return aarch64_compile_func(func_to_compile, ctx->mod, ctx->buf, ctx->buflen,
                                     out_len, ctx->arena);
     return -1;
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -88,6 +88,7 @@ int test_target_copy_patch_fallback_matches_isel_for_non_x86(void);
 int test_target_x86_streaming_hooks_isel_smoke(void);
 int test_target_x86_streaming_hooks_copy_patch_smoke(void);
 int test_target_x86_streaming_hooks_phi_smoke(void);
+int test_target_aarch64_streaming_hooks_smoke(void);
 int test_parse_auto_selects_ll_frontend(void);
 int test_parse_auto_selects_wasm_frontend(void);
 int test_parse_auto_selects_bc_frontend(void);
@@ -341,6 +342,7 @@ int main(void) {
     RUN_TEST(test_target_x86_streaming_hooks_isel_smoke);
     RUN_TEST(test_target_x86_streaming_hooks_copy_patch_smoke);
     RUN_TEST(test_target_x86_streaming_hooks_phi_smoke);
+    RUN_TEST(test_target_aarch64_streaming_hooks_smoke);
     RUN_TEST(test_parse_auto_selects_ll_frontend);
     RUN_TEST(test_parse_auto_selects_wasm_frontend);
     RUN_TEST(test_parse_auto_selects_bc_frontend);

--- a/tests/test_targets.c
+++ b/tests/test_targets.c
@@ -383,6 +383,92 @@ int test_target_x86_streaming_hooks_phi_smoke(void) {
     return 0;
 }
 
+int test_target_aarch64_streaming_hooks_smoke(void) {
+    lr_arena_t *module_arena = lr_arena_create(0);
+    lr_module_t *m = NULL;
+    const lr_target_t *t = lr_target_by_name("aarch64");
+    lr_type_t *params[2];
+    lr_operand_desc_t add_ops[2];
+    lr_operand_desc_t ret_ops[1];
+    lr_compile_inst_desc_t add_desc;
+    lr_compile_inst_desc_t ret_desc;
+    lr_compile_mode_t modes[2] = {LR_COMPILE_ISEL, LR_COMPILE_COPY_PATCH};
+    uint8_t isel_code[4096];
+    uint8_t cp_code[4096];
+    size_t isel_len = 0;
+    size_t cp_len = 0;
+
+    TEST_ASSERT(module_arena != NULL, "arena create");
+    TEST_ASSERT(t != NULL, "aarch64 target exists");
+
+    m = lr_module_create(module_arena);
+    TEST_ASSERT(m != NULL, "module create");
+
+    params[0] = m->type_i32;
+    params[1] = m->type_i32;
+
+    for (size_t i = 0; i < 2; i++) {
+        lr_arena_t *compile_arena = lr_arena_create(0);
+        lr_compile_func_meta_t meta;
+        void *compile_ctx = NULL;
+        uint8_t *out_buf = (i == 0) ? isel_code : cp_code;
+        size_t *out_len = (i == 0) ? &isel_len : &cp_len;
+        int rc;
+
+        TEST_ASSERT(compile_arena != NULL, "compile arena create");
+
+        memset(&meta, 0, sizeof(meta));
+        meta.ret_type = m->type_i32;
+        meta.param_types = params;
+        meta.num_params = 2;
+        meta.next_vreg = 4;
+        meta.mode = modes[i];
+
+        rc = t->compile_begin(&compile_ctx, &meta, m, out_buf, 4096, compile_arena);
+        TEST_ASSERT_EQ(rc, 0, "compile_begin succeeds");
+        TEST_ASSERT(compile_ctx != NULL, "compile ctx exists");
+        TEST_ASSERT_EQ(t->compile_set_block(compile_ctx, 0), 0, "set block 0");
+
+        memset(add_ops, 0, sizeof(add_ops));
+        add_ops[0].kind = LR_OP_KIND_VREG;
+        add_ops[0].type = m->type_i32;
+        add_ops[0].vreg = 1;
+        add_ops[1].kind = LR_OP_KIND_VREG;
+        add_ops[1].type = m->type_i32;
+        add_ops[1].vreg = 2;
+        memset(&add_desc, 0, sizeof(add_desc));
+        add_desc.op = LR_OP_ADD;
+        add_desc.type = m->type_i32;
+        add_desc.dest = 3;
+        add_desc.operands = add_ops;
+        add_desc.num_operands = 2;
+        TEST_ASSERT_EQ(t->compile_emit(compile_ctx, &add_desc), 0, "emit add");
+
+        memset(ret_ops, 0, sizeof(ret_ops));
+        ret_ops[0].kind = LR_OP_KIND_VREG;
+        ret_ops[0].type = m->type_i32;
+        ret_ops[0].vreg = 3;
+        memset(&ret_desc, 0, sizeof(ret_desc));
+        ret_desc.op = LR_OP_RET;
+        ret_desc.type = m->type_i32;
+        ret_desc.operands = ret_ops;
+        ret_desc.num_operands = 1;
+        TEST_ASSERT_EQ(t->compile_emit(compile_ctx, &ret_desc), 0, "emit ret");
+
+        TEST_ASSERT_EQ(t->compile_end(compile_ctx, out_len), 0, "compile_end succeeds");
+        TEST_ASSERT(*out_len > 0, "generated code");
+
+        lr_arena_destroy(compile_arena);
+    }
+
+    TEST_ASSERT(isel_len == cp_len, "copy-patch fallback length matches isel");
+    TEST_ASSERT(memcmp(isel_code, cp_code, isel_len) == 0,
+                "copy-patch fallback bytes match isel");
+
+    lr_arena_destroy(module_arena);
+    return 0;
+}
+
 int test_parse_auto_selects_ll_frontend(void) {
     const char *src =
         "define i32 @main() {\n"


### PR DESCRIPTION
## Summary
- implement a real `aarch64` streaming bridge in `src/target_aarch64.c` so `compile_emit`/`compile_set_block` are no longer stubs
- allow `compile_begin` without `func_meta->func` by materializing a temporary stream function from emitted descriptors
- finalize streamed blocks/instructions through `lr_func_finalize()` and compile via existing aarch64 backends in `compile_end`
- add `test_target_aarch64_streaming_hooks_smoke` and register it in `tests/test_main.c`

## Verification
Commands:
- `cmake -S . -B build -G Ninja 2>&1 | tee /tmp/test.log`
- `cmake --build build -j$(nproc) 2>&1 | tee -a /tmp/test.log`
- `ctest --test-dir build --output-on-failure -R test_liric 2>&1 | tee -a /tmp/test.log` (no ctest entries are registered in this workspace)
- `./build/test_liric 2>&1 | tee -a /tmp/test.log`

Output excerpts:
- `[3/10] Building C object CMakeFiles/liric.dir/src/target_aarch64.c.o`
- `test_target_aarch64_streaming_hooks_smoke... ok`
- `227 tests: 227 passed, 0 failed`

Artifacts:
- `/tmp/test.log`
