### PR TITLE
fix: investigate 25ms subprocess overhead floor in API benchmarks (fixes #440)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,14 @@ add_test(
 )
 
 add_test(
+    NAME bench_api_subprocess_overhead_summary
+    COMMAND ${CMAKE_COMMAND}
+        -DBENCH_API=$<TARGET_FILE:bench_api>
+        -DWORKDIR=${LIRIC_CTEST_WORK_ROOT}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_api_subprocess_overhead_summary.cmake
+)
+
+add_test(
     NAME bench_api_empty_dataset_gate
     COMMAND ${CMAKE_COMMAND}
         -DBENCH_API=$<TARGET_FILE:bench_api>

--- a/tests/cmake/test_bench_api_subprocess_overhead_summary.cmake
+++ b/tests/cmake/test_bench_api_subprocess_overhead_summary.cmake
@@ -1,0 +1,106 @@
+if(NOT DEFINED BENCH_API OR NOT DEFINED WORKDIR)
+    message(FATAL_ERROR "BENCH_API and WORKDIR are required")
+endif()
+
+set(root "${WORKDIR}/bench_api_subprocess_overhead_summary")
+set(bench_dir "${root}/bench")
+set(test_dir "${root}/integration_tests")
+set(fake_llvm "${root}/fake_lfortran_llvm.sh")
+set(fake_liric "${root}/fake_lfortran_liric.sh")
+
+file(REMOVE_RECURSE "${root}")
+file(MAKE_DIRECTORY "${bench_dir}")
+file(MAKE_DIRECTORY "${test_dir}")
+
+file(WRITE "${bench_dir}/compat_ll.txt"
+"overhead_case\n")
+
+file(WRITE "${bench_dir}/compat_ll_options.jsonl"
+"{\"name\":\"overhead_case\",\"options\":\"\"}\n")
+
+file(WRITE "${test_dir}/overhead_case.f90"
+"program overhead_case\n"
+"print *, 1\n"
+"end program\n")
+
+file(WRITE "${fake_llvm}" "#!/usr/bin/env bash\n"
+"set -euo pipefail\n"
+"sleep 0.06\n"
+"cat <<'OUT'\n"
+"File reading: 4.0\n"
+"Src -> ASR: 4.0\n"
+"ASR passes (total): 4.0\n"
+"ASR -> mod: 4.0\n"
+"LLVM IR creation: 4.0\n"
+"LLVM opt: 4.0\n"
+"LLVM -> JIT: 11.0\n"
+"JIT run: 15.0\n"
+"Total time: 50.0\n"
+"OUT\n"
+"exit 0\n")
+
+file(WRITE "${fake_liric}" "#!/usr/bin/env bash\n"
+"set -euo pipefail\n"
+"sleep 0.06\n"
+"cat <<'OUT'\n"
+"File reading: 3.0\n"
+"Src -> ASR: 3.0\n"
+"ASR passes (total): 3.0\n"
+"ASR -> mod: 3.0\n"
+"LLVM IR creation: 3.0\n"
+"LLVM opt: 3.0\n"
+"LLVM -> JIT: 10.0\n"
+"JIT run: 12.0\n"
+"Total time: 40.0\n"
+"OUT\n"
+"exit 0\n")
+
+execute_process(COMMAND chmod +x "${fake_llvm}" "${fake_liric}"
+                RESULT_VARIABLE chmod_rc)
+if(NOT chmod_rc EQUAL 0)
+    message(FATAL_ERROR "chmod failed")
+endif()
+
+execute_process(
+    COMMAND "${BENCH_API}"
+        --lfortran "${fake_llvm}"
+        --lfortran-liric "${fake_liric}"
+        --test-dir "${test_dir}"
+        --bench-dir "${bench_dir}"
+        --timeout 5
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+)
+
+if(NOT rc EQUAL 0)
+    message(FATAL_ERROR "bench_api should pass when subprocess overhead summary is emitted\nstdout:\n${out}\nstderr:\n${err}")
+endif()
+
+set(summary "${bench_dir}/bench_api_summary.json")
+if(NOT EXISTS "${summary}")
+    message(FATAL_ERROR "missing bench_api_summary.json")
+endif()
+
+file(READ "${summary}" summary_text)
+if(NOT summary_text MATCHES "\"measurement_contract_version\": ")
+    message(FATAL_ERROR "summary missing measurement_contract_version:\n${summary_text}")
+endif()
+if(NOT summary_text MATCHES "\"subprocess_overhead\": \\{")
+    message(FATAL_ERROR "summary missing subprocess_overhead object:\n${summary_text}")
+endif()
+if(NOT summary_text MATCHES "\"has_data\": true")
+    message(FATAL_ERROR "subprocess_overhead.has_data should be true:\n${summary_text}")
+endif()
+if(NOT summary_text MATCHES "\"samples\": 1")
+    message(FATAL_ERROR "subprocess_overhead.samples should be 1:\n${summary_text}")
+endif()
+if(NOT summary_text MATCHES "\"method\": \"elapsed_ms_minus_time_report_total\"")
+    message(FATAL_ERROR "summary missing subprocess_overhead method:\n${summary_text}")
+endif()
+if(summary_text MATCHES "\"shared_floor_median_ms\": 0\\.000000")
+    message(FATAL_ERROR "shared_floor_median_ms should be non-zero:\n${summary_text}")
+endif()
+if(summary_text MATCHES "\"adjusted_wall_speedup_median\": 0\\.000000")
+    message(FATAL_ERROR "adjusted_wall_speedup_median should be non-zero:\n${summary_text}")
+endif()


### PR DESCRIPTION
## Summary
- add explicit subprocess-overhead analysis to `bench_api` using existing `elapsed_ms - time_report_total_ms` measurements
- emit a new `subprocess_overhead` block in `bench_api_summary.json` with median/avg overhead, shared floor estimate, and adjusted wall-speedup signal
- print the same overhead-floor section in CLI output for fast diagnosis
- add regression coverage (`bench_api_subprocess_overhead_summary`) and register it in CMake

## Verification
- Requirement: benchmark artifacts must expose the subprocess overhead floor directly.
  - Command: `ctest --test-dir build --output-on-failure -R "bench_api_nonzero_compat|bench_api_subprocess_overhead_summary"`
  - Output excerpt: `Test #21: bench_api_subprocess_overhead_summary ..........   Passed`
  - Artifact: `build/ctest_work/bench_api_subprocess_overhead_summary/bench/bench_api_summary.json`
  - Artifact excerpt (from `jq '{subprocess_overhead, full_pipeline: .full_pipeline.speedup}' ...`):
    - `subprocess_overhead.has_data: true`
    - `subprocess_overhead.shared_floor_median_ms: 13.448940`
    - `subprocess_overhead.observed_wall_speedup_median: 1.250000`
    - `subprocess_overhead.adjusted_wall_speedup_median: 1.376633`

- Requirement: existing API benchmark summary behavior remains compatible.
  - Command: same `ctest` run above
  - Output excerpt: `Test #20: bench_api_nonzero_compat .......................   Passed`

- Requirement: verification log should show no runtime/test errors.
  - Command: `rg -n "FAILED|[Ee]rror|Assertion|Segmentation" /tmp/test.log || true`
  - Output excerpt: *(no matches)*
