### PR TITLE
Fix silent empty-object success in direct object emission path

### DIFF
--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -254,6 +254,7 @@ int test_builder_compat_jit_exec(void);
 int test_builder_compat_jit_exec_with_call(void);
 int test_builder_compat_load_library_null_rejects(void);
 int test_builder_compat_emit_executable_llvm_mode_contract(void);
+int test_builder_compat_direct_large_object_emission(void);
 int test_llvm_c_shim_add_and_lookup(void);
 int test_llvm_c_shim_load_library_rejects_null(void);
 #if !defined(__APPLE__)
@@ -575,6 +576,7 @@ int main(void) {
     RUN_TEST(test_builder_compat_jit_exec_with_call);
     RUN_TEST(test_builder_compat_load_library_null_rejects);
     RUN_TEST(test_builder_compat_emit_executable_llvm_mode_contract);
+    RUN_TEST(test_builder_compat_direct_large_object_emission);
     RUN_TEST(test_llvm_c_shim_add_and_lookup);
     RUN_TEST(test_llvm_c_shim_load_library_rejects_null);
 


### PR DESCRIPTION
## Summary
- propagate object emission failures out of llvm-compat `legacy::PassManager::run()` by throwing on non-zero emit rc instead of returning success-like status
- remove fixed `FUNC_COMPILE_BUF_CAP` in direct mode and size the per-function compile buffer from remaining JIT code capacity, reusing existing allocation for performance
- add a regression test that forces a >1 MiB direct compat object emission and asserts success/non-empty output to prevent fixed-size buffer regressions

## Validation
- `cmake --build build --target lfortran_build_liric -j$( (command -v nproc >/dev/null && nproc) || sysctl -n hw.ncpu )`
- `LIRIC_COMPILE_MODE=isel LIRIC_POLICY=direct build/deps/lfortran/build-liric/src/bin/lfortran -g -c build/deps/lfortran/integration_tests/print_arr_08.f90 -o /tmp/print_arr_08.o` (rc=0, non-empty object)
- `ctest --test-dir build --output-on-failure`

Fixes #487.
