### PR TITLE
fix: WITH_LIRIC nightly_mass: unresolved runtime ABI class (3 cases) (fixes #448)

### DIFF
--- a/tests/cmake/test_nightly_mass_shell_runner.cmake
+++ b/tests/cmake/test_nightly_mass_shell_runner.cmake
@@ -79,6 +79,7 @@ file(WRITE "${COMPAT_FAIL}"
     "{\"name\":\"case_mismatch\",\"source\":\"/tmp/c.f90\",\"options\":\"\",\"llvm_ok\":true,\"liric_ok\":true,\"lli_ok\":true,\"liric_match\":false,\"lli_match\":false,\"llvm_rc\":0,\"liric_rc\":0,\"lli_rc\":0,\"error\":\"\"}\n"
     "{\"name\":\"case_rc_mismatch\",\"source\":\"/tmp/e.f90\",\"options\":\"\",\"llvm_ok\":true,\"liric_ok\":true,\"lli_ok\":true,\"liric_match\":false,\"lli_match\":false,\"llvm_rc\":0,\"liric_rc\":1,\"lli_rc\":1,\"error\":\"\"}\n"
     "{\"name\":\"case_unresolved_symbol\",\"source\":\"/tmp/d.f90\",\"options\":\"\",\"llvm_ok\":true,\"liric_ok\":false,\"lli_ok\":false,\"liric_match\":false,\"lli_match\":false,\"llvm_rc\":0,\"liric_rc\":-1,\"lli_rc\":-1,\"error\":\"unresolved symbol: _lfortran_printf\"}\n"
+    "{\"name\":\"case_runtime_failure\",\"source\":\"/tmp/f.f90\",\"options\":\"\",\"llvm_ok\":true,\"liric_ok\":false,\"lli_ok\":false,\"liric_match\":false,\"lli_match\":false,\"llvm_rc\":0,\"liric_rc\":-11,\"lli_rc\":-11,\"error\":\"segmentation fault\"}\n"
 )
 file(WRITE "${BASELINE_FAIL}"
     "{\"case_id\":\"case_mismatch\",\"classification\":\"pass\"}\n"
@@ -113,11 +114,17 @@ endif()
 if(NOT summary_fail MATCHES "\"unsupported_abi\"[ \t]*:[ \t]*1")
     message(FATAL_ERROR "expected unsupported_abi=1 in fail summary")
 endif()
+if(NOT summary_fail MATCHES "\"unsupported_feature\"[ \t]*:[ \t]*1")
+    message(FATAL_ERROR "expected unsupported_feature=1 in fail summary")
+endif()
 if(NOT summary_fail MATCHES "output-format\\|rc-mismatch\\|general")
     message(FATAL_ERROR "expected rc-mismatch taxonomy bucket in fail summary")
 endif()
 if(NOT summary_fail MATCHES "jit-link\\|unresolved-symbol\\|runtime-api")
     message(FATAL_ERROR "expected unresolved-symbol taxonomy bucket in fail summary")
+endif()
+if(NOT summary_fail MATCHES "runtime\\|unsupported-feature\\|general")
+    message(FATAL_ERROR "expected runtime unsupported-feature taxonomy bucket in fail summary")
 endif()
 if(NOT summary_fail MATCHES "\"mapped\"[ \t]*:[ \t]*true")
     message(FATAL_ERROR "expected unsupported bucket coverage entry to be mapped")
@@ -132,4 +139,7 @@ if(NOT summary_fail_md MATCHES "## Taxonomy Counts \\(Mismatch\\)")
 endif()
 if(NOT summary_fail_md MATCHES "output-format\\|rc-mismatch\\|general")
     message(FATAL_ERROR "expected rc-mismatch entry in fail summary markdown")
+endif()
+if(NOT summary_fail_md MATCHES "runtime\\|unsupported-feature\\|general")
+    message(FATAL_ERROR "expected runtime unsupported-feature entry in fail summary markdown")
 endif()

--- a/tools/lfortran_mass/nightly_mass.sh
+++ b/tools/lfortran_mass/nightly_mass.sh
@@ -194,7 +194,7 @@ jq -c '
 
 jq -c '
 def str_lc($v): ($v // "" | tostring | ascii_downcase);
-def has_any($s; $patterns): any($patterns[]; $s | contains(.));
+def has_any($s; $patterns): reduce $patterns[] as $p (false; . or ($s | contains($p)));
 def classify_liric_fail:
   (str_lc(.error)) as $err |
   if has_any($err; ["unresolved symbol", "function not found", "unsupported signature", "entrypoint", "dlsym"])


### PR DESCRIPTION
## Summary
- Fix `tools/lfortran_mass/nightly_mass.sh` pattern matching so `has_any()` checks each pattern correctly instead of always returning true.
- Prevent false `unsupported_abi` classification when LIRIC failures do not contain unresolved-symbol/link signatures.
- Extend `tests/cmake/test_nightly_mass_shell_runner.cmake` with a runtime-failure fixture and assertions that distinguish:
  - unresolved symbol -> `unsupported_abi`
  - generic runtime crash -> `unsupported_feature`

## Verification
- Requirement: unresolved-symbol bucketing must only trigger on ABI/link signature text, not all failures.
  - Command: `ctest --test-dir build --output-on-failure -R nightly_mass_shell_runner 2>&1 | tee /tmp/test.log`
  - Evidence: test passes and includes assertions for both `unsupported_abi=1` and `unsupported_feature=1` with correct taxonomy buckets.
  - Output excerpt:
    - `Test #35: nightly_mass_shell_runner ... Passed`
    - `100% tests passed, 0 tests failed out of 3`

- Requirement: current #448 corpus rows should no longer be forced into `jit-link|unresolved-symbol|runtime-api` when error text is empty/non-matching.
  - Command: `./tools/lfortran_mass/nightly_mass.sh --compat-jsonl /tmp/liric_mass_from_liric/bench/compat_check.jsonl --output-root /tmp/liric_mass_issue448_verify`
  - Evidence (`/tmp/liric_mass_issue448_verify/summary.json`):
    - `classification_counts`: `{"pass":2261,"mismatch":55,"lfortran_emit_fail":42,"unsupported_feature":3}`
    - `unsupported_taxonomy_counts`: `{"runtime|unsupported-feature|general":3}`
    - no `unsupported_abi` bucket remains for these 3 cases.
  - Artifact paths:
    - `/tmp/liric_mass_issue448_verify/summary.json`
    - `/tmp/liric_mass_issue448_verify/results.jsonl`
