### PR TITLE
fix: Unified API reset: streaming-first single public surface (fixes #390)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,14 @@ add_test(
 )
 
 add_test(
+    NAME bench_matrix_requires_lfortran_liric
+    COMMAND ${CMAKE_COMMAND}
+        -DBENCH_MATRIX=$<TARGET_FILE:bench_matrix>
+        -DWORKDIR=${LIRIC_CTEST_WORK_ROOT}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_matrix_requires_lfortran_liric.cmake
+)
+
+add_test(
     NAME bench_api_nonzero_compat
     COMMAND ${CMAKE_COMMAND}
         -DBENCH_API=$<TARGET_FILE:bench_api>
@@ -578,6 +586,14 @@ add_test(
         -DBENCH_API=$<TARGET_FILE:bench_api>
         -DWORKDIR=${LIRIC_CTEST_WORK_ROOT}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_api_empty_dataset_gate.cmake
+)
+
+add_test(
+    NAME bench_api_requires_lfortran_liric
+    COMMAND ${CMAKE_COMMAND}
+        -DBENCH_API=$<TARGET_FILE:bench_api>
+        -DWORKDIR=${LIRIC_CTEST_WORK_ROOT}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_api_requires_lfortran_liric.cmake
 )
 
 add_test(

--- a/tests/cmake/test_bench_api_requires_lfortran_liric.cmake
+++ b/tests/cmake/test_bench_api_requires_lfortran_liric.cmake
@@ -1,0 +1,41 @@
+if(NOT DEFINED BENCH_API OR NOT DEFINED WORKDIR)
+    message(FATAL_ERROR "BENCH_API and WORKDIR are required")
+endif()
+
+set(root "${WORKDIR}/bench_api_requires_lfortran_liric")
+set(bench_dir "${root}/bench")
+
+file(REMOVE_RECURSE "${root}")
+file(MAKE_DIRECTORY "${bench_dir}")
+
+find_program(TRUE_EXE true)
+if(NOT TRUE_EXE)
+    message(FATAL_ERROR "true executable is required")
+endif()
+
+execute_process(
+    COMMAND "${BENCH_API}"
+        --bench-dir "${bench_dir}"
+        --lfortran "${TRUE_EXE}"
+        --allow-empty
+    WORKING_DIRECTORY "${root}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+)
+
+if(rc EQUAL 0)
+    message(FATAL_ERROR
+        "bench_api should fail without a WITH_LIRIC binary\nstdout:\n${out}\nstderr:\n${err}"
+    )
+endif()
+
+if(NOT err MATCHES "lfortran \\(WITH_LIRIC\\) not found")
+    message(FATAL_ERROR
+        "missing expected WITH_LIRIC preflight error\nstdout:\n${out}\nstderr:\n${err}"
+    )
+endif()
+
+if(EXISTS "${bench_dir}/bench_api_summary.json")
+    message(FATAL_ERROR "bench_api_summary.json must not be produced on binary preflight failure")
+endif()

--- a/tests/cmake/test_bench_matrix_lfortran_rebuild.cmake
+++ b/tests/cmake/test_bench_matrix_lfortran_rebuild.cmake
@@ -25,6 +25,8 @@ set(mode_log "${log_dir}/mode.log")
 set(fake_cmake "${root}/fake_cmake.sh")
 set(fake_compat "${root}/fake_bench_compat_check.sh")
 set(fake_api "${root}/fake_bench_api.sh")
+set(fake_lfortran_llvm "${root}/fake_lfortran_llvm.sh")
+set(fake_lfortran_liric "${root}/fake_lfortran_liric.sh")
 set(llvm_build_dir "${root}/lfortran_build_llvm")
 set(liric_build_dir "${root}/lfortran_build_liric")
 set(manifest "${CMAKE_CURRENT_LIST_DIR}/../../tools/bench_manifest.json")
@@ -102,7 +104,19 @@ cat > \"$bench_dir/bench_api_summary.json\" <<'JSON'
 JSON
 ")
 
-execute_process(COMMAND "${CHMOD_EXE}" +x "${fake_cmake}" "${fake_compat}" "${fake_api}")
+file(WRITE "${fake_lfortran_llvm}" "#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+")
+
+file(WRITE "${fake_lfortran_liric}" "#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+")
+
+execute_process(COMMAND "${CHMOD_EXE}" +x
+    "${fake_cmake}" "${fake_compat}" "${fake_api}"
+    "${fake_lfortran_llvm}" "${fake_lfortran_liric}")
 
 execute_process(
     COMMAND "${BENCH_MATRIX}"
@@ -117,8 +131,8 @@ execute_process(
         --cmake "${fake_cmake}"
         --lfortran-build-dir "${llvm_build_dir}"
         --lfortran-liric-build-dir "${liric_build_dir}"
-        --lfortran /opt/lfortran-llvm/bin/lfortran
-        --lfortran-liric /opt/lfortran-liric/bin/lfortran
+        --lfortran "${fake_lfortran_llvm}"
+        --lfortran-liric "${fake_lfortran_liric}"
         --bench-compat-check "${fake_compat}"
         --bench-api "${fake_api}"
     RESULT_VARIABLE rc

--- a/tests/cmake/test_bench_matrix_requires_lfortran_liric.cmake
+++ b/tests/cmake/test_bench_matrix_requires_lfortran_liric.cmake
@@ -1,0 +1,51 @@
+if(NOT DEFINED BENCH_MATRIX OR NOT DEFINED WORKDIR)
+    message(FATAL_ERROR "BENCH_MATRIX and WORKDIR are required")
+endif()
+
+set(root "${WORKDIR}/bench_matrix_requires_lfortran_liric")
+set(bench_dir "${root}/bench")
+set(manifest "${CMAKE_CURRENT_LIST_DIR}/../../tools/bench_manifest.json")
+
+file(REMOVE_RECURSE "${root}")
+file(MAKE_DIRECTORY "${bench_dir}")
+
+find_program(TRUE_EXE true)
+if(NOT TRUE_EXE)
+    message(FATAL_ERROR "true executable is required")
+endif()
+
+execute_process(
+    COMMAND "${BENCH_MATRIX}"
+        --bench-dir "${bench_dir}"
+        --manifest "${manifest}"
+        --modes isel
+        --policies direct
+        --lanes api_e2e
+        --iters 1
+        --timeout 5
+        --timeout-ms 500
+        --skip-lfortran-rebuild
+        --lfortran "${TRUE_EXE}"
+    WORKING_DIRECTORY "${root}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+)
+
+if(rc EQUAL 0)
+    message(FATAL_ERROR
+        "bench_matrix should fail when WITH_LIRIC lfortran binary is missing\nstdout:\n${out}\nstderr:\n${err}"
+    )
+endif()
+
+set(fails "${bench_dir}/matrix_failures.jsonl")
+if(NOT EXISTS "${fails}")
+    message(FATAL_ERROR "missing matrix_failures.jsonl:\nstdout:\n${out}\nstderr:\n${err}")
+endif()
+
+file(READ "${fails}" fails_text)
+if(NOT fails_text MATCHES "\"reason\":\"lfortran_liric_binary_missing\"")
+    message(FATAL_ERROR
+        "missing lfortran_liric_binary_missing failure reason\nfails:\n${fails_text}\nstdout:\n${out}\nstderr:\n${err}"
+    )
+endif()

--- a/tools/bench_api.c
+++ b/tools/bench_api.c
@@ -1515,7 +1515,7 @@ static const char *classify_llvm_failure_from_output(const cmd_result_t *r) {
 static void usage(void) {
     printf("usage: bench_lane_api [options]\n");
     printf("  --lfortran PATH      path to lfortran+LLVM binary (default: ../lfortran/build/src/bin/lfortran)\n");
-    printf("  --lfortran-liric PATH path to lfortran+WITH_LIRIC binary (default: ../lfortran/build-liric/src/bin/lfortran, fallback: ../lfortran/build_liric/src/bin/lfortran, then ../lfortran/build/src/bin/lfortran)\n");
+    printf("  --lfortran-liric PATH path to lfortran+WITH_LIRIC binary (default: ../lfortran/build-liric/src/bin/lfortran, fallback: ../lfortran/build_liric/src/bin/lfortran)\n");
     printf("  --runtime-lib PATH   runtime shared library to load in liric JIT sessions\n");
     printf("  --liric-compile-mode MODE  liric compile mode: isel|copy_patch|stencil|llvm\n");
     printf("  --liric-policy MODE  liric session policy: direct|ir\n");
@@ -1546,7 +1546,7 @@ static cfg_t parse_args(int argc, char **argv) {
                              ? default_lfortran_liric_hyphen
                              : (file_exists(default_lfortran_liric_underscore)
                                     ? default_lfortran_liric_underscore
-                                    : cfg.lfortran);
+                                    : NULL);
     cfg.runtime_lib = NULL;
     cfg.liric_compile_mode = getenv("LIRIC_COMPILE_MODE");
     if (!cfg.liric_compile_mode || !cfg.liric_compile_mode[0])
@@ -1630,6 +1630,9 @@ static cfg_t parse_args(int argc, char **argv) {
         die("invalid --liric-policy (expected direct|ir)", cfg.liric_policy);
 
     if (!file_exists(cfg.lfortran)) die("lfortran (LLVM) not found", cfg.lfortran);
+    if (!cfg.lfortran_liric || !cfg.lfortran_liric[0]) {
+        die("lfortran (WITH_LIRIC) not found; pass --lfortran-liric PATH", NULL);
+    }
     if (!file_exists(cfg.lfortran_liric)) die("lfortran (WITH_LIRIC) not found", cfg.lfortran_liric);
 
     cfg.lfortran = to_abs_path(cfg.lfortran);

--- a/tools/bench_matrix.c
+++ b/tools/bench_matrix.c
@@ -501,7 +501,7 @@ static cfg_t parse_args(int argc, char **argv) {
                              ? default_lfortran_liric_hyphen
                              : (file_exists(default_lfortran_liric_underscore)
                                     ? default_lfortran_liric_underscore
-                                    : cfg.lfortran);
+                                    : NULL);
     cfg.lfortran_build_dir = "../lfortran/build";
     cfg.lfortran_liric_build_dir = dir_exists(default_lfortran_build_liric_hyphen)
                                        ? default_lfortran_build_liric_hyphen
@@ -842,7 +842,32 @@ int main(int argc, char **argv) {
     if (!fails)
         die("failed to open failures output: %s", fails_path);
 
-    if (cfg.lanes[LANE_API_E2E] && cfg.rebuild_lfortran) {
+    if (cfg.lanes[LANE_API_E2E]) {
+        if (!cfg.lfortran || !cfg.lfortran[0] || !file_exists(cfg.lfortran)) {
+            write_failure_row(fails,
+                              "api_e2e",
+                              "all",
+                              "all",
+                              "lfortran_llvm",
+                              "lfortran_binary_missing",
+                              127,
+                              cfg.lfortran ? cfg.lfortran : "");
+            compat_ok = 0;
+        }
+        if (!cfg.lfortran_liric || !cfg.lfortran_liric[0] || !file_exists(cfg.lfortran_liric)) {
+            write_failure_row(fails,
+                              "api_e2e",
+                              "all",
+                              "all",
+                              "lfortran_llvm",
+                              "lfortran_liric_binary_missing",
+                              127,
+                              cfg.lfortran_liric ? cfg.lfortran_liric : "");
+            compat_ok = 0;
+        }
+    }
+
+    if (cfg.lanes[LANE_API_E2E] && cfg.rebuild_lfortran && compat_ok) {
         if (run_lfortran_rebuild_step(&cfg,
                                       fails,
                                       cfg.lfortran_build_dir,


### PR DESCRIPTION
## Summary
- Removed implicit `lfortran` -> `lfortran_liric` fallback in benchmark defaults so API/matrix runs cannot silently compare LLVM-vs-LLVM.
- Added explicit preflight failure paths when a WITH_LIRIC binary is unavailable.
- Added regression coverage for both `bench_api` and `bench_matrix` strict behavior.
- Updated existing `bench_matrix_lfortran_rebuild` fixture to provide executable fake lfortran binaries under the new preflight contract.

## Verification
- Requirement: `Unsupported combinations must hard-fail explicitly`
  Evidence: `bench_api` now fails immediately when WITH_LIRIC binary is missing (`tools/bench_api.c`), covered by test `bench_api_requires_lfortran_liric` (`tests/cmake/test_bench_api_requires_lfortran_liric.cmake`).
  Command: `ctest --test-dir build --output-on-failure -R "bench_matrix_lfortran_rebuild|bench_matrix_requires_lfortran_liric|bench_api_requires_lfortran_liric|bench_api_empty_dataset_gate"`
  Output excerpt: `Test #25: bench_api_requires_lfortran_liric ... Passed`

- Requirement: `No hidden fallback / no workaround path`
  Evidence: implicit default fallback was removed in both `bench_api` and `bench_matrix` (`tools/bench_api.c`, `tools/bench_matrix.c`), and matrix emits hard failure reason `lfortran_liric_binary_missing` when missing (`tests/cmake/test_bench_matrix_requires_lfortran_liric.cmake`).
  Command: same `ctest` command above.
  Output excerpt: `Test #22: bench_matrix_requires_lfortran_liric ... Passed`
  Artifact check in test: `matrix_failures.jsonl` contains `"reason":"lfortran_liric_binary_missing"`.

- Requirement: `Keep matrix preflight behavior valid under strict mode`
  Evidence: rebuild-path contract remains green with explicit fake binaries in `tests/cmake/test_bench_matrix_lfortran_rebuild.cmake`.
  Command: same `ctest` command above.
  Output excerpt: `Test #21: bench_matrix_lfortran_rebuild ... Passed`

- Regression sanity:
  Command: same `ctest` command above.
  Output excerpt: `100% tests passed, 0 tests failed out of 6`
