### PR TITLE
fix: bench_lane_ir llvm/direct is partial (3/100) due to broad skip (fixes #415)

### DIFF
--- a/src/liric_compat.c
+++ b/src/liric_compat.c
@@ -3200,7 +3200,7 @@ static int compat_add_to_jit_direct(lc_module_compat_t *mod, lr_jit_t *jit) {
         void *addr = NULL;
         if (!f->name || !f->name[0])
             continue;
-        addr = lr_jit_get_function(session_jit, f->name);
+        addr = lr_session_lookup(mod->session, f->name);
         if (!f->is_decl && !addr)
             return -1;
         if (addr)
@@ -3211,7 +3211,7 @@ static int compat_add_to_jit_direct(lc_module_compat_t *mod, lr_jit_t *jit) {
         void *addr = NULL;
         if (!g->name || !g->name[0])
             continue;
-        addr = lr_jit_get_function(session_jit, g->name);
+        addr = lr_session_lookup(mod->session, g->name);
         if (!g->is_external && !addr)
             return -1;
         if (addr)

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -218,6 +218,7 @@ int test_session_arithmetic_chain(void);
 int test_session_stream_stencil_fast_path(void);
 int test_session_stream_isel_fast_path(void);
 int test_session_direct_llvm_mode_stream_contract(void);
+int test_session_direct_llvm_forward_ref_lookup_contract(void);
 int test_session_explicit_backend_overrides_env(void);
 int test_session_stream_stencil_no_ir_fallback(void);
 int test_session_add_phi_copy_api(void);
@@ -510,6 +511,7 @@ int main(void) {
     RUN_TEST(test_session_stream_stencil_fast_path);
     RUN_TEST(test_session_stream_isel_fast_path);
     RUN_TEST(test_session_direct_llvm_mode_stream_contract);
+    RUN_TEST(test_session_direct_llvm_forward_ref_lookup_contract);
     RUN_TEST(test_session_explicit_backend_overrides_env);
     RUN_TEST(test_session_stream_stencil_no_ir_fallback);
     RUN_TEST(test_session_add_phi_copy_api);


### PR DESCRIPTION
## Summary
- Defer module JIT in `DIRECT+llvm` when `lr_session_func_end(..., out_addr=NULL)` is used, and materialize once at `lr_session_lookup()` so forward references resolve against the full module.
- Add a DIRECT+llvm forward-reference regression test: `test_session_direct_llvm_forward_ref_lookup_contract`.
- Keep compat DIRECT add-to-jit working with deferred DIRECT+llvm materialization by resolving symbols through `lr_session_lookup()`.

## Verification
1. Requirement: `ir_file + llvm + direct` no longer partial/ambiguous.
- Command: `./build/bench_matrix --modes llvm --policies direct --lanes ir_file --iters 1 --skip-compat-check`
- Output excerpt: `[matrix] cells: attempted=1 ok=1 failed=0`
- Artifact: `/tmp/liric_bench/matrix_summary.json` has `"status":"OK"`, `"cells_failed":0`.

2. Requirement: canonical corpus lane completes `100/100` (no broad skips).
- Artifact: `/tmp/liric_bench/matrix_rows.jsonl` row has `"status":"OK","attempted":100,"completed":100`.
- Artifact: `/tmp/liric_bench/llvm/direct/ir_file/bench_corpus_compare_summary.json` has `"status":"OK"`, `"attempted_tests":100`, `"completed_tests":100`.

3. Requirement: forward-reference resolution is deterministic at lookup boundary for DIRECT+llvm.
- Command: compile+run targeted repro `/tmp/repro_session_forward_direct_llvm.c`
- Output excerpt: `session direct+llvm forward-ref repro ok`

4. Regression safety for compat DIRECT+llvm add-to-jit path.
- Command: compile+run targeted repro `/tmp/repro_compat_phi_direct_llvm.c`
- Output excerpt: `compat direct+llvm repro ok`

5. Required benchmark precondition from repo policy (rebuild external lfortran binary before benchmark verification).
- Command: `cmake --build ../lfortran/build -j$(nproc)`
- Output excerpt: build completed (runtime regeneration steps finished successfully).
