### PR TITLE
fix: streaming: compat API through session — all builders streaming (fixes #328)

### DIFF
--- a/include/liric/liric_compat.h
+++ b/include/liric/liric_compat.h
@@ -92,7 +92,6 @@ void lc_context_destroy(lc_context_t *ctx);
 /* ---- Module ---- */
 lc_module_compat_t *lc_module_create(lc_context_t *ctx, const char *name);
 void lc_module_destroy(lc_module_compat_t *mod);
-void lc_module_finalize_phis(lc_module_compat_t *mod);
 lr_module_t *lc_module_get_ir(lc_module_compat_t *mod);
 void lc_module_dump(lc_module_compat_t *mod);
 void lc_module_print(lc_module_compat_t *mod, FILE *out);
@@ -368,8 +367,7 @@ lc_phi_node_t *lc_create_phi(lc_module_compat_t *mod, lr_block_t *b,
                               lr_func_t *f, lr_type_t *ty, const char *name);
 void lc_phi_add_incoming(lc_phi_node_t *phi, lc_value_t *val,
                          lr_block_t *block);
-/* Finalization is idempotent; lc_module_finalize_phis owns lc_phi_node_t
-   lifetime and releases nodes at module materialization time. */
+/* Finalization is idempotent and may be a no-op in streaming mode. */
 void lc_phi_finalize(lc_phi_node_t *phi);
 
 /* Select */

--- a/include/liric/liric_session.h
+++ b/include/liric/liric_session.h
@@ -122,6 +122,9 @@ int lr_session_func_end(lr_session_t *s, void **out_addr, lr_error_t *err);
 
 uint32_t lr_session_block(lr_session_t *s);
 int lr_session_set_block(lr_session_t *s, uint32_t block_id, lr_error_t *err);
+int lr_session_bind_ir(lr_session_t *s, lr_module_t *module,
+                       lr_func_t *func, lr_block_t *block,
+                       lr_error_t *err);
 
 /* ---- Vreg allocation --------------------------------------------------- */
 

--- a/include/llvm/IR/Module.h
+++ b/include/llvm/IR/Module.h
@@ -522,8 +522,6 @@ inline bool legacy::PassManager::run(Module &M) {
     if (!compat)
         return false;
 
-    lc_module_finalize_phis(compat);
-
     FILE *f = detail::obj_emit_state.out->getFileOrNull();
     if (!f)
         return false;


### PR DESCRIPTION
## Summary
- Route compat IRBuilder-style emission through session descriptors by introducing `lr_session_bind_ir()` and using `lr_session_emit()` in compat builder helpers.
- Remove direct instruction construction from `src/liric_compat.c` (`lr_inst_create`/`lr_block_append`) and delete the obsolete fast operand helper (`lc_value_to_op_fast`).
- Switch PHI incoming handling to call `lr_session_add_phi_copy()` and keep PHI operands synchronized incrementally (no module-level PHI finalize pass).
- Remove `lc_module_finalize_phis()` from the public compat API and stop calling it from the LLVM compat module pass manager path.

## Verification
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure -R "llvm_compat_tests|liric_tests" 2>&1 | tee /tmp/test-issue328.log`
  - Excerpt:
    - `2/2 Test #28: llvm_compat_tests ................   Passed`
    - `100% tests passed, 0 tests failed out of 2`
- `rg -n "lr_inst_create\(|lc_value_to_op_fast|lc_module_finalize_phis\(" src/liric_compat.c include/liric/liric_compat.h include/llvm/IR/Module.h`
  - Excerpt: no matches
- Artifacts:
  - `/tmp/test-issue328.log`
