### PR TITLE
fix: compat: BasicBlock mutation stubs for erase/move ops (fixes #436)

### DIFF
--- a/include/liric/liric_compat.h
+++ b/include/liric/liric_compat.h
@@ -203,6 +203,10 @@ lr_func_t *lc_value_get_block_func(lc_value_t *val);
 lc_phi_node_t *lc_value_get_phi_node(lc_value_t *val);
 lr_type_t *lc_value_get_alloca_type(lc_value_t *val);
 bool lc_block_has_terminator(lr_block_t *block);
+bool lc_func_uses_block_id(lr_func_t *func, lr_block_t *skip_block,
+                            uint32_t block_id);
+void lc_func_remap_block_operands_after_erase(lr_func_t *func,
+                                               uint32_t removed_id);
 
 /* ---- Value/switch compat helpers ---- */
 int lc_value_replace_all_uses_with(lc_value_t *from, lc_value_t *to);

--- a/include/llvm/IR/BasicBlock.h
+++ b/include/llvm/IR/BasicBlock.h
@@ -17,6 +17,39 @@ class Instruction;
 class LLVMContext;
 class Module;
 
+namespace detail {
+
+inline lr_block_t *find_prev_block(lr_func_t *func, lr_block_t *target) {
+    if (!func || !target || func->first_block == target) return nullptr;
+    for (lr_block_t *b = func->first_block; b && b->next; b = b->next) {
+        if (b->next == target) return b;
+    }
+    return nullptr;
+}
+
+inline void invalidate_function_block_caches(lr_func_t *func) {
+    if (!func) return;
+    func->block_array = nullptr;
+    func->linear_inst_array = nullptr;
+    func->block_inst_offsets = nullptr;
+    func->num_linear_insts = 0;
+}
+
+inline bool function_uses_block_id(const lr_func_t *func,
+                                   const lr_block_t *skip,
+                                   uint32_t block_id) {
+    return lc_func_uses_block_id(const_cast<lr_func_t *>(func),
+                                 const_cast<lr_block_t *>(skip),
+                                 block_id);
+}
+
+inline void remap_block_operands_after_erase(lr_func_t *func,
+                                             uint32_t removed_id) {
+    lc_func_remap_block_operands_after_erase(func, removed_id);
+}
+
+} // namespace detail
+
 class BasicBlock : public Value {
 public:
     using iterator = Instruction *;
@@ -74,9 +107,105 @@ public:
     BasicBlock *getSinglePredecessor() const { return nullptr; }
     BasicBlock *getUniquePredecessor() const { return nullptr; }
 
-    void eraseFromParent() {}
-    void moveAfter(BasicBlock *) {}
-    void moveBefore(BasicBlock *) {}
+    void eraseFromParent() {
+        lr_block_t *block = impl_block();
+        if (!block || !block->func) return;
+
+        lr_func_t *func = block->func;
+        if (detail::function_uses_block_id(func, block, block->id)) {
+            return;
+        }
+
+        lr_block_t *prev = detail::find_prev_block(func, block);
+        if (!prev && func->first_block != block) return;
+
+        if (prev) {
+            prev->next = block->next;
+        } else {
+            func->first_block = block->next;
+        }
+        if (func->last_block == block) {
+            func->last_block = prev;
+        }
+
+        const uint32_t removed_id = block->id;
+        block->func = nullptr;
+        block->next = nullptr;
+        detail::unregister_block_parent(block);
+
+        if (func->num_blocks > 0u) {
+            func->num_blocks--;
+        }
+        for (lr_block_t *it = func->first_block; it; it = it->next) {
+            if (it->id > removed_id) it->id--;
+        }
+        detail::remap_block_operands_after_erase(func, removed_id);
+        if (!func->first_block) {
+            func->is_decl = true;
+        } else {
+            func->is_decl = false;
+        }
+        detail::invalidate_function_block_caches(func);
+    }
+
+    void moveAfter(BasicBlock *other) {
+        lr_block_t *block = impl_block();
+        lr_block_t *anchor = other ? other->impl_block() : nullptr;
+        if (!block || !anchor || block == anchor) return;
+        if (!block->func || block->func != anchor->func) return;
+
+        lr_func_t *func = block->func;
+        if (anchor->next == block) return;
+
+        lr_block_t *prev = detail::find_prev_block(func, block);
+        if (!prev && func->first_block != block) return;
+
+        if (prev) {
+            prev->next = block->next;
+        } else {
+            func->first_block = block->next;
+        }
+        if (func->last_block == block) {
+            func->last_block = prev;
+        }
+
+        block->next = anchor->next;
+        anchor->next = block;
+        if (func->last_block == anchor) {
+            func->last_block = block;
+        }
+        detail::invalidate_function_block_caches(func);
+    }
+
+    void moveBefore(BasicBlock *other) {
+        lr_block_t *block = impl_block();
+        lr_block_t *anchor = other ? other->impl_block() : nullptr;
+        if (!block || !anchor || block == anchor) return;
+        if (!block->func || block->func != anchor->func) return;
+        if (block->next == anchor) return;
+
+        lr_func_t *func = block->func;
+        lr_block_t *prev = detail::find_prev_block(func, block);
+        if (!prev && func->first_block != block) return;
+
+        if (prev) {
+            prev->next = block->next;
+        } else {
+            func->first_block = block->next;
+        }
+        if (func->last_block == block) {
+            func->last_block = prev;
+        }
+
+        lr_block_t *anchor_prev = detail::find_prev_block(func, anchor);
+        if (anchor_prev) {
+            anchor_prev->next = block;
+        } else {
+            func->first_block = block;
+        }
+        block->next = anchor;
+        detail::invalidate_function_block_caches(func);
+    }
 };
 
 } // namespace llvm

