### PR TITLE
fix: Benchmark harness should fail hard when effective test set is em (fixes #371)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,11 +479,35 @@ add_test(
 )
 
 add_test(
+    NAME bench_ll_empty_dataset_gate
+    COMMAND ${CMAKE_COMMAND}
+        -DBENCH_LL=$<TARGET_FILE:bench_ll>
+        -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_ll_empty_dataset_gate.cmake
+)
+
+add_test(
+    NAME bench_corpus_empty_dataset_gate
+    COMMAND ${CMAKE_COMMAND}
+        -DBENCH_CORPUS=$<TARGET_FILE:bench_corpus>
+        -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_corpus_empty_dataset_gate.cmake
+)
+
+add_test(
     NAME bench_api_nonzero_compat
     COMMAND ${CMAKE_COMMAND}
         -DBENCH_API=$<TARGET_FILE:bench_api>
         -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_api_nonzero_compat.cmake
+)
+
+add_test(
+    NAME bench_api_empty_dataset_gate
+    COMMAND ${CMAKE_COMMAND}
+        -DBENCH_API=$<TARGET_FILE:bench_api>
+        -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_api_empty_dataset_gate.cmake
 )
 
 add_test(

--- a/tests/cmake/test_bench_api_empty_dataset_gate.cmake
+++ b/tests/cmake/test_bench_api_empty_dataset_gate.cmake
@@ -1,0 +1,84 @@
+if(NOT DEFINED BENCH_API OR NOT DEFINED WORKDIR)
+    message(FATAL_ERROR "BENCH_API and WORKDIR are required")
+endif()
+
+set(root "${WORKDIR}/bench_api_empty_dataset_gate")
+set(test_dir "${root}/integration_tests")
+
+file(REMOVE_RECURSE "${root}")
+file(MAKE_DIRECTORY "${test_dir}")
+
+find_program(TRUE_BIN NAMES true)
+if(NOT TRUE_BIN)
+    message(FATAL_ERROR "Unable to locate `true` executable")
+endif()
+
+function(run_case case_name allow_empty expect_rc)
+    set(bench_dir "${root}/${case_name}")
+    set(compat "${bench_dir}/compat_ll.txt")
+    set(opts "${bench_dir}/compat_ll_options.jsonl")
+
+    file(MAKE_DIRECTORY "${bench_dir}")
+    file(WRITE "${compat}" "")
+    file(WRITE "${opts}" "")
+
+    set(cmd
+        "${BENCH_API}"
+        --lfortran "${TRUE_BIN}"
+        --lfortran-liric "${TRUE_BIN}"
+        --test-dir "${test_dir}"
+        --bench-dir "${bench_dir}"
+        --compat-list "${compat}"
+        --options-jsonl "${opts}"
+        --iters 1
+        --timeout 1
+    )
+    if(allow_empty)
+        list(APPEND cmd --allow-empty)
+    endif()
+
+    execute_process(
+        COMMAND ${cmd}
+        RESULT_VARIABLE rc
+        OUTPUT_VARIABLE out
+        ERROR_VARIABLE err
+    )
+
+    if(expect_rc EQUAL 0)
+        if(NOT rc EQUAL 0)
+            message(FATAL_ERROR "bench_api --allow-empty should pass on empty dataset\nstdout:\n${out}\nstderr:\n${err}")
+        endif()
+    else()
+        if(rc EQUAL 0)
+            message(FATAL_ERROR "bench_api should fail on empty dataset by default\nstdout:\n${out}\nstderr:\n${err}")
+        endif()
+    endif()
+
+    if(NOT err MATCHES "EMPTY DATASET")
+        message(FATAL_ERROR "stderr missing EMPTY DATASET marker\nstderr:\n${err}")
+    endif()
+    if(NOT out MATCHES "Status: EMPTY DATASET")
+        message(FATAL_ERROR "stdout missing EMPTY DATASET status\nstdout:\n${out}")
+    endif()
+
+    set(summary "${bench_dir}/bench_api_summary.json")
+    if(NOT EXISTS "${summary}")
+        message(FATAL_ERROR "missing bench_api_summary.json for ${case_name}")
+    endif()
+    file(READ "${summary}" summary_text)
+    if(NOT summary_text MATCHES "\"status\": \"EMPTY DATASET\"")
+        message(FATAL_ERROR "summary missing EMPTY DATASET status:\n${summary_text}")
+    endif()
+    if(allow_empty)
+        if(NOT summary_text MATCHES "\"allow_empty\": true")
+            message(FATAL_ERROR "summary missing allow_empty=true:\n${summary_text}")
+        endif()
+    else()
+        if(NOT summary_text MATCHES "\"allow_empty\": false")
+            message(FATAL_ERROR "summary missing allow_empty=false:\n${summary_text}")
+        endif()
+    endif()
+endfunction()
+
+run_case("default_fail" OFF 1)
+run_case("allow_empty_pass" ON 0)

--- a/tests/cmake/test_bench_corpus_empty_dataset_gate.cmake
+++ b/tests/cmake/test_bench_corpus_empty_dataset_gate.cmake
@@ -1,0 +1,60 @@
+if(NOT DEFINED BENCH_CORPUS OR NOT DEFINED WORKDIR)
+    message(FATAL_ERROR "BENCH_CORPUS and WORKDIR are required")
+endif()
+
+set(root "${WORKDIR}/bench_corpus_empty_dataset_gate")
+set(cache_dir "${root}/cache")
+set(corpus "${root}/corpus.tsv")
+set(runtime_bc "${root}/runtime.bc")
+
+file(REMOVE_RECURSE "${root}")
+file(MAKE_DIRECTORY "${root}")
+file(WRITE "${runtime_bc}" "placeholder")
+file(WRITE "${corpus}" "case_001\tfake_case\t123\n")
+
+find_program(TRUE_BIN NAMES true)
+if(NOT TRUE_BIN)
+    message(FATAL_ERROR "Unable to locate `true` executable")
+endif()
+
+function(run_case allow_empty expect_rc)
+    set(cmd
+        "${BENCH_CORPUS}"
+        --probe-runner "${TRUE_BIN}"
+        --runtime-bc "${runtime_bc}"
+        --corpus "${corpus}"
+        --cache-dir "${cache_dir}"
+        --iters 1
+        --timeout 1
+    )
+    if(allow_empty)
+        list(APPEND cmd --allow-empty)
+    endif()
+
+    execute_process(
+        COMMAND ${cmd}
+        RESULT_VARIABLE rc
+        OUTPUT_VARIABLE out
+        ERROR_VARIABLE err
+    )
+
+    if(expect_rc EQUAL 0)
+        if(NOT rc EQUAL 0)
+            message(FATAL_ERROR "bench_corpus --allow-empty should pass on empty dataset\nstdout:\n${out}\nstderr:\n${err}")
+        endif()
+    else()
+        if(rc EQUAL 0)
+            message(FATAL_ERROR "bench_corpus should fail on empty dataset by default\nstdout:\n${out}\nstderr:\n${err}")
+        endif()
+    endif()
+
+    if(NOT err MATCHES "EMPTY DATASET")
+        message(FATAL_ERROR "stderr missing EMPTY DATASET marker\nstderr:\n${err}")
+    endif()
+    if(NOT out MATCHES "Status: EMPTY DATASET")
+        message(FATAL_ERROR "stdout missing EMPTY DATASET status\nstdout:\n${out}")
+    endif()
+endfunction()
+
+run_case(OFF 1)
+run_case(ON 0)

--- a/tests/cmake/test_bench_ll_empty_dataset_gate.cmake
+++ b/tests/cmake/test_bench_ll_empty_dataset_gate.cmake
@@ -1,0 +1,78 @@
+if(NOT DEFINED BENCH_LL OR NOT DEFINED WORKDIR)
+    message(FATAL_ERROR "BENCH_LL and WORKDIR are required")
+endif()
+
+set(root "${WORKDIR}/bench_ll_empty_dataset_gate")
+set(runtime_bc "${root}/runtime.bc")
+
+file(REMOVE_RECURSE "${root}")
+file(MAKE_DIRECTORY "${root}")
+file(WRITE "${runtime_bc}" "placeholder")
+
+find_program(TRUE_BIN NAMES true)
+if(NOT TRUE_BIN)
+    message(FATAL_ERROR "Unable to locate `true` executable")
+endif()
+
+function(run_case case_name allow_empty expect_rc)
+    set(bench_dir "${root}/${case_name}")
+    set(compat "${bench_dir}/compat_ll.txt")
+    set(summary "${bench_dir}/bench_ll_summary.json")
+
+    file(MAKE_DIRECTORY "${bench_dir}")
+    file(WRITE "${compat}" "")
+
+    set(cmd
+        "${BENCH_LL}"
+        --bench-dir "${bench_dir}"
+        --probe-runner "${TRUE_BIN}"
+        --runtime-lib "${TRUE_BIN}"
+        --runtime-bc "${runtime_bc}"
+        --lli-phases "${TRUE_BIN}"
+        --iters 1
+        --timeout 1
+    )
+    if(allow_empty)
+        list(APPEND cmd --allow-empty)
+    endif()
+
+    execute_process(
+        COMMAND ${cmd}
+        RESULT_VARIABLE rc
+        OUTPUT_VARIABLE out
+        ERROR_VARIABLE err
+    )
+
+    if(expect_rc EQUAL 0)
+        if(NOT rc EQUAL 0)
+            message(FATAL_ERROR "bench_ll --allow-empty should pass on empty dataset\nstdout:\n${out}\nstderr:\n${err}")
+        endif()
+    else()
+        if(rc EQUAL 0)
+            message(FATAL_ERROR "bench_ll should fail on empty dataset by default\nstdout:\n${out}\nstderr:\n${err}")
+        endif()
+    endif()
+
+    if(NOT err MATCHES "EMPTY DATASET")
+        message(FATAL_ERROR "stderr missing EMPTY DATASET marker\nstderr:\n${err}")
+    endif()
+    if(NOT EXISTS "${summary}")
+        message(FATAL_ERROR "missing bench_ll_summary.json")
+    endif()
+    file(READ "${summary}" summary_text)
+    if(NOT summary_text MATCHES "\"status\":\"EMPTY DATASET\"")
+        message(FATAL_ERROR "summary missing EMPTY DATASET status:\n${summary_text}")
+    endif()
+    if(allow_empty)
+        if(NOT summary_text MATCHES "\"allow_empty\":true")
+            message(FATAL_ERROR "summary missing allow_empty=true:\n${summary_text}")
+        endif()
+    else()
+        if(NOT summary_text MATCHES "\"allow_empty\":false")
+            message(FATAL_ERROR "summary missing allow_empty=false:\n${summary_text}")
+        endif()
+    endif()
+endfunction()
+
+run_case("default_fail" OFF 1)
+run_case("allow_empty_pass" ON 0)


### PR DESCRIPTION
## Summary
- Added a consistent empty-dataset gate to `bench_ll`, `bench_api`, and `bench_corpus`.
- Default behavior now fails on empty effective datasets; `--allow-empty` overrides only that gate.
- Added explicit `EMPTY DATASET` status reporting in benchmark output/summary artifacts.
- Added regression tests for default-fail and override-pass behavior across all three tools.

## Verification
1. Requirement: non-zero exit when the effective runnable set is empty (default behavior).
- Command: `ctest --test-dir build --output-on-failure -R "bench_ll_empty_dataset_gate|bench_corpus_empty_dataset_gate|bench_api_empty_dataset_gate"`
- Output excerpt:
  - `Test #15: bench_ll_empty_dataset_gate .......   Passed`
  - `Test #16: bench_corpus_empty_dataset_gate ...   Passed`
  - `Test #18: bench_api_empty_dataset_gate ......   Passed`
- Test evidence (default non-zero assertions):
  - `tests/cmake/test_bench_ll_empty_dataset_gate.cmake`
  - `tests/cmake/test_bench_corpus_empty_dataset_gate.cmake`
  - `tests/cmake/test_bench_api_empty_dataset_gate.cmake`

2. Requirement: optional `--allow-empty` override.
- Command: same `ctest` command above.
- Output excerpt: `100% tests passed, 0 tests failed out of 3`.
- Test evidence (`--allow-empty` expects rc=0):
  - `tests/cmake/test_bench_ll_empty_dataset_gate.cmake`
  - `tests/cmake/test_bench_corpus_empty_dataset_gate.cmake`
  - `tests/cmake/test_bench_api_empty_dataset_gate.cmake`

3. Requirement: summaries clearly include `EMPTY DATASET` status.
- Artifact-path evidence checked by tests:
  - `build/bench_ll_empty_dataset_gate/default_fail/bench_ll_summary.json` contains `"status":"EMPTY DATASET"`.
  - `build/bench_api_empty_dataset_gate/default_fail/bench_api_summary.json` contains `"status": "EMPTY DATASET"`.
  - `bench_corpus` output includes `Status: EMPTY DATASET` (asserted in `tests/cmake/test_bench_corpus_empty_dataset_gate.cmake`).
