### PR TITLE
fix: repair nightly_mass workflow parse failure

### DIFF
--- a/.github/workflows/nightly_mass.yml
+++ b/.github/workflows/nightly_mass.yml
@@ -28,8 +28,8 @@ jobs:
       LFORTRAN_REPO: https://github.com/krystophny/lfortran.git
       LFORTRAN_REF: origin/liric-aot
       LIRIC_BUILD: ${{ github.workspace }}/build
-      MASS_OUT: ${{ runner.temp }}/liric_lfortran_mass
-      BASELINE_DIR: ${{ runner.temp }}/liric_lfortran_mass_baseline/${{ matrix.os }}
+      MASS_OUT: ${{ github.workspace }}/.nightly_mass/${{ matrix.os }}/out
+      BASELINE_DIR: ${{ github.workspace }}/.nightly_mass/${{ matrix.os }}/baseline
 
     steps:
       - name: Checkout liric


### PR DESCRIPTION
## Summary
- fix invalid GitHub Actions context usage in `.github/workflows/nightly_mass.yml`
- replace job-level env paths using `${{ runner.temp }}` with `${{ github.workspace }}`-based paths
- keep lane behavior and cache keys unchanged

## Why
Push-triggered runs of `.github/workflows/nightly_mass.yml` were failing at `0s` with no jobs created due to workflow file validation errors.

## Expected result
- workflow should be parsed and jobs should be created normally
- no more immediate `This run likely failed because of a workflow file issue` failures for this workflow on push
