### PR TITLE
fix: LLVM-compat parity: implement real global linkage semantics (Glo (fixes #463)

### DIFF
--- a/include/liric/liric_types.h
+++ b/include/liric/liric_types.h
@@ -96,6 +96,7 @@ struct lr_global {
     struct lr_reloc *relocs;
     bool is_const;
     bool is_external;
+    bool is_local;
     uint32_t id;
     struct lr_global *next;
 };

--- a/include/llvm/IR/GlobalVariable.h
+++ b/include/llvm/IR/GlobalVariable.h
@@ -23,6 +23,10 @@ public:
         LocalExecTLSModel,
     };
 
+private:
+    lc_module_compat_t *compat_mod_ = nullptr;
+
+public:
     GlobalVariable() = default;
     ~GlobalVariable() {
         detail::unregister_value_wrapper(this);
@@ -41,6 +45,10 @@ public:
     bool hasInitializer() const;
     Constant *getInitializer() const;
     void setInitializer(Constant *InitVal);
+    void setLinkage(LinkageTypes lt);
+
+    void setCompatMod(lc_module_compat_t *m) { compat_mod_ = m; }
+    lc_module_compat_t *getCompatMod() const { return compat_mod_; }
 
     template <typename AlignTy>
     void setAlignment(AlignTy A) { (void)A; }

--- a/src/ir.c
+++ b/src/ir.c
@@ -852,6 +852,8 @@ lr_global_t *lr_global_create(lr_module_t *m, const char *name, lr_type_t *type,
     g->name = lr_arena_strdup(a, name, strlen(name));
     g->type = type;
     g->is_const = is_const;
+    g->is_external = false;
+    g->is_local = false;
     g->id = m->num_globals++;
     if (!m->first_global) m->first_global = g;
     else m->last_global->next = g;
@@ -2155,12 +2157,14 @@ int lr_module_merge(lr_module_t *dest, lr_module_t *src) {
                 dg->type = merge_remap_type(dest, sg->type);
                 dg->is_const = sg->is_const;
                 dg->is_external = false;
+                dg->is_local = sg->is_local;
                 merge_copy_global_data(dest, dg, sg);
             }
         } else {
             lr_global_t *ng = lr_global_create(dest, sg->name,
                 merge_remap_type(dest, sg->type), sg->is_const);
             ng->is_external = sg->is_external;
+            ng->is_local = sg->is_local;
             merge_copy_global_data(dest, ng, sg);
         }
     }

--- a/src/ir.h
+++ b/src/ir.h
@@ -142,6 +142,7 @@ typedef struct lr_global {
     lr_reloc_t *relocs;
     bool is_const;
     bool is_external;
+    bool is_local;
     uint32_t id;
     struct lr_global *next;
 } lr_global_t;

--- a/src/objfile.h
+++ b/src/objfile.h
@@ -37,6 +37,7 @@ typedef struct lr_obj_symbol {
     uint32_t offset;
     uint8_t section;
     bool is_defined;
+    bool is_local;
 } lr_obj_symbol_t;
 
 typedef struct lr_objfile_ctx {


### PR DESCRIPTION
## Summary
- Added explicit global linkage metadata in IR/shared structs via `lr_global_t.is_local`.
- Wired LLVM-compat global linkage mutation to compat IR state:
  - `GlobalVariable` now tracks its owning compat module.
  - `GlobalVariable::setLinkage()` now applies linkage to underlying globals.
  - Mapping implemented for local linkage semantics (`InternalLinkage`/`PrivateLinkage` => local, non-external).
- Updated object build/emission to preserve linkage semantics:
  - Global symbols carry `is_local` into object symbol metadata.
  - ELF `.symtab` now emits locals before globals, sets `STB_LOCAL`/`STB_GLOBAL` appropriately, and remaps reloc symbol indices accordingly.
- Added LLVM-compat regression coverage: `test_set_linkage_updates_object_symbol_binding`.

## Verification
- Requirement: Add linkage metadata to compat global representation.
  - Evidence: `lr_global_t.is_local` added and propagated in `src/ir.h`, `src/ir.c`, `include/liric/liric_types.h`.
  - Evidence command: `ctest --test-dir build-compat --output-on-failure -V -R "^llvm_compat_tests$"`
  - Output excerpt: `test_set_linkage_updates_object_symbol_binding... ok`

- Requirement: Implement linkage mapping for global linkage types used by current consumers.
  - Evidence: `GlobalVariable::setLinkage()` now applies linkage to compat globals in `include/llvm/IR/Module.h` via `applyCompatGlobalLinkage(...)`.
  - Output-affecting evidence: demotion to internal emits local binding and promotion to external emits global binding (asserted in test).

- Requirement: Plumb linkage from `GlobalValue::setLinkage`/`Module::createGlobalVariable`/`IRBuilder::CreateGlobalStringPtr` paths.
  - Evidence:
    - `Module::createGlobalVariable(...)` sets compat module and calls `setLinkage(...)` on globals.
    - Existing private string scoping path remains covered by `test_private_global_strings_are_module_scoped... ok`.
    - New test exercises post-creation `setLinkage(...)` mutation and verifies object symbols.

- Requirement: Ensure object emitter respects symbol visibility/linkage.
  - Evidence: `src/objfile.c` persists local-symbol flag; `src/objfile_elf.c` emits local/global bindings with correct local-first ordering and relocation remap.
  - Artifact: `/tmp/liric_test_llvm_compat_linkage_binding.o` (created and inspected by the new llvm-compat test).

- Requirement: Add/extend compatibility unit tests.
  - Evidence: Added `test_set_linkage_updates_object_symbol_binding` in `tests/test_llvm_compat.cpp` and registered in suite.

- Regression safety for core suite:
  - Command: `ctest --test-dir build --output-on-failure -V -R "^liric_tests$"`
  - Output excerpt: `256 tests: 256 passed, 0 failed`
