### PR TITLE
fix: DIRECT streaming path is disabled when LIRIC_COMPILE_MODE=llvm (fixes #367)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ All frontends produce `lr_module_t`, a register-based SSA IR with explicit CFG.
 
 Selected via `LIRIC_COMPILE_MODE` env var (`isel` | `copy_patch` | `llvm`).
 
+`LR_MODE_DIRECT` streaming fast-path is available only with `isel` or `copy_patch`.
+When `LIRIC_COMPILE_MODE=llvm`, session DIRECT mode falls back to the IR path.
+
 | Backend | Coverage | Mechanism | Targets |
 |---------|----------|-----------|---------|
 | ISel (default) | full | single-pass select + encode | x86_64, aarch64, riscv64 |
@@ -98,7 +101,7 @@ C core                ir.h, jit.h      (lr_module_t, lr_jit_t, arena allocator)
 
 The C++ headers allow LLVM-based compilers (e.g., lfortran) to switch backends with zero source changes.
 
-**DIRECT mode** streams instructions directly to the backend (compile_begin/emit/end) without constructing persistent IR. The backend emits relocatable code when an `lr_objfile_ctx` is installed, capturing machine code blobs and relocation records for later exe/obj emission. JIT execution uses the same compiled code with relocations patched in-place.
+**DIRECT mode** streams instructions directly to the backend (compile_begin/emit/end) without constructing persistent IR when compile mode is `isel` or `copy_patch`. The backend emits relocatable code when an `lr_objfile_ctx` is installed, capturing machine code blobs and relocation records for later exe/obj emission. JIT execution uses the same compiled code with relocations patched in-place.
 
 ## Platform Support
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -210,6 +210,7 @@ int test_session_add_args(void);
 int test_session_arithmetic_chain(void);
 int test_session_stream_stencil_fast_path(void);
 int test_session_stream_isel_fast_path(void);
+int test_session_direct_llvm_mode_ir_fallback_contract(void);
 int test_session_stream_stencil_unsupported_fallback(void);
 int test_session_add_phi_copy_api(void);
 int test_session_icmp_branch(void);
@@ -489,6 +490,7 @@ int main(void) {
     RUN_TEST(test_session_arithmetic_chain);
     RUN_TEST(test_session_stream_stencil_fast_path);
     RUN_TEST(test_session_stream_isel_fast_path);
+    RUN_TEST(test_session_direct_llvm_mode_ir_fallback_contract);
     RUN_TEST(test_session_stream_stencil_unsupported_fallback);
     RUN_TEST(test_session_add_phi_copy_api);
     RUN_TEST(test_session_icmp_branch);


### PR DESCRIPTION
## Summary
- Add a one-time runtime diagnostic in session DIRECT mode when `LIRIC_COMPILE_MODE=llvm` is requested, while preserving existing IR fallback behavior.
- Add regression coverage for DIRECT+llvm fallback semantics in session tests.
- Clarify README docs that DIRECT streaming fast-path applies to `isel`/`copy_patch` modes.

## Verification
- Requirement: Document that DIRECT streaming fast-path is not active in llvm mode.
  - Evidence: `README.md` now states that `LR_MODE_DIRECT` fast-path is available only for `isel`/`copy_patch`, and that `LIRIC_COMPILE_MODE=llvm` falls back to IR.
- Requirement: Surface a clear runtime diagnostic when DIRECT is requested with llvm mode.
  - Command: `./build/test_liric 2>&1 | tee /tmp/test_issue367.log`
  - Output excerpt: `liric session: LR_MODE_DIRECT fast-path supports LIRIC_COMPILE_MODE=isel/copy_patch; got llvm, falling back to IR`
  - Log lookup: `rg -n "LR_MODE_DIRECT fast-path supports" /tmp/test_issue367.log` (lines 204, 245, 247).
- Requirement: Add regression proving DIRECT+llvm uses IR fallback behavior.
  - Test added: `test_session_direct_llvm_mode_ir_fallback_contract` in `tests/test_session.c`.
  - Execution evidence: same `test_liric` run shows `test_session_direct_llvm_mode_ir_fallback_contract... ok` and summary `237 tests: 237 passed, 0 failed`.
