### PR TITLE
fix: compat: provide no-op definitions for LLVMInitializeX86Target an (fixes #437)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,6 +690,14 @@ if(CMAKE_NM AND NOT WITH_REAL_LLVM_BACKEND)
             -DHAVE_LLVM_BITCODE=OFF
             -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_static_archive_symbols.cmake
     )
+    add_test(
+        NAME llvm_target_init_stubs_defined
+        COMMAND ${CMAKE_COMMAND}
+            -DNM_EXE=${CMAKE_NM}
+            -DARCHIVE=$<TARGET_FILE:liric>
+            -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_llvm_target_init_stubs.cmake
+    )
 endif()
 
 include(GNUInstallDirs)

--- a/src/llvm_stubs.c
+++ b/src/llvm_stubs.c
@@ -1,14 +1,18 @@
 #if !defined(LIRIC_HAVE_REAL_LLVM_BACKEND) || !LIRIC_HAVE_REAL_LLVM_BACKEND
-void LLVMInitializeAArch64Target(void) {}
-void LLVMInitializeAArch64TargetInfo(void) {}
-void LLVMInitializeAArch64TargetMC(void) {}
-void LLVMInitializeAArch64AsmPrinter(void) {}
-void LLVMInitializeAArch64AsmParser(void) {}
-void LLVMInitializeX86Target(void) {}
-void LLVMInitializeX86TargetInfo(void) {}
-void LLVMInitializeX86TargetMC(void) {}
-void LLVMInitializeX86AsmPrinter(void) {}
-void LLVMInitializeX86AsmParser(void) {}
+#define LLVM_TARGET(TargetName) void LLVMInitialize##TargetName##Target(void) {}
+#include "llvm/Config/Targets.def"
+
+#define LLVM_TARGET(TargetName) void LLVMInitialize##TargetName##TargetInfo(void) {}
+#include "llvm/Config/Targets.def"
+
+#define LLVM_TARGET(TargetName) void LLVMInitialize##TargetName##TargetMC(void) {}
+#include "llvm/Config/Targets.def"
+
+#define LLVM_ASM_PRINTER(TargetName) void LLVMInitialize##TargetName##AsmPrinter(void) {}
+#include "llvm/Config/AsmPrinters.def"
+
+#define LLVM_ASM_PARSER(TargetName) void LLVMInitialize##TargetName##AsmParser(void) {}
+#include "llvm/Config/AsmParsers.def"
 #else
 int liric_real_llvm_backend_uses_system_target_init_symbols = 1;
 #endif

