### PR TITLE
fix: streaming/aarch64: complete opcode parity in compile_emit (fixes #322)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -90,6 +90,7 @@ int test_target_x86_streaming_hooks_isel_smoke(void);
 int test_target_x86_streaming_hooks_copy_patch_smoke(void);
 int test_target_x86_streaming_hooks_phi_smoke(void);
 int test_target_aarch64_streaming_hooks_smoke(void);
+int test_target_aarch64_streaming_fp_convert_ops(void);
 int test_target_riscv64_streaming_hooks_smoke(void);
 int test_parse_auto_selects_ll_frontend(void);
 int test_parse_auto_selects_wasm_frontend(void);
@@ -356,6 +357,7 @@ int main(void) {
     RUN_TEST(test_target_x86_streaming_hooks_copy_patch_smoke);
     RUN_TEST(test_target_x86_streaming_hooks_phi_smoke);
     RUN_TEST(test_target_aarch64_streaming_hooks_smoke);
+    RUN_TEST(test_target_aarch64_streaming_fp_convert_ops);
     RUN_TEST(test_target_riscv64_streaming_hooks_smoke);
     RUN_TEST(test_parse_auto_selects_ll_frontend);
     RUN_TEST(test_parse_auto_selects_wasm_frontend);


### PR DESCRIPTION
## Summary
- Implemented missing AArch64 streaming emission for `LR_OP_UITOFP` and `LR_OP_FPTOUI` in `src/target_aarch64.c`.
- Added AArch64 opcode helpers for unsigned int/FP conversions (`enc_ucvtf`, `enc_fcvtzu`).
- Added a focused streaming test that emits both ops in `isel` and `copy_patch` modes and validates the expected AArch64 instruction encodings are present.

## Verification
- Requirement: Implement `LR_OP_UITOFP` in aarch64 streaming compile path.
  - Evidence: `src/target_aarch64.c` now handles `case LR_OP_UITOFP` and emits `enc_ucvtf(...)`.
  - Evidence: `tests/test_targets.c` test `test_target_aarch64_streaming_fp_convert_ops` asserts generated code contains `0x9E630120` (`ucvtf d0, x9`).
- Requirement: Implement `LR_OP_FPTOUI` in aarch64 streaming compile path.
  - Evidence: `src/target_aarch64.c` now handles `case LR_OP_FPTOUI` and emits `enc_fcvtzu(...)`.
  - Evidence: `tests/test_targets.c` test `test_target_aarch64_streaming_fp_convert_ops` asserts generated code contains `0x9E790009` (`fcvtzu x9, d0`).
- Requirement: Add tests that exercise both ops on aarch64 target path.
  - Evidence: Added `test_target_aarch64_streaming_fp_convert_ops` in `tests/test_targets.c`, registered in `tests/test_main.c`.
  - Evidence: Test runs in both `LR_COMPILE_ISEL` and `LR_COMPILE_COPY_PATCH` and checks copy-patch fallback parity.
- Requirement: Verify no opcode coverage regressions in aarch64 streaming mode.
  - Command: `./build/test_liric 2>&1 | tee /tmp/test.log`
  - Output excerpt: `test_target_aarch64_streaming_hooks_smoke... ok`
  - Output excerpt: `test_target_aarch64_streaming_fp_convert_ops... ok`
  - Output excerpt: `240 tests: 240 passed, 0 failed`
  - Artifact: `/tmp/test.log`
