### PR TITLE
fix: streaming: riscv64 streaming backend (fixes #323)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -89,6 +89,7 @@ int test_target_x86_streaming_hooks_isel_smoke(void);
 int test_target_x86_streaming_hooks_copy_patch_smoke(void);
 int test_target_x86_streaming_hooks_phi_smoke(void);
 int test_target_aarch64_streaming_hooks_smoke(void);
+int test_target_riscv64_streaming_hooks_smoke(void);
 int test_parse_auto_selects_ll_frontend(void);
 int test_parse_auto_selects_wasm_frontend(void);
 int test_parse_auto_selects_bc_frontend(void);
@@ -343,6 +344,7 @@ int main(void) {
     RUN_TEST(test_target_x86_streaming_hooks_copy_patch_smoke);
     RUN_TEST(test_target_x86_streaming_hooks_phi_smoke);
     RUN_TEST(test_target_aarch64_streaming_hooks_smoke);
+    RUN_TEST(test_target_riscv64_streaming_hooks_smoke);
     RUN_TEST(test_parse_auto_selects_ll_frontend);
     RUN_TEST(test_parse_auto_selects_wasm_frontend);
     RUN_TEST(test_parse_auto_selects_bc_frontend);


### PR DESCRIPTION
## Summary
- replace riscv64 no-op streaming hooks with a real descriptor-to-IR bridge (`compile_set_block`/`compile_emit`/`compile_end`)
- allow `compile_begin` to work without `func_meta->func` by synthesizing stream function metadata and parameter vregs
- keep rv64gc/rv64im codegen entrypoints unchanged while making streamed compilation paths functional
- add `test_target_riscv64_streaming_hooks_smoke` and register it in `test_main.c`

## Verification
```bash
cmake --build build -j$(nproc)
./build/test_liric 2>&1 | tee /tmp/test.log
grep -n "test_target_riscv64_streaming_hooks_smoke" /tmp/test.log
grep -n "tests: .*passed" /tmp/test.log
```

Output excerpts:
- `65:  test_target_riscv64_streaming_hooks_smoke... ok`
- `274:228 tests: 228 passed, 0 failed`

Artifact:
- `/tmp/test.log`
