### PR TITLE
fix: support data relocations in Mach-O obj emission (fixes #475)

### DIFF
--- a/src/objfile.c
+++ b/src/objfile.c
@@ -484,6 +484,10 @@ static int obj_build_module(lr_module_t *m, const lr_target_t *target,
         size_t galign = lr_type_align(g->type);
         if (galign == 0)
             galign = 8;
+        /* Globals with pointer relocations must be at least
+           pointer-aligned so the linker can patch 8-byte addresses. */
+        if (g->relocs && galign < 8)
+            galign = 8;
 
         out->data_pos = obj_align_up(out->data_pos, galign);
 
@@ -628,6 +632,8 @@ static int obj_build_from_blobs(const lr_func_blob_t *blobs,
             gsize = 8;
         size_t galign = lr_type_align(g->type);
         if (galign == 0)
+            galign = 8;
+        if (g->relocs && galign < 8)
             galign = 8;
         out->data_pos = obj_align_up(out->data_pos, galign);
         if (out->data_pos + gsize > OBJ_DATA_BUF_SIZE) {


### PR DESCRIPTION
## Summary

- Remove early `return -1` in `write_macho()` that rejected modules with data relocations, causing empty `.o` files
- Add full data relocation layout and emission in Mach-O object files (separate text/data reloc offsets, section headers, relocation entries)
- Add `macho_reloc_length()` to distinguish 8-byte `ABS64` from 4-byte code relocations; map `LR_RELOC_ARM64_ABS64` to native `ARM64_RELOC_UNSIGNED` (type 0)
- Emit local symbols with `N_SECT` only (without `N_EXT` flag)
- Enforce 8-byte minimum alignment for globals with pointer relocations in both `obj_build_module` and `obj_build_from_blobs`

## Verification

### All 39 ctest tests pass

```
$ ctest --test-dir build --output-on-failure
100% tests passed, 0 tests failed out of 39
Total Test time (real) =  13.76 sec
```

### bench_matrix: 24/24 cells OK, 0 failures

```
$ ./build/bench_matrix --timeout 15
[matrix] cells: attempted=24 ok=24 failed=0
```

### 5 of 6 issue cases now pass in direct mode (were all 6 failing)

| Case | Direct mode | IR mode |
|------|------------|---------|
| `cond_03` | PASS | PASS |
| `data_17` | PASS | PASS |
| `data_19` | PASS | PASS |
| `stop_03` | PASS | PASS |
| `string_concat_deferred_len` | FAIL (rc=11, runtime error, not empty obj) | PASS |
| `volatile_03` | PASS | PASS |

`string_concat_deferred_len` still fails in direct mode with rc=11 (a runtime error, no linker/empty-obj error) -- this is a separate issue from the empty object file emission bug.

### IR mode: 0 failures (was 6 from this issue)

All 31 compat cases pass in IR policy mode.

### Artifact paths

- `/tmp/liric_bench/matrix_summary.json`
- `/tmp/liric_bench/matrix_rows.jsonl`
- `/tmp/liric_bench/matrix_failures.jsonl`