### PR TITLE
fix: bench_lane_micro crashes with policy=ir across isel/copy_patch/l (fixes #416)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -228,6 +228,7 @@ int test_session_call(void);
 int test_session_operand_global_offset_propagates_to_ir(void);
 int test_session_select(void);
 int test_session_ir_print(void);
+int test_session_ir_lookup_prefers_module_symbol_over_process_symbol(void);
 int test_session_ll_compile(void);
 int test_session_bc_compile(void);
 int test_session_auto_compile_ll_and_bc(void);
@@ -519,6 +520,7 @@ int main(void) {
     RUN_TEST(test_session_operand_global_offset_propagates_to_ir);
     RUN_TEST(test_session_select);
     RUN_TEST(test_session_ir_print);
+    RUN_TEST(test_session_ir_lookup_prefers_module_symbol_over_process_symbol);
     RUN_TEST(test_session_ll_compile);
     RUN_TEST(test_session_bc_compile);
     RUN_TEST(test_session_auto_compile_ll_and_bc);


### PR DESCRIPTION
## Summary
- Fix IR session lookup ordering so `lr_session_lookup()` materializes IR modules before any JIT symbol-provider fallback.
- This prevents process symbol fallback (for example host `main`/`abs`) from shadowing module-defined symbols in IR mode.
- Add regression coverage for IR symbol precedence (`test_session_ir_lookup_prefers_module_symbol_over_process_symbol`).

## Verification
- Requirement: Eliminate crashes in all three `micro_c + policy=ir` cells (`isel`, `copy_patch`, `llvm`).
  - Command: `./build/bench_matrix --modes all --policies ir --lanes micro_c --iters 1 --skip-compat-check --allow-partial`
  - Evidence (from `/tmp/test_issue416.log`):
    - `[matrix] mode=isel policy=ir lane=micro_c`
    - `[matrix] mode=copy_patch policy=ir lane=micro_c`
    - `[matrix] mode=llvm policy=ir lane=micro_c`
    - `[matrix] cells: attempted=3 ok=3 failed=0`
  - Crash check: `rg -n "SIGSEGV|SIGABRT|rc=-11|failed=[1-9]" /tmp/test_issue416.log` -> `no crash markers`.

- Requirement: Produce deterministic summary artifacts per cell.
  - Evidence files:
    - `/tmp/liric_bench/isel/ir/micro_c/bench_tcc_summary.json`
    - `/tmp/liric_bench/copy_patch/ir/micro_c/bench_tcc_summary.json`
    - `/tmp/liric_bench/llvm/ir/micro_c/bench_tcc_summary.json`
  - Evidence (from `rg` over artifacts): each summary has `"status": "OK"`, correct `"mode"`, `"policy": "ir"`, and `"wall_passed" == "inproc_passed" == "total_cases" == 5`.

- Requirement: Full matrix no longer reports `micro_c + policy=ir` failures.
  - Evidence:
    - `/tmp/liric_bench/matrix_summary.json` shows `"status": "OK"` and `"cells_failed": 0`.
    - `/tmp/liric_bench/matrix_failures.jsonl` is empty (`0` bytes).

- Regression safety (unit/integration harness).
  - Command: `./build/test_liric`
  - Evidence (from `/tmp/test_liric_issue416.log`):
    - `test_session_ir_lookup_prefers_module_symbol_over_process_symbol... ok`
    - `249 tests: 249 passed, 0 failed`
