### PR TITLE
feat: DIRECT mode exe/obj emission via blob capture

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -66,12 +66,6 @@ typedef struct lr_sig_buf {
     size_t cap;
 } lr_sig_buf_t;
 
-typedef struct lr_cached_reloc {
-    uint32_t offset;
-    uint8_t type;
-    const char *symbol_name;
-} lr_cached_reloc_t;
-
 typedef struct lr_mat_cache_entry {
     uint64_t key_hash;
     uint32_t epoch;
@@ -2485,6 +2479,10 @@ void *lr_jit_get_function(lr_jit_t *j, const char *name) {
             return NULL;
     }
     return lookup_symbol_hashed(j, name, hash);
+}
+
+int lr_jit_patch_relocs(lr_jit_t *j, const struct lr_objfile_ctx *ctx) {
+    return apply_jit_relocs(j, ctx, NULL);
 }
 
 void lr_jit_destroy(lr_jit_t *j) {

--- a/src/jit.h
+++ b/src/jit.h
@@ -87,6 +87,9 @@ int lr_jit_add_module(lr_jit_t *j, lr_module_t *m);
 void lr_jit_end_update(lr_jit_t *j);
 void *lr_jit_get_function(lr_jit_t *j, const char *name);
 void lr_jit_destroy(lr_jit_t *j);
+struct lr_objfile_ctx;
+int lr_jit_patch_relocs(lr_jit_t *j, const struct lr_objfile_ctx *ctx);
+
 void lr_jit_materialize_cache_invalidate_all(void);
 uint32_t lr_jit_materialize_cache_epoch(void);
 void lr_jit_materialize_cache_reset_stats(void);

--- a/src/objfile.c
+++ b/src/objfile.c
@@ -297,7 +297,7 @@ static int obj_define_intrinsic_stubs(lr_obj_build_result_t *out,
     return 0;
 }
 
-static void obj_ctx_destroy(lr_objfile_ctx_t *ctx) {
+void lr_objfile_ctx_destroy(lr_objfile_ctx_t *ctx) {
     if (!ctx)
         return;
     free(ctx->relocs);
@@ -312,7 +312,7 @@ static void obj_ctx_destroy(lr_objfile_ctx_t *ctx) {
 static void obj_build_result_destroy(lr_obj_build_result_t *build) {
     if (!build)
         return;
-    obj_ctx_destroy(&build->ctx);
+    lr_objfile_ctx_destroy(&build->ctx);
     free(build->code_buf);
     free(build->data_buf);
     memset(build, 0, sizeof(*build));

--- a/src/objfile.h
+++ b/src/objfile.h
@@ -101,6 +101,7 @@ void lr_obj_add_data_reloc(lr_objfile_ctx_t *oc, uint32_t offset,
                             uint32_t symbol_idx, uint8_t type);
 
 int lr_obj_build_symbol_cache(lr_objfile_ctx_t *oc, lr_module_t *m);
+void lr_objfile_ctx_destroy(lr_objfile_ctx_t *ctx);
 
 int lr_emit_executable_from_blobs(const lr_func_blob_t *blobs,
                                   uint32_t num_blobs,

--- a/src/objfile.h
+++ b/src/objfile.h
@@ -57,6 +57,22 @@ typedef struct lr_objfile_ctx {
     bool preserve_symbol_names;
 } lr_objfile_ctx_t;
 
+/* Name-based relocation (used for blob capture and materialization cache) */
+typedef struct lr_cached_reloc {
+    uint32_t offset;
+    uint8_t type;
+    const char *symbol_name;
+} lr_cached_reloc_t;
+
+/* Pre-compiled function blob for exe/obj emission from DIRECT mode */
+typedef struct lr_func_blob {
+    const char *name;
+    const uint8_t *code;
+    size_t code_len;
+    const lr_cached_reloc_t *relocs;
+    uint32_t num_relocs;
+} lr_func_blob_t;
+
 /* Mapped relocation info returned by format-specific reloc mappers */
 typedef struct {
     uint32_t native_type;
@@ -83,6 +99,21 @@ void lr_obj_add_reloc(lr_objfile_ctx_t *oc, uint32_t offset,
 
 void lr_obj_add_data_reloc(lr_objfile_ctx_t *oc, uint32_t offset,
                             uint32_t symbol_idx, uint8_t type);
+
+int lr_obj_build_symbol_cache(lr_objfile_ctx_t *oc, lr_module_t *m);
+
+int lr_emit_executable_from_blobs(const lr_func_blob_t *blobs,
+                                  uint32_t num_blobs,
+                                  lr_module_t *m,
+                                  const lr_target_t *target,
+                                  FILE *out,
+                                  const char *entry_symbol);
+
+int lr_emit_object_from_blobs(const lr_func_blob_t *blobs,
+                              uint32_t num_blobs,
+                              lr_module_t *m,
+                              const lr_target_t *target,
+                              FILE *out);
 
 /* Byte-level write helpers shared by Mach-O and ELF format writers */
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -256,6 +256,10 @@ int test_session_ir_exe_ret_42(void);
 int test_session_ir_exe_branch(void);
 int test_session_ir_exe_call(void);
 int test_session_ir_exe_loop(void);
+int test_session_direct_exe_ret_42(void);
+int test_session_direct_exe_branch(void);
+int test_session_direct_exe_call(void);
+int test_session_direct_jit_and_exe(void);
 #endif
 
 #if defined(__x86_64__) || defined(_M_X64)
@@ -504,6 +508,12 @@ int main(void) {
     RUN_TEST(test_session_ir_exe_branch);
     RUN_TEST(test_session_ir_exe_call);
     RUN_TEST(test_session_ir_exe_loop);
+
+    fprintf(stderr, "\nSession DIRECT exe tests:\n");
+    RUN_TEST(test_session_direct_exe_ret_42);
+    RUN_TEST(test_session_direct_exe_branch);
+    RUN_TEST(test_session_direct_exe_call);
+    RUN_TEST(test_session_direct_jit_and_exe);
 #endif
 
     fprintf(stderr, "\nModule merge tests:\n");


### PR DESCRIPTION
## Summary
- Capture pre-relocation machine code bytes and relocations during DIRECT mode streaming compilation
- Use captured blobs for ELF exe/obj emission without constructing IR
- All platforms supported: Linux x86_64 (static/dynamic), aarch64, riscv64, macOS aarch64

## Changes
- **session.c**: Install `lr_objfile_ctx` during `begin_direct_compile` so backend emits relocatable code. `capture_blob()` saves code + name-based relocs. `lr_jit_patch_relocs()` applies relocs for JIT. `emit_exe`/`emit_object` use blob path when available.
- **objfile.c**: New `obj_build_from_blobs()`, `lr_emit_executable_from_blobs()`, `lr_emit_object_from_blobs()` -- produce ELF/Mach-O from captured blobs with full global/intrinsic stub support.
- **objfile.h**: Move `lr_cached_reloc_t` from jit.c (shared type), add `lr_func_blob_t`, export new functions.
- **jit.c/jit.h**: Remove duplicate `lr_cached_reloc_t`, expose `lr_jit_patch_relocs()`.
- **test_session.c**: 4 new Linux-only DIRECT exe tests (ret42, branch, call, jit+exe).
- **test_llvm_compat.cpp**: Fix test that relied on accidental IR fallback -- verify module-level artefacts instead of dumping DIRECT-mode function bodies.

## Test plan
- [x] `ctest --test-dir build --output-on-failure` -- 30/30 pass (100%)
- [x] 4 new DIRECT exe emission tests
- [x] 49/49 compat tests pass
- [ ] CI on all platforms