### PR TITLE
fix: WITH_LIRIC nightly_mass: rc-mismatch class (2 cases) (fixes #446)

### DIFF
--- a/tests/cmake/test_nightly_mass_shell_runner.cmake
+++ b/tests/cmake/test_nightly_mass_shell_runner.cmake
@@ -77,6 +77,7 @@ endif()
 
 file(WRITE "${COMPAT_FAIL}"
     "{\"name\":\"case_mismatch\",\"source\":\"/tmp/c.f90\",\"options\":\"\",\"llvm_ok\":true,\"liric_ok\":true,\"lli_ok\":true,\"liric_match\":false,\"lli_match\":false,\"llvm_rc\":0,\"liric_rc\":0,\"lli_rc\":0,\"error\":\"\"}\n"
+    "{\"name\":\"case_rc_mismatch\",\"source\":\"/tmp/e.f90\",\"options\":\"\",\"llvm_ok\":true,\"liric_ok\":true,\"lli_ok\":true,\"liric_match\":false,\"lli_match\":false,\"llvm_rc\":0,\"liric_rc\":1,\"lli_rc\":1,\"error\":\"\"}\n"
     "{\"name\":\"case_unresolved_symbol\",\"source\":\"/tmp/d.f90\",\"options\":\"\",\"llvm_ok\":true,\"liric_ok\":false,\"lli_ok\":false,\"liric_match\":false,\"lli_match\":false,\"llvm_rc\":0,\"liric_rc\":-1,\"lli_rc\":-1,\"error\":\"unresolved symbol: _lfortran_printf\"}\n"
 )
 file(WRITE "${BASELINE_FAIL}"
@@ -100,8 +101,8 @@ if(fail_rc EQUAL 0)
 endif()
 
 file(READ "${OUT_FAIL}/summary.json" summary_fail)
-if(NOT summary_fail MATCHES "\"mismatch_count\"[ \t]*:[ \t]*1")
-    message(FATAL_ERROR "expected mismatch_count=1 in fail summary")
+if(NOT summary_fail MATCHES "\"mismatch_count\"[ \t]*:[ \t]*2")
+    message(FATAL_ERROR "expected mismatch_count=2 in fail summary")
 endif()
 if(NOT summary_fail MATCHES "\"new_supported_regressions\"[ \t]*:[ \t]*1")
     message(FATAL_ERROR "expected new_supported_regressions=1 in fail summary")
@@ -112,6 +113,9 @@ endif()
 if(NOT summary_fail MATCHES "\"unsupported_abi\"[ \t]*:[ \t]*1")
     message(FATAL_ERROR "expected unsupported_abi=1 in fail summary")
 endif()
+if(NOT summary_fail MATCHES "output-format\\|rc-mismatch\\|general")
+    message(FATAL_ERROR "expected rc-mismatch taxonomy bucket in fail summary")
+endif()
 if(NOT summary_fail MATCHES "jit-link\\|unresolved-symbol\\|runtime-api")
     message(FATAL_ERROR "expected unresolved-symbol taxonomy bucket in fail summary")
 endif()
@@ -120,4 +124,12 @@ if(NOT summary_fail MATCHES "\"mapped\"[ \t]*:[ \t]*true")
 endif()
 if(NOT summary_fail MATCHES "\"#[0-9][0-9]*\"")
     message(FATAL_ERROR "expected unsupported bucket issue mapping to include an issue reference")
+endif()
+
+file(READ "${OUT_FAIL}/summary.md" summary_fail_md)
+if(NOT summary_fail_md MATCHES "## Taxonomy Counts \\(Mismatch\\)")
+    message(FATAL_ERROR "expected mismatch taxonomy section in fail summary markdown")
+endif()
+if(NOT summary_fail_md MATCHES "output-format\\|rc-mismatch\\|general")
+    message(FATAL_ERROR "expected rc-mismatch entry in fail summary markdown")
 endif()


### PR DESCRIPTION
## Summary
- Surface mismatch taxonomy details in `nightly_mass.sh` reports so `rc-mismatch` is explicitly tracked apart from `wrong-stdout`.
- Add mismatch bucket coverage/mapping fields to `summary.json` and corresponding sections to `summary.md`.
- Extend `nightly_mass_shell_runner` contract test with a dedicated rc-mismatch case and assertions for the new reporting sections.

## Verification
- Requirement: Track return-code mismatches separately from stdout mismatches.
  - Command: `ctest --test-dir build --output-on-failure -R '^nightly_mass_shell_runner$' 2>&1 | tee /tmp/test.log`
  - Output excerpt: `100% tests passed, 0 tests failed out of 3`
  - Artifact: `build/ctest_work/nightly_mass_shell_runner/out_fail/summary.json`
  - Evidence excerpt (`jq '{mismatch_count, mismatch_taxonomy_counts}' ...`):
    - `"mismatch_count": 2`
    - `"output-format|wrong-stdout|general": 1`
    - `"output-format|rc-mismatch|general": 1`

- Requirement: Human-facing report must show rc-mismatch taxonomy explicitly.
  - Command: `rg -n "Taxonomy Counts \\(Mismatch\\)|output-format\\|rc-mismatch\\|general|Mismatch Bucket Coverage" build/ctest_work/nightly_mass_shell_runner/out_fail/summary.md`
  - Output excerpt:
    - `28:## Taxonomy Counts (Mismatch)`
    - `30:- output-format|rc-mismatch|general: 1`
    - `33:## Mismatch Bucket Coverage`

- Requirement: rc-mismatch taxonomy bucket is mapped to the tracking issue.
  - Artifact: `build/ctest_work/nightly_mass_shell_runner/out_fail/summary.json`
  - Evidence excerpt (`jq '.mismatch_bucket_issue_coverage' ...`):
    - entry `"taxonomy_node": "output-format|rc-mismatch|general"`
    - `"mapped": true`
    - `"issues": ["#446"]`
