### PR TITLE
fix direct mode split function interleaving via suspend/resume

### DIFF
--- a/include/liric/liric_session.h
+++ b/include/liric/liric_session.h
@@ -179,6 +179,20 @@ lr_func_t *lr_session_cur_func(lr_session_t *s);
 lr_block_t *lr_session_cur_block(lr_session_t *s);
 lr_jit_t *lr_session_jit(lr_session_t *s);
 
+/* ---- Function suspension/resumption for interleaved generation --------- */
+
+/* Suspend the active direct-mode function compilation, saving all state.
+   Returns 0 on success, -1 on error. */
+int lr_session_suspend_func(lr_session_t *s);
+
+/* Resume a previously suspended function compilation by its index in the
+   suspended list. Returns 0 on success, -1 on error. */
+int lr_session_resume_func(lr_session_t *s, uint32_t suspended_idx);
+
+/* Find a suspended function by its lr_func_t pointer.
+   Returns the index in the suspended list, or -1 if not found. */
+int lr_session_find_suspended(lr_session_t *s, lr_func_t *func);
+
 /* ---- Inline convenience wrappers --------------------------------------- */
 
 static inline uint32_t lr_emit_add(lr_session_t *s, lr_type_t *ty,


### PR DESCRIPTION
## Summary

- Add function suspension/resumption infrastructure to the session API to handle interleaved function generation from lfortran's compat layer
- Use per-function malloc'd temp buffers (1MB) instead of writing directly to the JIT code buffer, preventing buffer overlap when functions compile out of order
- Handle relocation gaps for resumed functions by iterating over two disjoint ranges

## Why

When lfortran builds IR via the liric compat API, it sometimes interleaves function generation: while building `main`, it switches to build helper functions (`_copy_*`, `_allocate_*`), then returns to finish `main`. The previous `compat_bind_emit` finalized partially-built functions when switching, producing incomplete machine code (no `ret` instruction) that caused infinite loops at runtime.

**Stage:** Session / Compat API

## Changes

- [`src/session.c#L82-L113`](https://github.com/krystophny/liric/blob/ef8b2b5102b51bb84c5d697cc7627a6221a737ae/src/session.c#L82-L113): Add `FUNC_COMPILE_BUF_CAP` define and `suspended_compile_t` struct
- [`src/session.c#L134-L148`](https://github.com/krystophny/liric/blob/ef8b2b5102b51bb84c5d697cc7627a6221a737ae/src/session.c#L134-L148): Add suspension tracking fields to `struct lr_session`
- [`src/session.c#L561-L622`](https://github.com/krystophny/liric/blob/ef8b2b5102b51bb84c5d697cc7627a6221a737ae/src/session.c#L561-L622): Modify `begin_direct_compile` to use per-function temp buffer and register symbol as undefined
- [`src/session.c#L745-L862`](https://github.com/krystophny/liric/blob/ef8b2b5102b51bb84c5d697cc7627a6221a737ae/src/session.c#L745-L862): Modify `finish_direct_compile` to assign JIT offset after compile, copy from temp buffer, define symbol, handle reloc gaps
- [`src/session.c#L1005-L1188`](https://github.com/krystophny/liric/blob/ef8b2b5102b51bb84c5d697cc7627a6221a737ae/src/session.c#L1005-L1188): Add `lr_session_suspend_func`, `lr_session_resume_func`, `lr_session_find_suspended`, helpers
- [`src/liric_compat.c#L503-L589`](https://github.com/krystophny/liric/blob/ef8b2b5102b51bb84c5d697cc7627a6221a737ae/src/liric_compat.c#L503-L589): Rename to `compat_finish_one_func`, new `compat_finish_active_func` drains suspended list, `compat_bind_emit` suspends/resumes instead of finishing
- [`include/liric/liric_session.h#L182-L195`](https://github.com/krystophny/liric/blob/ef8b2b5102b51bb84c5d697cc7627a6221a737ae/include/liric/liric_session.h#L182-L195): Public API declarations for suspend/resume/find

## Tests

Existing test `test_builder_compat_memory_and_call_path` exercises the function-switching pattern (callee built first, then caller with call to callee). All 40 ctest tests pass, all 256 unit tests pass.

## Verification

### All ctest tests pass on branch
```
$ git checkout fix/direct-mode-split-function-interleaving
$ cmake --build build -j$(nproc) && ctest --test-dir build --output-on-failure
100% tests passed, 0 tests failed out of 40

$ ./build/test_liric
256 tests: 256 passed, 0 failed
```

### Integration tests pass on branch
```
$ LIRIC_COMPILE_MODE=isel LIRIC_POLICY=direct timeout 15 lfortran --backend=llvm --no-color integration_tests/allocate_13.f90
ok
exit=0

$ LIRIC_COMPILE_MODE=isel LIRIC_POLICY=direct timeout 15 lfortran --backend=llvm --no-color integration_tests/allocatable_polymorphic_mold_01.f90
exit=0
```

Note: The immediate hang symptoms were resolved by commit 0509175 (block offset corruption fix). This PR addresses the root cause at the architectural level: proper suspension/resumption instead of premature finalization of partially-built functions.