### PR TITLE
fix: bench_compat_check near-zero compat from rc mismatch (fixes #365)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,6 +479,14 @@ add_test(
 )
 
 add_test(
+    NAME bench_compat_check_rc_policy
+    COMMAND ${CMAKE_COMMAND}
+        -DBENCH_COMPAT_CHECK=$<TARGET_FILE:bench_compat_check>
+        -DWORKDIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_compat_check_rc_policy.cmake
+)
+
+add_test(
     NAME bench_ll_empty_dataset_gate
     COMMAND ${CMAKE_COMMAND}
         -DBENCH_LL=$<TARGET_FILE:bench_ll>

--- a/tests/cmake/test_bench_compat_check_rc_policy.cmake
+++ b/tests/cmake/test_bench_compat_check_rc_policy.cmake
@@ -1,0 +1,133 @@
+if(NOT DEFINED BENCH_COMPAT_CHECK OR NOT DEFINED WORKDIR)
+    message(FATAL_ERROR "BENCH_COMPAT_CHECK and WORKDIR are required")
+endif()
+
+set(root "${WORKDIR}/compat_check_rc_policy")
+set(bench_dir "${root}/bench")
+set(int_dir "${root}/integration_tests")
+set(fake_lfortran "${root}/fake_lfortran.sh")
+set(fake_probe "${root}/fake_probe_runner.sh")
+set(fake_lli "${root}/fake_lli.sh")
+set(runtime_lib "${root}/libfake_runtime.so")
+set(runtime_bc "${root}/runtime.bc")
+
+file(REMOVE_RECURSE "${root}")
+file(MAKE_DIRECTORY "${bench_dir}")
+file(MAKE_DIRECTORY "${int_dir}")
+
+file(WRITE "${int_dir}/CMakeLists.txt"
+"RUN(NAME rc_case FILE rc_case.f90 LABELS llvm)\n")
+file(WRITE "${int_dir}/rc_case.f90"
+"program rc_case\n"
+"print *, 7\n"
+"end program\n")
+
+file(WRITE "${runtime_lib}" "fake")
+file(WRITE "${runtime_bc}" "fake")
+
+file(WRITE "${fake_lfortran}" "#!/usr/bin/env bash\n"
+"set -euo pipefail\n"
+"show_llvm=0\n"
+"out=\"\"\n"
+"for arg in \"$@\"; do\n"
+"  if [[ \"$arg\" == \"--show-llvm\" ]]; then\n"
+"    show_llvm=1\n"
+"  fi\n"
+"done\n"
+"if [[ \"$show_llvm\" -eq 1 ]]; then\n"
+"  cat <<'IR'\n"
+"define i32 @main(i32 %argc, i8** %argv) {\n"
+"entry:\n"
+"  ret i32 0\n"
+"}\n"
+"IR\n"
+"  exit 0\n"
+"fi\n"
+"while [[ $# -gt 0 ]]; do\n"
+"  if [[ \"$1\" == \"-o\" ]]; then\n"
+"    out=\"$2\"\n"
+"    shift 2\n"
+"  else\n"
+"    shift\n"
+"  fi\n"
+"done\n"
+"if [[ -z \"$out\" ]]; then\n"
+"  exit 1\n"
+"fi\n"
+"cat > \"$out\" <<'BIN'\n"
+"#!/usr/bin/env bash\n"
+"echo 7\n"
+"exit 0\n"
+"BIN\n"
+"chmod +x \"$out\"\n"
+"exit 0\n")
+
+file(WRITE "${fake_probe}" "#!/usr/bin/env bash\n"
+"set -euo pipefail\n"
+"echo 7\n"
+"exit 1\n")
+
+file(WRITE "${fake_lli}" "#!/usr/bin/env bash\n"
+"set -euo pipefail\n"
+"echo 7\n"
+"exit 0\n")
+
+execute_process(COMMAND chmod +x "${fake_lfortran}" "${fake_probe}" "${fake_lli}"
+                RESULT_VARIABLE chmod_rc)
+if(NOT chmod_rc EQUAL 0)
+    message(FATAL_ERROR "chmod failed")
+endif()
+
+execute_process(
+    COMMAND "${BENCH_COMPAT_CHECK}"
+        --timeout 5
+        --limit 1
+        --lfortran "${fake_lfortran}"
+        --probe-runner "${fake_probe}"
+        --runtime-lib "${runtime_lib}"
+        --runtime-bc "${runtime_bc}"
+        --lli "${fake_lli}"
+        --cmake "${int_dir}/CMakeLists.txt"
+        --bench-dir "${bench_dir}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+)
+
+if(NOT rc EQUAL 0)
+    message(FATAL_ERROR "bench_compat_check failed rc=${rc}\nstdout:\n${out}\nstderr:\n${err}")
+endif()
+
+set(compat_api "${bench_dir}/compat_api.txt")
+set(compat_ll "${bench_dir}/compat_ll.txt")
+set(jsonl "${bench_dir}/compat_check.jsonl")
+
+file(READ "${compat_api}" compat_api_text)
+if(NOT compat_api_text MATCHES "rc_case")
+    message(FATAL_ERROR "compat_api.txt missing rc_case:\n${compat_api_text}")
+endif()
+
+file(READ "${compat_ll}" compat_ll_text)
+if(NOT compat_ll_text MATCHES "rc_case")
+    message(FATAL_ERROR "compat_ll.txt missing rc_case:\n${compat_ll_text}")
+endif()
+
+file(READ "${jsonl}" jsonl_text)
+if(NOT jsonl_text MATCHES "\"name\":\"rc_case\"")
+    message(FATAL_ERROR "compat_check.jsonl missing rc_case row:\n${jsonl_text}")
+endif()
+if(NOT jsonl_text MATCHES "\"liric_match\":true")
+    message(FATAL_ERROR "compat_check.jsonl should mark output match for liric:\n${jsonl_text}")
+endif()
+if(NOT jsonl_text MATCHES "\"lli_match\":true")
+    message(FATAL_ERROR "compat_check.jsonl should mark output match for lli:\n${jsonl_text}")
+endif()
+if(NOT jsonl_text MATCHES "\"liric_rc_match\":false")
+    message(FATAL_ERROR "compat_check.jsonl should preserve rc mismatch signal:\n${jsonl_text}")
+endif()
+if(NOT jsonl_text MATCHES "\"lli_rc_match\":true")
+    message(FATAL_ERROR "compat_check.jsonl should preserve lli rc parity signal:\n${jsonl_text}")
+endif()
+if(NOT jsonl_text MATCHES "\"llvm_rc\":0,\"liric_rc\":1,\"lli_rc\":0")
+    message(FATAL_ERROR "compat_check.jsonl missing expected rc values:\n${jsonl_text}")
+endif()


### PR DESCRIPTION
## Summary
- treat `liric_match`/`lli_match` as stdout compatibility (not strict rc parity), so output-compatible runs are kept in `compat_api.txt`/`compat_ll.txt`
- keep return-code diagnostics explicit by adding `liric_rc_match` and `lli_rc_match` fields to each `compat_check.jsonl` row
- add a regression test (`bench_compat_check_rc_policy`) that reproduces `llvm_rc=0` + `liric_rc=1` with identical stdout and asserts expected compatibility artifacts/JSON signals

## Verification
- Requirement: revisit compatibility contract for return codes in benchmark harness.
  - Evidence: `tools/bench_compat_check.c` now computes `liric_match`/`lli_match` from normalized stdout equality and records rc parity separately in `liric_rc_match`/`lli_rc_match`.
- Requirement: distinguish output-compatible-but-rc-different from hard mismatch.
  - Evidence: JSON rows now include both `*_match` and `*_rc_match`; regression case asserts `"liric_match":true` with `"liric_rc_match":false` and rc tuple `"llvm_rc":0,"liric_rc":1,"lli_rc":0`.
  - Artifact path validated by test: `${WORKDIR}/compat_check_rc_policy/bench/compat_check.jsonl` (checked in `tests/cmake/test_bench_compat_check_rc_policy.cmake`).
- Requirement: add explicit regression test around rc parity policy.
  - Evidence command: `ctest --test-dir build --output-on-failure -R "bench_compat_check_(freeze_artifacts|rc_policy)" 2>&1 | tee /tmp/test.log`
  - Output excerpt:
    - `1/2 Test #14: bench_compat_check_freeze_artifacts ...   Passed`
    - `2/2 Test #15: bench_compat_check_rc_policy ..........   Passed`
    - `100% tests passed, 0 tests failed out of 2`
