### PR TITLE
Stabilize WITH_LIRIC API compatibility lane and CI

### DIFF
--- a/.github/workflows/lfortran_api_compat.yml
+++ b/.github/workflows/lfortran_api_compat.yml
@@ -39,7 +39,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build cmake bison re2c zstd jq python3 git
+          sudo apt-get install -y ninja-build cmake bison re2c zstd jq python3 git libunwind-dev
 
       - name: Install macOS deps
         if: runner.os == 'macOS'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,9 +265,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "riscv6
     list(APPEND LIRIC_PLATFORM_ASM_SOURCES
         src/platform/platform_intrinsic_stubs_riscv64_linux.S)
 endif()
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
-    target_sources(liric PRIVATE src/platform/platform_intrinsic_stubs_riscv64_linux.S)
-endif()
 if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
     list(APPEND LIRIC_PLATFORM_ASM_SOURCES
         src/platform/platform_intrinsic_stubs_aarch64_darwin.S)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,6 +883,16 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64
             -DEXPECT_RC=130
             -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_exe_run.cmake
     )
+
+    add_test(
+        NAME liric_cli_exe_intrinsic_va_end_unsuffixed
+        COMMAND ${CMAKE_COMMAND}
+            -DCLI=$<TARGET_FILE:liric_bin>
+            -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/tests/ll/intrinsic_exec_va_end_unsuffixed.ll
+            -DWORKDIR=${LIRIC_CTEST_WORK_ROOT}/liric_cli_exe_intrinsic_va_end_unsuffixed
+            -DEXPECT_RC=77
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_liric_cli_exe_run.cmake
+    )
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ set(LIRIC_LFORTRAN_BUILD_LLVM "${LIRIC_LFORTRAN_ROOT}/build-llvm"
     CACHE PATH "Path to lfortran baseline LLVM build directory")
 set(LIRIC_LFORTRAN_BUILD_LIRIC "${LIRIC_LFORTRAN_ROOT}/build-liric"
     CACHE PATH "Path to lfortran WITH_LIRIC build directory")
+set(LIRIC_LFORTRAN_BUILD_LIRIC_NOLLVM "${LIRIC_LFORTRAN_ROOT}/build-liric-nollvm"
+    CACHE PATH "Path to lfortran WITH_LIRIC no-LLVM build directory")
 set(LIRIC_LFORTRAN_API_OUTPUT_ROOT "${CMAKE_CURRENT_BINARY_DIR}/deps/lfortran_api_compat_out"
     CACHE PATH "Path to lfortran API compatibility output artifacts")
 set(LIRIC_LFORTRAN_API_OUTPUT_ROOT_SAFE "${CMAKE_CURRENT_BINARY_DIR}/deps/lfortran_api_compat_out_safe"
@@ -563,6 +565,12 @@ if(LIRIC_LFORTRAN_LIRIC_LINK_REAL_LLVM)
     set(LIRIC_LFORTRAN_LIRIC_PRECONFIGURE_COMMAND
         ${CMAKE_COMMAND} -E rm -rf ${LIRIC_LFORTRAN_BUILD_LIRIC})
 endif()
+set(LIRIC_LFORTRAN_LIRIC_CONFIGURE_LLVM_ARGS "")
+if(LIRIC_LFORTRAN_LIRIC_LINK_REAL_LLVM)
+    list(APPEND LIRIC_LFORTRAN_LIRIC_CONFIGURE_LLVM_ARGS
+        ${LIRIC_LFORTRAN_LLVM_ARGS}
+        ${LIRIC_LFORTRAN_LIRIC_LLVM_LINK_ARGS})
+endif()
 
 # Always pass an explicit liric archive into WITH_LIRIC builds so lfortran does
 # not resolve to an unintended default archive. When real LLVM linkage is
@@ -588,6 +596,17 @@ else()
             -DLIRIC_LIB=$<TARGET_FILE:liric>)
         set(LIRIC_LFORTRAN_LIRIC_LIB_DEPS liric)
     endif()
