### PR TITLE
Expose LIRIC session headers to the LFortran benchmark baseline (#528)

### DIFF
--- a/.github/workflows/bench_matrix_llvm_api.yml
+++ b/.github/workflows/bench_matrix_llvm_api.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  LIRIC_LFORTRAN_REF: origin/liric-showcase
+
 jobs:
   bench-matrix-llvm-api:
     name: bench_matrix (mode=llvm api lanes)
@@ -41,7 +44,10 @@ jobs:
             -DLIRIC_LFORTRAN_LIRIC_LINK_REAL_LLVM=ON \
             -DWITH_BENCH_TCC=OFF \
             -DWITH_BENCH_LLI_PHASES=OFF \
+            -DLIRIC_LFORTRAN_REF="${LIRIC_LFORTRAN_REF}" \
             -DLIRIC_LLVM_CONFIG_EXE="${llvm_config}"
+          echo "tested LFortran ref: ${LIRIC_LFORTRAN_REF}"
+          grep -F -- "-DLIRIC_INCLUDE_DIR=" build/lfortran_baseline_configure_args.txt
           cmake --build build -j"$(nproc)" --target bench_matrix bench_compat_check bench_api liric_probe_runner lfortran_build_all
 
       - name: Run bench_matrix llvm API lanes
@@ -54,6 +60,7 @@ jobs:
             --policies direct,ir \
             --lanes api_full_llvm,api_backend_llvm \
             --api-cases 10 \
+            --require-cells 4 \
             --timeout 15 \
             --timeout-ms 15000 || {
               rc=$?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -730,8 +730,21 @@ if(NOT LIRIC_LFORTRAN_LLVM_LIBDIR_EFFECTIVE)
     endif()
 endif()
 
+# Public LIRIC headers must be visible to every downstream LFortran build,
+# including the LLVM baseline that still compiles asr_to_liric.cpp. The
+# include contract is explicit so a fresh build tree cannot silently lose
+# <liric/liric_session.h>.
+set(LIRIC_PUBLIC_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+if(NOT EXISTS "${LIRIC_PUBLIC_INCLUDE_DIR}/liric/liric_session.h")
+    message(FATAL_ERROR
+        "LIRIC public include directory is missing liric/liric_session.h: "
+        "${LIRIC_PUBLIC_INCLUDE_DIR}")
+endif()
+
 set(LIRIC_LFORTRAN_LLVM_ARGS "")
 set(LIRIC_LFORTRAN_LIRIC_LLVM_LINK_ARGS "")
+list(APPEND LIRIC_LFORTRAN_LLVM_ARGS
+    -DLIRIC_INCLUDE_DIR=${LIRIC_PUBLIC_INCLUDE_DIR})
 if(LIRIC_LFORTRAN_LLVM_DIR_EFFECTIVE)
     list(APPEND LIRIC_LFORTRAN_LLVM_ARGS
         -DLLVM_DIR=${LIRIC_LFORTRAN_LLVM_DIR_EFFECTIVE})
@@ -857,6 +870,7 @@ add_custom_target(
         -DBUILD_TESTING=ON
         -DWITH_LIRIC=yes
         -DLIRIC_ROOT=${CMAKE_CURRENT_SOURCE_DIR}
+        -DLIRIC_INCLUDE_DIR=${LIRIC_PUBLIC_INCLUDE_DIR}
         -DLIRIC_REQUIRE_REAL_LLVM_LINK=${LIRIC_LFORTRAN_LIRIC_LINK_REAL_LLVM}
         ${LIRIC_LFORTRAN_LIRIC_LIB_ARGS}
         ${LIRIC_LFORTRAN_LIRIC_CONFIGURE_LLVM_ARGS}
@@ -882,6 +896,7 @@ add_custom_target(
         -DBUILD_TESTING=ON
         -DWITH_LIRIC=yes
         -DLIRIC_ROOT=${CMAKE_CURRENT_SOURCE_DIR}
+        -DLIRIC_INCLUDE_DIR=${LIRIC_PUBLIC_INCLUDE_DIR}
         -DLIRIC_REQUIRE_REAL_LLVM_LINK=OFF
         ${LIRIC_LFORTRAN_LIRIC_LIB_ARGS_NOLLVM}
         -DWITH_RUNTIME_STACKTRACE=ON
@@ -898,6 +913,13 @@ add_custom_target(
     lfortran_build_all
     DEPENDS lfortran_build_llvm lfortran_build_liric
 )
+
+# Machine-readable record of the LFortran baseline configure arguments so the
+# header contract test can reproduce header discovery in a fresh build tree.
+string(REPLACE ";" "\n" LIRIC_LFORTRAN_LLVM_ARGS_TEXT
+    "${LIRIC_LFORTRAN_LLVM_ARGS}")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/lfortran_baseline_configure_args.txt"
+    "${LIRIC_LFORTRAN_LLVM_ARGS_TEXT}\n")
 
 add_custom_target(
     lfortran_api_compat
@@ -1261,6 +1283,15 @@ add_test(
         -DBENCH_MATRIX=$<TARGET_FILE:bench_matrix>
         -DWORKDIR=${LIRIC_CTEST_WORK_ROOT}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_matrix_lfortran_rebuild.cmake
+)
+
+add_test(
+    NAME bench_matrix_lfortran_header_contract
+    COMMAND ${CMAKE_COMMAND}
+        -DARGS_FILE=${CMAKE_CURRENT_BINARY_DIR}/lfortran_baseline_configure_args.txt
+        -DC_COMPILER=${CMAKE_C_COMPILER}
+        -DWORKDIR=${LIRIC_CTEST_WORK_ROOT}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/test_bench_matrix_lfortran_header_contract.cmake
 )
 
 add_test(

--- a/tests/cmake/test_bench_matrix_lfortran_header_contract.cmake
+++ b/tests/cmake/test_bench_matrix_lfortran_header_contract.cmake
@@ -1,0 +1,83 @@
+if(NOT DEFINED ARGS_FILE OR NOT DEFINED WORKDIR)
+    message(FATAL_ERROR "ARGS_FILE and WORKDIR are required")
+endif()
+
+if(NOT EXISTS "${ARGS_FILE}")
+    message(FATAL_ERROR
+        "lfortran baseline configure argument record not found: ${ARGS_FILE}")
+endif()
+
+file(STRINGS "${ARGS_FILE}" baseline_args)
+
+set(include_dir "")
+foreach(arg IN LISTS baseline_args)
+    if(arg MATCHES "^-DLIRIC_INCLUDE_DIR=(.+)$")
+        set(include_dir "${CMAKE_MATCH_1}")
+    endif()
+endforeach()
+
+if(include_dir STREQUAL "")
+    message(FATAL_ERROR
+        "lfortran baseline configure arguments do not define "
+        "LIRIC_INCLUDE_DIR; the LLVM baseline cannot find "
+        "<liric/liric_session.h>:\n${baseline_args}")
+endif()
+
+if(NOT IS_DIRECTORY "${include_dir}")
+    message(FATAL_ERROR
+        "LIRIC_INCLUDE_DIR is not a directory: ${include_dir}")
+endif()
+
+if(NOT EXISTS "${include_dir}/liric/liric_session.h")
+    message(FATAL_ERROR
+        "LIRIC_INCLUDE_DIR does not provide liric/liric_session.h: "
+        "${include_dir}")
+endif()
+
+if(NOT DEFINED C_COMPILER OR C_COMPILER STREQUAL "")
+    message(STATUS "no C compiler provided; skipping compile probe")
+    return()
+endif()
+
+set(root "${WORKDIR}/bench_matrix_lfortran_header_contract")
+file(REMOVE_RECURSE "${root}")
+file(MAKE_DIRECTORY "${root}")
+
+set(probe "${root}/probe.c")
+file(WRITE "${probe}"
+"#include <liric/liric_session.h>\n"
+"int main() { return 0; }\n")
+
+# Positive: a fresh build tree compiles the session header using only the
+# baseline include contract.
+execute_process(
+    COMMAND "${C_COMPILER}" -fsyntax-only "-I${include_dir}" "${probe}"
+    WORKING_DIRECTORY "${root}"
+    RESULT_VARIABLE ok_rc
+    OUTPUT_VARIABLE ok_out
+    ERROR_VARIABLE ok_err
+)
+if(NOT ok_rc EQUAL 0)
+    message(FATAL_ERROR
+        "baseline include contract failed to compile "
+        "<liric/liric_session.h> rc=${ok_rc}\n"
+        "stdout:\n${ok_out}\nstderr:\n${ok_err}")
+endif()
+
+# Negative: without the configured include directory the same source must not
+# compile, proving the probe really depends on the contract.
+execute_process(
+    COMMAND "${C_COMPILER}" -fsyntax-only "${probe}"
+    WORKING_DIRECTORY "${root}"
+    RESULT_VARIABLE bad_rc
+    OUTPUT_VARIABLE bad_out
+    ERROR_VARIABLE bad_err
+)
+if(bad_rc EQUAL 0)
+    message(FATAL_ERROR
+        "<liric/liric_session.h> compiled without LIRIC_INCLUDE_DIR; "
+        "the probe does not exercise the include contract\n"
+        "stdout:\n${bad_out}\nstderr:\n${bad_err}")
+endif()
+
+message(STATUS "lfortran baseline header contract ok: ${include_dir}")

--- a/tests/cmake/test_bench_matrix_lfortran_rebuild.cmake
+++ b/tests/cmake/test_bench_matrix_lfortran_rebuild.cmake
@@ -200,3 +200,42 @@ endif()
 if(NOT summary_text MATCHES "\"cells_failed\"[ \t]*:[ \t]*0")
     message(FATAL_ERROR "matrix summary failed count mismatch:\n${summary_text}")
 endif()
+
+# Negative: a matrix smaller than the required cell count fails with a named
+# diagnostic before the results can be reported as complete.
+set(gate_bench_dir "${root}/bench_gate")
+file(MAKE_DIRECTORY "${gate_bench_dir}")
+
+execute_process(
+    COMMAND "${BENCH_MATRIX}"
+        --bench-dir "${gate_bench_dir}"
+        --manifest "${manifest}"
+        --modes isel
+        --policies direct
+        --lanes api_full_llvm
+        --timeout 5
+        --timeout-ms 1000
+        --require-cells 4
+        --cmake "${fake_cmake}"
+        --lfortran-build-dir "${llvm_build_dir}"
+        --lfortran-liric-build-dir "${liric_build_dir}"
+        --lfortran "${fake_lfortran_llvm}"
+        --lfortran-liric "${fake_lfortran_liric}"
+        --bench-compat-check "${fake_compat}"
+        --bench-api "${fake_api}"
+        --build-dir "${build_dir}"
+    WORKING_DIRECTORY "${root}"
+    RESULT_VARIABLE gate_rc
+    OUTPUT_VARIABLE gate_out
+    ERROR_VARIABLE gate_err
+)
+
+if(gate_rc EQUAL 0)
+    message(FATAL_ERROR
+        "bench_matrix accepted a 1-cell matrix under --require-cells 4\n"
+        "stdout:\n${gate_out}\nstderr:\n${gate_err}")
+endif()
+if(NOT gate_err MATCHES "matrix cell gate failed: attempted=1 required=4")
+    message(FATAL_ERROR
+        "missing named cell-gate diagnostic\nstderr:\n${gate_err}")
+endif()

--- a/tools/bench_matrix.c
+++ b/tools/bench_matrix.c
@@ -80,6 +80,7 @@ typedef struct {
 
     int run_compat_check;
     int allow_partial;
+    int require_cells;
     int rebuild_lfortran;
     int rebuild_jobs;
 
@@ -551,6 +552,7 @@ static void usage(void) {
     printf("  --timeout-ms N           timeout ms for bench_api (default: 3000)\n");
     printf("  --skip-compat-check      do not regenerate compat artifacts\n");
     printf("  --allow-partial          report failures but return 0\n");
+    printf("  --require-cells N        fail unless at least N matrix cells are attempted\n");
     printf("  --runtime-bc PATH        runtime bitcode\n");
     printf("  --runtime-lib PATH       runtime shared library\n");
     printf("  --runtime-archive PATH   static runtime archive for bench_api\n");
@@ -592,6 +594,7 @@ static cfg_t parse_args(int argc, char **argv) {
     cfg.timeout_ms = 3000;
     cfg.run_compat_check = 1;
     cfg.allow_partial = 0;
+    cfg.require_cells = 0;
     cfg.rebuild_lfortran = 1;
     cfg.rebuild_jobs = host_nproc();
     cfg.cmake = "cmake";
@@ -647,6 +650,9 @@ static cfg_t parse_args(int argc, char **argv) {
             cfg.run_compat_check = 0;
         } else if (strcmp(argv[i], "--allow-partial") == 0) {
             cfg.allow_partial = 1;
+        } else if (strcmp(argv[i], "--require-cells") == 0 && i + 1 < argc) {
+            cfg.require_cells = atoi(argv[++i]);
+            if (cfg.require_cells < 0) die("invalid --require-cells value");
         } else if (strcmp(argv[i], "--runtime-bc") == 0 && i + 1 < argc) {
             cfg.runtime_bc = argv[++i];
         } else if (strcmp(argv[i], "--runtime-lib") == 0 && i + 1 < argc) {
@@ -2502,6 +2508,12 @@ int main(int argc, char **argv) {
 
     if (cells_attempted == 0) {
         fprintf(stderr, "no matrix cells attempted\n");
+        return 1;
+    }
+    if (cfg.require_cells > 0 && cells_attempted < cfg.require_cells) {
+        fprintf(stderr,
+                "matrix cell gate failed: attempted=%d required=%d\n",
+                cells_attempted, cfg.require_cells);
         return 1;
     }
     if (cells_failed > 0 && !cfg.allow_partial) return 1;


### PR DESCRIPTION
Fixes #528

## Preserved compiler invariant
The LFortran LLVM baseline and the WITH_LIRIC build both resolve `<liric/liric_session.h>` through one explicit configured include contract (`-DLIRIC_INCLUDE_DIR`), and the benchmark matrix refuses to report performance unless all four required cells were attempted. AOT-only LFortran execution is unchanged.

## Changes
- `CMakeLists.txt`: `LIRIC_PUBLIC_INCLUDE_DIR` with a configure-time existence check; `-DLIRIC_INCLUDE_DIR` appended to `LIRIC_LFORTRAN_LLVM_ARGS` and to both WITH_LIRIC configures; baseline args recorded to `build/lfortran_baseline_configure_args.txt`; new test `bench_matrix_lfortran_header_contract`.
- `tools/bench_matrix.c`: new `--require-cells N` gate with named diagnostic `matrix cell gate failed: attempted=N required=M`.
- `.github/workflows/bench_matrix_llvm_api.yml`: pins and echoes the tested LFortran ref, greps the recorded include contract, passes `--require-cells 4`.
- `tests/cmake/*`: fresh-workspace header compile probe (positive + negative), and a zero/one-cell matrix gate negative fixture.

## Red evidence (unmodified main)
```
CMake Error at tests/cmake/test_bench_matrix_lfortran_header_contract.cmake:6 (message):
  lfortran baseline configure argument record not found:
  .../build/lfortran_baseline_configure_args.txt

$ build/bench_matrix --require-cells 4
unknown argument: --require-cells
```

## Green evidence
```
ctest --test-dir build --output-on-failure
100% tests passed out of 48
```
