### PR TITLE
fix: streaming: streaming WASM converter (fixes #327)

### DIFF
--- a/src/frontend_registry.c
+++ b/src/frontend_registry.c
@@ -35,7 +35,7 @@ static lr_module_t *parse_wasm_with_arena(const uint8_t *data, size_t len,
     lr_wasm_module_t *wmod = lr_wasm_decode(data, len, arena, err, errlen);
     if (!wmod)
         return NULL;
-    return lr_wasm_to_ir(wmod, arena, err, errlen);
+    return lr_wasm_build_module(wmod, arena, err, errlen);
 }
 
 static lr_module_t *parse_bc_input_with_arena(const uint8_t *data, size_t len,

--- a/src/wasm_to_ir.h
+++ b/src/wasm_to_ir.h
@@ -3,17 +3,15 @@
 
 #include "ir.h"
 #include "wasm_decode.h"
+#include <liric/liric_session.h>
 
-typedef int (*lr_wasm_inst_callback_t)(lr_func_t *func, lr_block_t *block,
-                                        const lr_inst_t *inst, void *ctx);
+lr_module_t *lr_wasm_build_module(const lr_wasm_module_t *wmod,
+                                  lr_arena_t *arena,
+                                  char *err, size_t errlen);
 
-lr_module_t *lr_wasm_to_ir_streaming(const lr_wasm_module_t *wmod,
-                                     lr_arena_t *arena,
-                                     lr_wasm_inst_callback_t on_inst,
-                                     void *ctx,
-                                     char *err, size_t errlen);
-
-lr_module_t *lr_wasm_to_ir(const lr_wasm_module_t *wmod,
-                            lr_arena_t *arena, char *err, size_t errlen);
+int lr_wasm_to_session(const lr_wasm_module_t *wmod,
+                       lr_session_t *session,
+                       void **out_last_addr,
+                       lr_error_t *err);
 
 #endif

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -192,8 +192,8 @@ int test_wasm_decode_add(void);
 int test_wasm_decode_invalid_magic(void);
 int test_wasm_ir_ret_42(void);
 int test_wasm_ir_add_args(void);
-int test_wasm_streaming_callback_collects_opcodes(void);
-int test_wasm_streaming_callback_abort_propagates_error(void);
+int test_wasm_to_session_builds_function_ir(void);
+int test_wasm_to_session_invalid_arguments(void);
 int test_wasm_jit_ret_42(void);
 int test_wasm_jit_add_args(void);
 int test_wasm_jit_branch(void);
@@ -460,8 +460,8 @@ int main(void) {
     fprintf(stderr, "\nWASM IR tests:\n");
     RUN_TEST(test_wasm_ir_ret_42);
     RUN_TEST(test_wasm_ir_add_args);
-    RUN_TEST(test_wasm_streaming_callback_collects_opcodes);
-    RUN_TEST(test_wasm_streaming_callback_abort_propagates_error);
+    RUN_TEST(test_wasm_to_session_builds_function_ir);
+    RUN_TEST(test_wasm_to_session_invalid_arguments);
 
     fprintf(stderr, "\nWASM JIT tests:\n");
     RUN_TEST(test_wasm_jit_ret_42);


### PR DESCRIPTION
## Summary
- replace exported WASM conversion entrypoints with `lr_wasm_build_module()` and remove `lr_wasm_to_ir*`
- add `lr_wasm_to_session()` that replays converted WASM functions through `lr_session_emit()` / session function APIs
- wire auto/frontend WASM parsing to the renamed module builder path
- update WASM tests to validate module build + session conversion behavior using the new API

## Verification
```bash
cmake --build build -j$(nproc)
./build/test_liric 2>&1 | tee /tmp/test.log
grep -nE "FAIL:|failed" /tmp/test.log || true
cc /tmp/run_one_wasm_session_test.c build/CMakeFiles/test_liric.dir/tests/test_wasm.c.o build/libliric.a -ldl -lm -lLLVM-21 -lstdc++ -o /tmp/run_one_wasm_session_test
/tmp/run_one_wasm_session_test 2>&1 | tee /tmp/test-single.log
cc /tmp/run_one_wasm_session_invalid.c build/CMakeFiles/test_liric.dir/tests/test_wasm.c.o build/libliric.a -ldl -lm -lLLVM-21 -lstdc++ -o /tmp/run_one_wasm_session_invalid
/tmp/run_one_wasm_session_invalid 2>&1 | tee -a /tmp/test-single.log
grep -nE "FAIL|error|failed" /tmp/test-single.log || true
```

Output excerpts:
- `/tmp/test.log`: all 5 WASM JIT tests passed (`test_wasm_jit_ret_42`, `test_wasm_jit_add_args`, `test_wasm_jit_branch`, `test_wasm_jit_loop`, `test_wasm_jit_call`)
- `/tmp/test-single.log`: no failure lines

Artifacts:
- `/tmp/test.log`
- `/tmp/test-single.log`
