### PR TITLE
fix: Session DIRECT fails on forward function/global symbol reference (fixes #407)

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -219,6 +219,8 @@ int test_session_stream_stencil_fast_path(void);
 int test_session_stream_isel_fast_path(void);
 int test_session_direct_llvm_mode_stream_contract(void);
 int test_session_direct_llvm_forward_ref_lookup_contract(void);
+int test_session_direct_forward_ref_lookup_contract(void);
+int test_session_direct_forward_global_lookup_contract(void);
 int test_session_explicit_backend_overrides_env(void);
 int test_session_stream_stencil_no_ir_fallback(void);
 int test_session_add_phi_copy_api(void);
@@ -512,6 +514,8 @@ int main(void) {
     RUN_TEST(test_session_stream_isel_fast_path);
     RUN_TEST(test_session_direct_llvm_mode_stream_contract);
     RUN_TEST(test_session_direct_llvm_forward_ref_lookup_contract);
+    RUN_TEST(test_session_direct_forward_ref_lookup_contract);
+    RUN_TEST(test_session_direct_forward_global_lookup_contract);
     RUN_TEST(test_session_explicit_backend_overrides_env);
     RUN_TEST(test_session_stream_stencil_no_ir_fallback);
     RUN_TEST(test_session_add_phi_copy_api);


### PR DESCRIPTION
## Summary
- fixed DIRECT deferred relocation handling to distinguish unresolved-symbol deferral from hard relocation patch errors
- wrapped deferred relocation patching in JIT update windows so late patches run with writable code pages
- materialized globals on lookup/global mutation paths so forward global references can resolve after late definitions
- added DIRECT regression tests for forward function and forward global references

## Verification
- Requirement 1: Forward-reference modules no longer fail during per-function DIRECT finalize.
  - Evidence: new tests `test_session_direct_forward_ref_lookup_contract` and `test_session_direct_forward_global_lookup_contract` in `tests/test_session.c`.
  - Command: `cc -O2 -g -Iinclude -I. /tmp/issue407_verify.c -o /tmp/issue407_verify build/libliric.a -ldl -lm -lLLVM-21 -lstdc++ && /tmp/issue407_verify 2>&1 | tee /tmp/test.log`
  - Output excerpt: `issue407 verification: ok`
  - Artifact: `/tmp/test.log`
- Requirement 2: Keep strict DIRECT semantics (no IR fallback / no skip carveouts for this forward-ref behavior).
  - Evidence: forward-ref regressions exercise DIRECT mode with `cfg.mode = LR_MODE_DIRECT` and `cfg.backend = LR_SESSION_BACKEND_ISEL`, and verify deferred lookup before symbols are defined plus successful resolution after definitions.
- Requirement 3: Resolution errors are deferred only for unresolved symbols; hard relocation patch failures are explicit.
  - Evidence: `src/session.c` now uses `patch_direct_relocs()` (returns unresolved-symbol vs hard-error states) and fails with `S_ERR_BACKEND` on non-symbol patch failures instead of silently deferring all failures.

## Notes
- Rebuilt liric and rebuilt lfortran runtime tree per repo policy:
  - `cmake --build build -j$(nproc)`
  - `cmake --build ../lfortran/build -j$(nproc)`
