### PR TITLE
Fix WITH_LIRIC API compat intrinsic modfile generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,7 +504,7 @@ add_custom_target(
         -DWITH_LLVM=yes
         -DUSE_DYNAMIC_ZSTD=yes
     COMMAND ${CMAKE_COMMAND} --build ${LIRIC_LFORTRAN_BUILD_LLVM}
-        --target lfortran lfortran_runtime --parallel
+        --target lfortran lfortran_runtime build_runtime --parallel
     DEPENDS lfortran_prepare
     COMMENT "Configure/build LFortran baseline LLVM in ${LIRIC_LFORTRAN_BUILD_LLVM}"
     USES_TERMINAL
@@ -527,7 +527,7 @@ add_custom_target(
         -DWITH_RUNTIME_STACKTRACE=yes
         -DWITH_LLVM=OFF
     COMMAND ${CMAKE_COMMAND} --build ${LIRIC_LFORTRAN_BUILD_LIRIC}
-        --target lfortran lfortran_runtime --parallel
+        --target lfortran lfortran_runtime build_runtime --parallel
     DEPENDS lfortran_prepare liric_probe_runner
     COMMENT "Configure/build LFortran WITH_LIRIC in ${LIRIC_LFORTRAN_BUILD_LIRIC}"
     USES_TERMINAL


### PR DESCRIPTION
## Summary
- fix CMake-managed LFortran builds to also build the nested `build_runtime` target
- ensure intrinsic runtime `.mod` files are generated in both managed build trees before `lfortran_api_compat` runs with `--skip-lfortran-build`

## Root Cause
`lfortran_api_compat` depends on `lfortran_build_all`, but those custom targets were only building:
- `lfortran`
- `lfortran_runtime` (legacy C runtime)

They were not building LFortran's nested `build_runtime` target that produces:
- `lfortran_intrinsic_iso_c_binding.mod`
- `lfortran_intrinsic_iso_fortran_env.mod`
- `lfortran_intrinsic_ieee_arithmetic.mod`
- `lfortran_intrinsic_custom.mod`
- `omp_lib.mod`

So the compat lane could start without required intrinsic modfiles and fail with `modfile was not found`.

## Change
In `CMakeLists.txt`, update both managed LFortran build commands to include `build_runtime`:
- baseline LLVM lane: `--target lfortran lfortran_runtime build_runtime`
- WITH_LIRIC lane: `--target lfortran lfortran_runtime build_runtime`

## Verification
- `ctest --test-dir build --output-on-failure` (39/39 passed)
- Re-ran `cmake --build build --target lfortran_api_compat -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"`
- Confirmed intrinsic modfiles now exist in both:
  - `build/deps/lfortran/build-llvm/src/runtime/*.mod`
  - `build/deps/lfortran/build-liric/src/runtime/*.mod`
- Confirmed previous missing-modfile signatures are absent:
  - no `modfile was not found` in `build/deps/lfortran_api_compat_out/logs/lfortran_reference_tests.log`
  - no `modfile was not found` in `build/deps/lfortran_api_compat_out/logs/lfortran_integration_tests_liric_api.log`

## Notes
A separate later-stage WITH_LIRIC integration failure remains (`print_arr_08` empty object / compat finalize failures), tracked separately in #487.

Closes #486.