--- a/tests/cmake/test_llvm_target_init_stubs.cmake
+++ b/tests/cmake/test_llvm_target_init_stubs.cmake
@@ -1,0 +1,74 @@
+if(NOT DEFINED ARCHIVE OR ARCHIVE STREQUAL "")
+    message(FATAL_ERROR "ARCHIVE is required")
+endif()
+
+if(NOT EXISTS "${ARCHIVE}")
+    message(FATAL_ERROR "archive does not exist: ${ARCHIVE}")
+endif()
+
+if(NOT DEFINED SOURCE_DIR OR SOURCE_DIR STREQUAL "")
+    message(FATAL_ERROR "SOURCE_DIR is required")
+endif()
+
+set(_nm "${NM_EXE}")
+if(_nm STREQUAL "")
+    set(_nm nm)
+endif()
+
+function(read_def_names def_path macro_name out_var)
+    if(NOT EXISTS "${def_path}")
+        message(FATAL_ERROR "missing def file: ${def_path}")
+    endif()
+    file(STRINGS "${def_path}" _matches REGEX "^${macro_name}\\([A-Za-z0-9_]+\\)$")
+    set(_names "")
+    foreach(_match IN LISTS _matches)
+        string(REGEX REPLACE "${macro_name}\\(([A-Za-z0-9_]+)\\)" "\\1" _name "${_match}")
+        list(APPEND _names "${_name}")
+    endforeach()
+    set(${out_var} "${_names}" PARENT_SCOPE)
+endfunction()
+
+read_def_names("${SOURCE_DIR}/include/llvm/Config/Targets.def" "LLVM_TARGET" target_names)
+read_def_names("${SOURCE_DIR}/include/llvm/Config/AsmPrinters.def" "LLVM_ASM_PRINTER" printer_names)
+read_def_names("${SOURCE_DIR}/include/llvm/Config/AsmParsers.def" "LLVM_ASM_PARSER" parser_names)
+
+set(expected_symbols "")
+foreach(_target IN LISTS target_names)
+    list(APPEND expected_symbols
+        "LLVMInitialize${_target}Target"
+        "LLVMInitialize${_target}TargetInfo"
+        "LLVMInitialize${_target}TargetMC"
+    )
+endforeach()
+foreach(_target IN LISTS printer_names)
+    list(APPEND expected_symbols "LLVMInitialize${_target}AsmPrinter")
+endforeach()
+foreach(_target IN LISTS parser_names)
+    list(APPEND expected_symbols "LLVMInitialize${_target}AsmParser")
+endforeach()
+
+list(REMOVE_DUPLICATES expected_symbols)
+
+execute_process(
+    COMMAND "${_nm}" -g --defined-only "${ARCHIVE}"
+    RESULT_VARIABLE NM_RC
+    OUTPUT_VARIABLE NM_OUT
+    ERROR_VARIABLE NM_ERR
+)
+
+if(NOT NM_RC EQUAL 0)
+    message(FATAL_ERROR "nm failed (${NM_RC}): ${NM_ERR}")
+endif()
+
+set(missing "")
+foreach(_sym IN LISTS expected_symbols)
+    if(NOT NM_OUT MATCHES "([ \t\r\n]|^)_?${_sym}([ \t\r\n]|$)")
+        list(APPEND missing "${_sym}")
+    endif()
+endforeach()
+
+if(missing)
+    string(REPLACE ";" "\n" missing_text "${missing}")
+    message(FATAL_ERROR
+        "missing LLVM target initialization stubs in libliric.a:\n${missing_text}")
+endif()


### PR DESCRIPTION
## Summary
- Replace hardcoded `LLVMInitialize*` stubs in `src/llvm_stubs.c` with `.def`-driven generation from:
  - `include/llvm/Config/Targets.def`
  - `include/llvm/Config/AsmPrinters.def`
  - `include/llvm/Config/AsmParsers.def`
- Add regression test `llvm_target_init_stubs_defined` (`tests/cmake/test_llvm_target_init_stubs.cmake`) that derives the expected symbol set from those `.def` files and verifies they are defined in `libliric.a`.
- Register the new test in `CMakeLists.txt` under the existing `CMAKE_NM && !WITH_REAL_LLVM_BACKEND` test gate.

## Verification
- Requirement: provide no-op definitions for all targets listed in `Targets.def` and `AsmPrinters.def`/`AsmParsers.def`.
  - Evidence: `src/llvm_stubs.c` now includes those `.def` files for all five symbol families (`Target`, `TargetInfo`, `TargetMC`, `AsmPrinter`, `AsmParser`) so the stub list follows config automatically.
  - Evidence path: `src/llvm_stubs.c`

- Requirement: ensure every expected init symbol from `.def` files is defined in non-real-LLVM builds.
  - Evidence command: `ctest --test-dir build --output-on-failure -R "(liric_static_archive_no_llvm_undef|llvm_target_init_stubs_defined)"`
  - Output excerpt: `100% tests passed, 0 tests failed out of 4`
  - Evidence log: `/tmp/test_final.log`

- Requirement: symbols are actually present in the built archive (link-time availability).
  - Evidence command: `nm -g --defined-only build/libliric.a | rg "LLVMInitialize(AArch64|X86)(Target|TargetInfo|TargetMC|AsmPrinter|AsmParser)"`
  - Output excerpt:
    - `00000000 T LLVMInitializeAArch64Target`
    - `00000000 T LLVMInitializeAArch64TargetInfo`
    - `00000000 T LLVMInitializeAArch64TargetMC`
    - `00000000 T LLVMInitializeAArch64AsmPrinter`
    - `00000000 T LLVMInitializeAArch64AsmParser`
    - `00000000 T LLVMInitializeX86Target`
    - `00000000 T LLVMInitializeX86TargetInfo`
    - `00000000 T LLVMInitializeX86TargetMC`
    - `00000000 T LLVMInitializeX86AsmPrinter`
    - `00000000 T LLVMInitializeX86AsmParser`
  - Artifact path: `build/libliric.a`