--- a/include/llvm/IR/LLVMContext.h
+++ b/include/llvm/IR/LLVMContext.h
@@ -72,6 +72,10 @@ namespace detail {
         return it == block_parents.end() ? nullptr : it->second;
     }
 
+    inline void unregister_block_parent(const lr_block_t *b) {
+        if (b) block_parents.erase(b);
+    }
+
     inline void unregister_blocks_for_function(Function *fn) {
         for (auto it = block_parents.begin(); it != block_parents.end();) {
             if (it->second == fn) {


### PR DESCRIPTION
## Summary
- implement real LLVM-compat `BasicBlock` mutations for `eraseFromParent()`, `moveAfter()`, and `moveBefore()`.
- keep parent/cache state consistent by clearing stale block-parent mappings and invalidating function block/linearization caches after mutation.
- add compat C helpers to (1) guard erase when block IDs are still referenced and (2) remap block-id operands after an erase.
- add regression coverage in `test_llvm_compat` (`test_basicblock_mutation_ops`).

## Verification
- Requirement: `BasicBlock` mutation methods are no longer no-op stubs.
  - Evidence: implemented in `include/llvm/IR/BasicBlock.h` with real unlink/reinsert/erase behavior.
  - Evidence: support functions added in `src/liric_compat.c` and declared in `include/liric/liric_compat.h` to detect/remap block-id operand references.
  - Evidence: stale parent-cache entry cleanup added in `include/llvm/IR/LLVMContext.h`.
- Requirement: mutation behavior is tested end-to-end.
  - Command: `(cmake --build build -j$(nproc) && cmake --build build-compat -j$(nproc) && ./build-compat/test_llvm_compat) 2>&1 | tee /tmp/test_llvm_compat.log`
  - Output excerpt: `test_basicblock_mutation_ops... ok`
  - Output excerpt: `53 tests: 53 passed, 0 failed`
- Requirement: repo tests remain green after the change.
  - Command: `./build/test_liric 2>&1 | tee /tmp/test.log`
  - Output excerpt: `256 tests: 256 passed, 0 failed`