+endif()
+set(LIRIC_LFORTRAN_LIRIC_LIB_ARGS_NOLLVM "")
+set(LIRIC_LFORTRAN_LIRIC_LIB_DEPS_NOLLVM "")
+if(TARGET liric_nollvm)
+    set(LIRIC_LFORTRAN_LIRIC_LIB_ARGS_NOLLVM
+        -DLIRIC_LIB=$<TARGET_FILE:liric_nollvm>)
+    set(LIRIC_LFORTRAN_LIRIC_LIB_DEPS_NOLLVM liric_nollvm)
+else()
+    set(LIRIC_LFORTRAN_LIRIC_LIB_ARGS_NOLLVM
+        -DLIRIC_LIB=$<TARGET_FILE:liric>)
+    set(LIRIC_LFORTRAN_LIRIC_LIB_DEPS_NOLLVM liric)
 endif()
 
 add_custom_target(
@@ -635,8 +654,7 @@ add_custom_target(
         -DLIRIC_DIR=${CMAKE_CURRENT_SOURCE_DIR}
         -DLIRIC_REQUIRE_REAL_LLVM_LINK=${LIRIC_LFORTRAN_LIRIC_LINK_REAL_LLVM}
         ${LIRIC_LFORTRAN_LIRIC_LIB_ARGS}
-        ${LIRIC_LFORTRAN_LLVM_ARGS}
-        ${LIRIC_LFORTRAN_LIRIC_LLVM_LINK_ARGS}
+        ${LIRIC_LFORTRAN_LIRIC_CONFIGURE_LLVM_ARGS}
         -DWITH_RUNTIME_STACKTRACE=OFF
         -DWITH_LLVM=OFF
     COMMAND ${CMAKE_COMMAND} --build ${LIRIC_LFORTRAN_BUILD_LIRIC}
@@ -644,6 +662,30 @@ add_custom_target(
         test_cwrapper test_stacktrace test_lfortran --parallel
     DEPENDS lfortran_prepare liric_probe_runner ${LIRIC_LFORTRAN_LIRIC_LIB_DEPS}
     COMMENT "Configure/build LFortran WITH_LIRIC in ${LIRIC_LFORTRAN_BUILD_LIRIC}"
+    USES_TERMINAL
+)
+
+add_custom_target(
+    lfortran_build_liric_nollvm
+    COMMAND ${CMAKE_COMMAND} -E rm -rf ${LIRIC_LFORTRAN_BUILD_LIRIC_NOLLVM}
+    COMMAND ${CMAKE_COMMAND}
+        -S ${LIRIC_LFORTRAN_ROOT}
+        -B ${LIRIC_LFORTRAN_BUILD_LIRIC_NOLLVM}
+        -G Ninja
+        -DCMAKE_BUILD_TYPE=${LIRIC_EXTERNAL_BUILD_TYPE}
+        ${LIRIC_LFORTRAN_LIRIC_COMPILER_ARGS}
+        -DBUILD_TESTING=ON
+        -DWITH_LIRIC=yes
+        -DLIRIC_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+        -DLIRIC_REQUIRE_REAL_LLVM_LINK=OFF
+        ${LIRIC_LFORTRAN_LIRIC_LIB_ARGS_NOLLVM}
+        -DWITH_RUNTIME_STACKTRACE=OFF
+        -DWITH_LLVM=OFF
+    COMMAND ${CMAKE_COMMAND} --build ${LIRIC_LFORTRAN_BUILD_LIRIC_NOLLVM}
+        --target lfortran lfortran_runtime build_runtime
+        test_cwrapper test_stacktrace test_lfortran --parallel
+    DEPENDS lfortran_prepare liric_probe_runner ${LIRIC_LFORTRAN_LIRIC_LIB_DEPS_NOLLVM}
+    COMMENT "Configure/build LFortran WITH_LIRIC (no LLVM runtime link) in ${LIRIC_LFORTRAN_BUILD_LIRIC_NOLLVM}"
     USES_TERMINAL
 )
 
@@ -660,11 +702,13 @@ add_custom_target(
         --workspace ${CMAKE_CURRENT_BINARY_DIR}/deps
         --output-root ${LIRIC_LFORTRAN_API_OUTPUT_ROOT}
         --lfortran-dir ${LIRIC_LFORTRAN_ROOT}
+        --lfortran-build-llvm ${LIRIC_LFORTRAN_BUILD_LLVM}
+        --lfortran-build-liric ${LIRIC_LFORTRAN_BUILD_LIRIC_NOLLVM}
         --skip-checkout
         --skip-lfortran-build
         --run-ref-tests yes
         --run-itests yes
-    DEPENDS lfortran_build_all
+    DEPENDS lfortran_build_llvm lfortran_build_liric_nollvm
     COMMENT "Run LFortran API compatibility suite using CMake-managed builds"
     USES_TERMINAL
 )
@@ -678,6 +722,8 @@ add_custom_target(
         --workspace ${CMAKE_CURRENT_BINARY_DIR}/deps
         --output-root ${LIRIC_LFORTRAN_API_OUTPUT_ROOT_SAFE}
         --lfortran-dir ${LIRIC_LFORTRAN_ROOT}
+        --lfortran-build-llvm ${LIRIC_LFORTRAN_BUILD_LLVM}
+        --lfortran-build-liric ${LIRIC_LFORTRAN_BUILD_LIRIC_NOLLVM}
         --skip-checkout
         --skip-lfortran-build
         --run-ref-tests yes
@@ -687,7 +733,7 @@ add_custom_target(
         --itest-timeout-sec 600
         --itest-memory-max 4G
         --itest-tasks-max 256
-    DEPENDS lfortran_build_all
+    DEPENDS lfortran_build_llvm lfortran_build_liric_nollvm
     COMMENT "Run LFortran API compatibility suite (safe profile, logged)"
     USES_TERMINAL
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "riscv6
     list(APPEND LIRIC_PLATFORM_ASM_SOURCES
         src/platform/platform_intrinsic_stubs_riscv64_linux.S)
 endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+    target_sources(liric PRIVATE src/platform/platform_intrinsic_stubs_riscv64_linux.S)
+endif()
 if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
     list(APPEND LIRIC_PLATFORM_ASM_SOURCES
         src/platform/platform_intrinsic_stubs_aarch64_darwin.S)

--- a/src/target_x86_64.c
+++ b/src/target_x86_64.c
@@ -101,6 +101,18 @@ static size_t align_up(size_t value, size_t align) {
     return ((value + align - 1) / align) * align;
 }
 
+static bool x86_is_llvm_va_start_name(const char *name) {
+    return name && strncmp(name, "llvm.va_start", 13) == 0;
+}
+
+static bool x86_is_llvm_va_end_name(const char *name) {
+    return name && strncmp(name, "llvm.va_end", 11) == 0;
+}
+
+static bool x86_is_llvm_va_copy_name(const char *name) {
+    return name && strncmp(name, "llvm.va_copy", 12) == 0;
+}
+
 static int32_t alloc_temp_slot(x86_compile_ctx_t *ctx, size_t size, size_t align) {
     if (size < 8) size = 8;
     if (align < 8) align = 8;
@@ -2865,7 +2877,7 @@ static int x86_64_compile_emit(void *compile_ctx,
         if (ops[0].kind == LR_VAL_GLOBAL && cc->mod) {
             const char *cname = lr_module_symbol_name(
                 cc->mod, ops[0].global_id);
-            if (cname && strcmp(cname, "llvm.va_start.p0") == 0) {
+            if (x86_is_llvm_va_start_name(cname)) {
                 if (cc->func_is_vararg && nops >= 2) {
                     emit_load_operand(cc, &ops[1], X86_RAX);
                     uint32_t gp_off = cc->vararg_named_gp * 8;
@@ -2890,9 +2902,9 @@ static int x86_64_compile_emit(void *compile_ctx,
                 }
                 break;
             }
-            if (cname && strcmp(cname, "llvm.va_end.p0") == 0)
+            if (x86_is_llvm_va_end_name(cname))
                 break;
-            if (cname && strcmp(cname, "llvm.va_copy.p0") == 0) {
+            if (x86_is_llvm_va_copy_name(cname)) {
                 if (nops >= 3) {
                     emit_load_operand(cc, &ops[1], X86_RAX);
                     emit_load_operand(cc, &ops[2], X86_RCX);

--- a/tests/ll/intrinsic_exec_va_end_unsuffixed.ll
+++ b/tests/ll/intrinsic_exec_va_end_unsuffixed.ll
@@ -1,0 +1,8 @@
+declare void @llvm.va_end(ptr)
+
+define i32 @main() {
+entry:
+  %ap = alloca i8, align 1
+  call void @llvm.va_end(ptr %ap)
+  ret i32 77
+}


### PR DESCRIPTION
## Summary
- isolate `lfortran_api_compat` onto a dedicated `build-liric-nollvm` profile
- keep WITH_LIRIC no-LLVM runtime dependency checks strict while allowing explicit real-LLVM opt-in only where requested
- add explicit `--lfortran-build-llvm` / `--lfortran-build-liric` wiring in `lfortran_api_compat.sh`
- harden integration cleanup around `integration_tests/test-llvm` to reduce flaky `Directory not empty` failures
- add `libunwind-dev` to Linux deps in `LFortran API Compatibility (WITH_LIRIC)` workflow

## Validation
- `bash -n tools/lfortran_mass/lfortran_api_compat.sh`
- `ctest --test-dir build --output-on-failure -R "nightly_mass_workflow_contract|llvm_backend_workflow_contract|lfortran_api_compat_"`
- `cmake --build build --target lfortran_build_liric_nollvm`
- `cmake --build build --target lfortran_api_compat`
- `build/deps/lfortran_api_compat_out/summary.json` reports `"pass": true`
