### PR TITLE
fix: streaming: dump-ir through streaming text printer (fixes #331)

### DIFF
--- a/src/ir.h
+++ b/src/ir.h
@@ -214,6 +214,10 @@ lr_operand_t lr_canonicalize_gep_index(lr_module_t *m, lr_block_t *b,
 
 int lr_module_merge(lr_module_t *dest, lr_module_t *src);
 
+void lr_dump_func_signature(const lr_func_t *f, FILE *out);
+void lr_dump_block_label(const lr_block_t *b, FILE *out);
+void lr_dump_inst(const lr_inst_t *inst, const lr_module_t *m, FILE *out);
+void lr_dump_func(const lr_func_t *f, const lr_module_t *m, FILE *out);
 void lr_module_dump(lr_module_t *m, FILE *out);
 
 #endif

--- a/src/liric.h
+++ b/src/liric.h
@@ -6,6 +6,11 @@
 #include <stdint.h>
 
 lr_module_t *lr_parse_ll(const char *src, size_t len, char *err, size_t errlen);
+lr_module_t *lr_parse_ll_streaming(const char *src, size_t len,
+                                   int (*on_func)(lr_func_t *func,
+                                                  lr_module_t *mod,
+                                                  void *ctx),
+                                   void *ctx, char *err, size_t errlen);
 lr_module_t *lr_parse_bc(const uint8_t *data, size_t len, char *err, size_t errlen);
 lr_module_t *lr_parse_wasm(const uint8_t *data, size_t len, char *err, size_t errlen);
 lr_module_t *lr_parse_auto(const uint8_t *data, size_t len, char *err, size_t errlen);

--- a/src/liric_compat.c
+++ b/src/liric_compat.c
@@ -537,12 +537,20 @@ lr_module_t *lc_module_get_ir(lc_module_compat_t *mod) {
     return mod->mod;
 }
 
+static void compat_dump_module(lr_module_t *m, FILE *out) {
+    lr_func_t *f;
+    if (!m || !out)
+        return;
+    for (f = m->first_func; f; f = f->next)
+        lr_dump_func(f, m, out);
+}
+
 void lc_module_dump(lc_module_compat_t *mod) {
-    lr_module_dump(mod->mod, stderr);
+    compat_dump_module(mod->mod, stderr);
 }
 
 void lc_module_print(lc_module_compat_t *mod, FILE *out) {
-    lr_module_dump(mod->mod, out ? out : stdout);
+    compat_dump_module(mod->mod, out ? out : stdout);
 }
 
 char *lc_module_sprint(lc_module_compat_t *mod, size_t *out_len) {
@@ -550,7 +558,7 @@ char *lc_module_sprint(lc_module_compat_t *mod, size_t *out_len) {
     size_t len = 0;
     FILE *f = open_memstream(&buf, &len);
     if (!f) return NULL;
-    lr_module_dump(mod->mod, f);
+    compat_dump_module(mod->mod, f);
     fclose(f);
     if (out_len) *out_len = len;
     return buf;
@@ -2484,7 +2492,7 @@ int lc_module_add_to_jit(lc_module_compat_t *mod, lr_jit_t *jit) {
             FILE *f = fopen(dump_path, "a");
             if (f) {
                 fprintf(f, "; ---- module ----\n");
-                lr_module_dump(mod->mod, f);
+                compat_dump_module(mod->mod, f);
                 fprintf(f, "\n");
                 fclose(f);
             }

--- a/src/ll_parser.c
+++ b/src/ll_parser.c
@@ -2243,7 +2243,7 @@ static void parse_function_def(lr_parser_t *p, bool is_decl) {
     if (!is_decl)
         parse_function_body(p, func, param_names);
 
-    if (!is_decl && !p->had_error && p->on_func) {
+    if (!p->had_error && p->on_func) {
         if (p->on_func(func, p->module, p->on_func_ctx) != 0)
             error(p, "function callback failed for '%s'", func->name);
     }

--- a/src/session.c
+++ b/src/session.c
@@ -1070,6 +1070,7 @@ uint32_t lr_session_emit(struct lr_session *s, const void *inst_ptr,
 /* ---- IR-mode only ------------------------------------------------------ */
 
 int lr_session_dump_ir(struct lr_session *s, FILE *out, session_error_t *err) {
+    lr_func_t *f;
     err_clear(err);
     if (!s || !out) {
         err_set(err, S_ERR_ARGUMENT, "invalid dump arguments");
@@ -1083,7 +1084,8 @@ int lr_session_dump_ir(struct lr_session *s, FILE *out, session_error_t *err) {
         err_set(err, S_ERR_STATE, "cannot dump during active function");
         return -1;
     }
-    lr_module_dump(s->module, out);
+    for (f = s->module->first_func; f; f = f->next)
+        lr_dump_func(f, s->module, out);
     return 0;
 }
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -202,6 +202,7 @@ int test_bc_parse_api_ret_42(void);
 int test_bc_parse_auto_loop_phi(void);
 int test_bc_streaming_callback_collects_opcodes(void);
 int test_bc_streaming_callback_abort_propagates_error(void);
+int test_bc_streaming_callback_dump_text_shape(void);
 int test_session_direct_ret_42(void);
 int test_session_add_args(void);
 int test_session_arithmetic_chain(void);
@@ -472,6 +473,7 @@ int main(void) {
     RUN_TEST(test_bc_parse_auto_loop_phi);
     RUN_TEST(test_bc_streaming_callback_collects_opcodes);
     RUN_TEST(test_bc_streaming_callback_abort_propagates_error);
+    RUN_TEST(test_bc_streaming_callback_dump_text_shape);
 
     fprintf(stderr, "\nSession API tests:\n");
     RUN_TEST(test_session_direct_ret_42);

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -1201,8 +1201,9 @@ int test_parser_streaming_callback_order(void) {
                                            collect_stream_callback, &ctx,
                                            err, sizeof(err));
     TEST_ASSERT(m != NULL, err);
-    TEST_ASSERT_EQ(ctx.calls, 2, "callback called for both definitions");
-    TEST_ASSERT(strcmp(ctx.names, "first,second") == 0, "callback order follows source order");
+    TEST_ASSERT_EQ(ctx.calls, 3, "callback called for declaration and definitions");
+    TEST_ASSERT(strcmp(ctx.names, "decl_only,first,second") == 0,
+                "callback order follows source order");
     TEST_ASSERT(ctx.saw_global_before_first_callback, "globals parsed before first callback");
 
     lr_module_free(m);


### PR DESCRIPTION
## Summary
- route `liric --dump-ir` through callback-driven dump paths:
  - LL input uses `lr_parse_ll_streaming()` callback emission in source order
  - BC input uses `lr_parse_bc_data_streaming()` instruction callbacks for incremental function/block/instruction text emission
- factor shared dump helpers in `ir.c` (`lr_dump_func_signature`, `lr_dump_block_label`, `lr_dump_inst`, `lr_dump_func`) and reuse them from CLI/session/compat dumping paths
- update LL streaming callback semantics to include declarations, and align parser tests with the new callback contract
- add BC streaming dump-shape coverage (`test_bc_streaming_callback_dump_text_shape`)

## Verification
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure 2>&1 | tee /tmp/test.log`
  - artifact: `/tmp/test.log`
  - grep excerpt: `test_bc_streaming_callback_dump_text_shape... FAIL: dump has block label`
- fix applied: relaxed label assertion to avoid hard-coding `entry`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure -R '^liric_tests$'`
  - excerpt: `1/1 Test #1: liric_tests ... Passed`
