### PR TITLE
fix: O(n^2) reloc re-application in DIRECT mode streaming (fixes #363)

### DIFF
--- a/src/jit.h
+++ b/src/jit.h
@@ -89,6 +89,8 @@ void *lr_jit_get_function(lr_jit_t *j, const char *name);
 void lr_jit_destroy(lr_jit_t *j);
 struct lr_objfile_ctx;
 int lr_jit_patch_relocs(lr_jit_t *j, const struct lr_objfile_ctx *ctx);
+int lr_jit_patch_relocs_from(lr_jit_t *j, const struct lr_objfile_ctx *ctx,
+                             uint32_t reloc_start);
 
 void lr_jit_materialize_cache_invalidate_all(void);
 uint32_t lr_jit_materialize_cache_epoch(void);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -139,6 +139,7 @@ int test_jit_phi_select_nested(void);
 int test_jit_phi_select_loop_carried(void);
 int test_jit_internal_global_load_store(void);
 int test_jit_internal_global_address_relocation(void);
+int test_jit_patch_relocs_from_skips_prior_entries(void);
 int test_jit_external_call_abs(void);
 int test_jit_external_call_abs_twice(void);
 int test_jit_varargs_printf_call(void);
@@ -403,6 +404,7 @@ int main(void) {
     RUN_TEST(test_jit_phi_select_loop_carried);
     RUN_TEST(test_jit_internal_global_load_store);
     RUN_TEST(test_jit_internal_global_address_relocation);
+    RUN_TEST(test_jit_patch_relocs_from_skips_prior_entries);
     RUN_TEST(test_jit_external_call_abs);
     RUN_TEST(test_jit_external_call_abs_twice);
     RUN_TEST(test_jit_varargs_printf_call);


### PR DESCRIPTION
## Summary
- add relocation-range patching support in JIT via `lr_jit_patch_relocs_from(..., reloc_start)`
- update DIRECT session finalize path to patch only newly added relocations starting at `direct_reloc_base`
- return a backend error when DIRECT relocation patching fails instead of silently continuing
- add regression test `test_jit_patch_relocs_from_skips_prior_entries` and register it in `test_main`

## Verification
- Requirement: patch only the new relocation slice for each DIRECT-compiled function (avoid reprocessing prior relocations).
  - Evidence: `src/session.c` now calls `lr_jit_patch_relocs_from(s->jit, &s->direct_obj_ctx, s->direct_reloc_base)` at `src/session.c:490`.
- Requirement: reloc patcher can process a relocation range `[start, num_relocs)`.
  - Evidence: `src/jit.c` `apply_jit_relocs(..., reloc_start, ...)` loops from `reloc_start`; public API added in `src/jit.h`.
- Requirement: regression coverage proving prior reloc entries are skipped.
  - Evidence: `tests/test_jit.c` test `test_jit_patch_relocs_from_skips_prior_entries` constructs two relocs (first unresolved, second resolvable), verifies `lr_jit_patch_relocs_from(..., 1)` succeeds and `lr_jit_patch_relocs_from(..., 0)` fails.
- Command evidence:
  - `cmake --build build -j$(nproc)` (successful build)
  - one-off runner for the new regression test:
    - `cc -std=gnu11 -O2 -g -fno-omit-frame-pointer -DNDEBUG -I/home/ert/code/lfortran-dev/liric/src -I/home/ert/code/lfortran-dev/liric/include /tmp/run_issue363_test.c build/CMakeFiles/test_liric.dir/tests/test_jit.c.o build/libliric.a -ldl -lm -lLLVM-21 -lstdc++ -o /tmp/run_issue363_test`
    - `/tmp/run_issue363_test 2>&1 | tee /tmp/test.log` (exit code 0)
    - `rg -n "FAIL|ERROR|error|failed" /tmp/test.log || true` produced no matches (`/tmp/test.log` has 0 lines)
