### PR TITLE
[llvm-compat-01] legalize legacy pointer IR without mutating modules

### DIFF
--- a/src/ir.c
+++ b/src/ir.c
@@ -2238,6 +2238,186 @@ static void legacy_materialize_pointer_types(lr_module_t *m) {
         legacy_insert_pointer_casts(m, f);
 }
 
+/* --- Non-mutating legacy emission (issue #525) ---------------------------
+   Legacy typed-pointer legalization rewrites function types, instruction
+   types, operand types, and block instruction lists. Running it on the
+   caller's module would make a dump or an object emission a destructive
+   operation and would make repeated emission order-dependent. Emission
+   therefore runs on an owned clone whose mutable IR lives in a private arena;
+   the source module is left byte-for-byte unchanged. Immutable, shared state
+   (scalar type singletons, interned symbol tables, globals, names) is aliased,
+   never freed through the clone. */
+
+static bool lr_emission_clone_forced_failure = false;
+
+void lr_ir_set_emission_clone_failure_for_testing(bool fail) {
+    lr_emission_clone_forced_failure = fail;
+}
+
+typedef struct lr_emission_clone {
+    lr_module_t *module;
+    lr_arena_t *arena;
+} lr_emission_clone_t;
+
+static lr_type_t *clone_emission_func_type(lr_arena_t *a, lr_type_t *t) {
+    lr_type_t *copy;
+    if (!t || t->kind != LR_TYPE_FUNC)
+        return t;
+    copy = lr_arena_new(a, lr_type_t);
+    if (!copy)
+        return NULL;
+    *copy = *t;
+    if (t->func.num_params > 0) {
+        copy->func.params = lr_arena_array(a, lr_type_t *, t->func.num_params);
+        if (!copy->func.params)
+            return NULL;
+        memcpy(copy->func.params, t->func.params,
+               sizeof(lr_type_t *) * (size_t)t->func.num_params);
+    } else {
+        copy->func.params = NULL;
+    }
+    return copy;
+}
+
+static lr_inst_t *clone_emission_inst(lr_arena_t *a, const lr_inst_t *src) {
+    lr_inst_t *copy = lr_arena_new(a, lr_inst_t);
+    if (!copy)
+        return NULL;
+    *copy = *src;
+    copy->next = NULL;
+    if (src->num_operands > 0) {
+        copy->operands = lr_arena_array(a, lr_operand_t, src->num_operands);
+        if (!copy->operands)
+            return NULL;
+        memcpy(copy->operands, src->operands,
+               sizeof(lr_operand_t) * (size_t)src->num_operands);
+    } else {
+        copy->operands = NULL;
+    }
+    return copy;
+}
+
+static lr_block_t *clone_emission_block(lr_arena_t *a, lr_func_t *owner,
+                                        const lr_block_t *src) {
+    lr_block_t *copy = lr_arena_new(a, lr_block_t);
+    lr_inst_t *tail = NULL;
+    if (!copy)
+        return NULL;
+    *copy = *src;
+    copy->func = owner;
+    copy->next = NULL;
+    copy->first = NULL;
+    copy->last = NULL;
+    copy->inst_array = NULL;
+    for (const lr_inst_t *inst = src->first; inst; inst = inst->next) {
+        lr_inst_t *inst_copy = clone_emission_inst(a, inst);
+        if (!inst_copy)
+            return NULL;
+        if (tail)
+            tail->next = inst_copy;
+        else
+            copy->first = inst_copy;
+        tail = inst_copy;
+    }
+    copy->last = tail;
+    return copy;
+}
+
+static lr_func_t *clone_emission_func(lr_arena_t *a, lr_module_t *owner,
+                                      const lr_func_t *src) {
+    lr_func_t *copy = lr_arena_new(a, lr_func_t);
+    lr_block_t *tail = NULL;
+    if (!copy)
+        return NULL;
+    *copy = *src;
+    copy->module = owner;
+    copy->next = NULL;
+    copy->first_block = NULL;
+    copy->last_block = NULL;
+    copy->block_array = NULL;
+    copy->linear_inst_array = NULL;
+    copy->block_inst_offsets = NULL;
+    copy->num_linear_insts = 0;
+    copy->type = clone_emission_func_type(a, src->type);
+    if (src->type && !copy->type)
+        return NULL;
+    if (src->num_params > 0) {
+        copy->param_types = lr_arena_array(a, lr_type_t *, src->num_params);
+        if (!copy->param_types)
+            return NULL;
+        memcpy(copy->param_types, src->param_types,
+               sizeof(lr_type_t *) * (size_t)src->num_params);
+        if (src->param_vregs) {
+            copy->param_vregs = lr_arena_array(a, uint32_t, src->num_params);
+            if (!copy->param_vregs)
+                return NULL;
+            memcpy(copy->param_vregs, src->param_vregs,
+                   sizeof(uint32_t) * (size_t)src->num_params);
+        }
+    }
+    for (const lr_block_t *b = src->first_block; b; b = b->next) {
+        lr_block_t *block_copy = clone_emission_block(a, copy, b);
+        if (!block_copy)
+            return NULL;
+        if (tail)
+            tail->next = block_copy;
+        else
+            copy->first_block = block_copy;
+        tail = block_copy;
+    }
+    copy->last_block = tail;
+    return copy;
+}
+
+static void lr_emission_clone_release(lr_emission_clone_t *clone) {
+    if (!clone)
+        return;
+    lr_arena_destroy(clone->arena);
+    clone->arena = NULL;
+    clone->module = NULL;
+}
+
+/* Returns false only on allocation failure; the source module is never
+   touched on any path. */
+static bool lr_module_clone_for_emission(lr_module_t *src,
+                                         lr_emission_clone_t *out) {
+    lr_arena_t *arena;
+    lr_module_t *copy;
+    lr_func_t *tail = NULL;
+    out->arena = NULL;
+    out->module = NULL;
+    if (lr_emission_clone_forced_failure)
+        return false;
+    arena = lr_arena_create(0);
+    if (!arena)
+        return false;
+    copy = lr_arena_new(arena, lr_module_t);
+    if (!copy) {
+        lr_arena_destroy(arena);
+        return false;
+    }
+    *copy = *src;
+    copy->arena = arena;
+    copy->first_func = NULL;
+    copy->last_func = NULL;
+    for (const lr_func_t *f = src->first_func; f; f = f->next) {
+        lr_func_t *func_copy = clone_emission_func(arena, copy, f);
+        if (!func_copy) {
+            lr_arena_destroy(arena);
+            return false;
+        }
+        if (tail)
+            tail->next = func_copy;
+        else
+            copy->first_func = func_copy;
+        tail = func_copy;
+    }
+    copy->last_func = tail;
+    out->arena = arena;
+    out->module = copy;
+    return true;
+}
+
 static const char *type_name(const lr_type_t *t) {
     switch (t->kind) {
     case LR_TYPE_VOID:   return "void";
@@ -4517,18 +4697,27 @@ static void lr_dump_undeclared_call_targets(const lr_module_t *m, FILE *out) {
 
 void lr_module_dump_opts(lr_module_t *m, FILE *out, unsigned dump_flags) {
     unsigned saved_dump_flags = lr_dump_flags_current;
+    lr_emission_clone_t clone = {0};
+    lr_module_t *emit = m;
     lr_dump_flags_current = dump_flags;
     if (!m || !out)
         goto done;
-    legacy_materialize_pointer_types(m);
-    lr_dump_named_types(m, out);
-    for (lr_global_t *g = m->first_global; g; g = g->next)
-        lr_dump_global_opts(m, g, out, dump_flags);
-    lr_dump_undeclared_call_targets(m, out);
-    if (m->first_global && m->first_func)
+    if (legacy_pointer_ir_enabled()) {
+        /* Legalize an owned clone so the caller's module is never mutated. */
+        if (!lr_module_clone_for_emission(m, &clone))
+            goto done;
+        emit = clone.module;
+        legacy_materialize_pointer_types(emit);
+    }
+    lr_dump_named_types(emit, out);
+    for (lr_global_t *g = emit->first_global; g; g = g->next)
+        lr_dump_global_opts(emit, g, out, dump_flags);
+    lr_dump_undeclared_call_targets(emit, out);
+    if (emit->first_global && emit->first_func)
         fprintf(out, "\n");
-    for (lr_func_t *f = m->first_func; f; f = f->next)
-        lr_dump_func_opts(f, m, out, dump_flags);
+    for (lr_func_t *f = emit->first_func; f; f = f->next)
+        lr_dump_func_opts(f, emit, out, dump_flags);
+    lr_emission_clone_release(&clone);
 
 done:
     lr_dump_flags_current = saved_dump_flags;

--- a/src/ir.h
+++ b/src/ir.h
@@ -214,6 +214,10 @@ lr_operand_t lr_op_block(uint32_t id);
 lr_operand_t lr_op_global(uint32_t id, lr_type_t *type);
 lr_operand_t lr_op_null(lr_type_t *type);
 uint32_t lr_module_intern_symbol(lr_module_t *m, const char *name);
+
+/* Test hook (issue #525): force the legacy emission clone to fail so the
+   non-mutating contract can be checked on the allocation-failure path. */
+void lr_ir_set_emission_clone_failure_for_testing(bool fail);
 const char *lr_module_symbol_name(const lr_module_t *m, uint32_t id);
 lr_func_t *lr_module_lookup_function(const lr_module_t *m, const char *name);
 void lr_module_disambiguate_local_function_collisions(lr_module_t *m);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -249,6 +249,8 @@ int test_session_operand_global_offset_propagates_to_ir(void);
 int test_session_select(void);
 int test_session_ir_print(void);
 int test_ir_dump_pointer_dialect_for_backend(void);
+int test_ir_emission_does_not_mutate_module(void);
+int test_ir_emission_clone_failure_preserves_module(void);
 int test_session_scalar_gep_undef_tail_trimmed(void);
 int test_ir_dump_scalar_gep_undef_tail_trimmed(void);
 int test_ir_dump_declares_undeclared_call_targets(void);
@@ -596,6 +598,8 @@ int main(void) {
     RUN_TEST(test_session_select);
     RUN_TEST(test_session_ir_print);
     RUN_TEST(test_ir_dump_pointer_dialect_for_backend);
+    RUN_TEST(test_ir_emission_does_not_mutate_module);
+    RUN_TEST(test_ir_emission_clone_failure_preserves_module);
     RUN_TEST(test_session_scalar_gep_undef_tail_trimmed);
     RUN_TEST(test_ir_dump_scalar_gep_undef_tail_trimmed);
     RUN_TEST(test_ir_dump_declares_undeclared_call_targets);

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -2842,3 +2842,253 @@ int test_session_runtime_archive_target_mismatch_rejected(void) {
 }
 
 #endif
+
+/* --- Issue #525: legacy pointer legalization must not mutate the source
+   module. Structural snapshots of the caller's `lr_module_t` must be identical
+   before and after any dump or object emission, in either pointer dialect. */
+
+static void snap_type(const lr_type_t *t, char **cur, char *end) {
+    int n;
+    if (*cur >= end)
+        return;
+    if (!t) {
+        n = snprintf(*cur, (size_t)(end - *cur), "<null>");
+        *cur += n > 0 ? n : 0;
+        return;
+    }
+    n = snprintf(*cur, (size_t)(end - *cur), "k%d", (int)t->kind);
+    *cur += n > 0 ? n : 0;
+    if (t->kind == LR_TYPE_PTR || t->kind == LR_TYPE_ARRAY ||
+        t->kind == LR_TYPE_VECTOR) {
+        if (*cur < end) {
+            n = snprintf(*cur, (size_t)(end - *cur), "[");
+            *cur += n > 0 ? n : 0;
+        }
+        snap_type(t->array.elem, cur, end);
+        if (*cur < end) {
+            n = snprintf(*cur, (size_t)(end - *cur), "]");
+            *cur += n > 0 ? n : 0;
+        }
+    } else if (t->kind == LR_TYPE_FUNC) {
+        if (*cur < end) {
+            n = snprintf(*cur, (size_t)(end - *cur), "(");
+            *cur += n > 0 ? n : 0;
+        }
+        snap_type(t->func.ret, cur, end);
+        for (uint32_t i = 0; i < t->func.num_params; i++) {
+            if (*cur < end) {
+                n = snprintf(*cur, (size_t)(end - *cur), ",");
+                *cur += n > 0 ? n : 0;
+            }
+            snap_type(t->func.params[i], cur, end);
+        }
+        if (*cur < end) {
+            n = snprintf(*cur, (size_t)(end - *cur), ")");
+            *cur += n > 0 ? n : 0;
+        }
+    }
+}
+
+static char *snapshot_module_structure(const lr_module_t *m) {
+    size_t cap = 1u << 16;
+    char *buf = (char *)malloc(cap);
+    char *cur;
+    char *end;
+    int n;
+    if (!buf)
+        return NULL;
+    cur = buf;
+    end = buf + cap - 1;
+    for (const lr_func_t *f = m->first_func; f; f = f->next) {
+        n = snprintf(cur, (size_t)(end - cur), "func %s vregs=%u params=%u ",
+                     f->name ? f->name : "?", f->next_vreg, f->num_params);
+        cur += n > 0 ? n : 0;
+        snap_type(f->type, &cur, end);
+        n = snprintf(cur, (size_t)(end - cur), " ret=");
+        cur += n > 0 ? n : 0;
+        snap_type(f->ret_type, &cur, end);
+        for (uint32_t i = 0; i < f->num_params; i++) {
+            n = snprintf(cur, (size_t)(end - cur), " p%u=", i);
+            cur += n > 0 ? n : 0;
+            snap_type(f->param_types[i], &cur, end);
+        }
+        n = snprintf(cur, (size_t)(end - cur), "\n");
+        cur += n > 0 ? n : 0;
+        for (const lr_block_t *b = f->first_block; b; b = b->next) {
+            n = snprintf(cur, (size_t)(end - cur), " block %s\n",
+                         b->name ? b->name : "?");
+            cur += n > 0 ? n : 0;
+            for (const lr_inst_t *inst = b->first; inst; inst = inst->next) {
+                n = snprintf(cur, (size_t)(end - cur), "  op=%d dest=%u t=",
+                             (int)inst->op, inst->dest);
+                cur += n > 0 ? n : 0;
+                snap_type(inst->type, &cur, end);
+                for (uint32_t i = 0; i < inst->num_operands; i++) {
+                    n = snprintf(cur, (size_t)(end - cur), " o%u:k%d:", i,
+                                 (int)inst->operands[i].kind);
+                    cur += n > 0 ? n : 0;
+                    snap_type(inst->operands[i].type, &cur, end);
+                }
+                n = snprintf(cur, (size_t)(end - cur), "\n");
+                cur += n > 0 ? n : 0;
+            }
+        }
+    }
+    *cur = '\0';
+    return buf;
+}
+
+/* Builds nested pointer traffic across alloca/load/store/GEP/call/return. */
+static lr_module_t *build_nonmutating_fixture(lr_arena_t *arena) {
+    lr_module_t *m = lr_module_create(arena);
+    lr_func_t *sink;
+    lr_func_t *f;
+    lr_block_t *b;
+    lr_type_t *params[1];
+    lr_operand_t ops[3];
+    if (!m)
+        return NULL;
+    params[0] = m->type_ptr;
+    sink = lr_func_declare(m, "sink_ptr", m->type_i32, params, 1, false);
+    if (!sink)
+        return NULL;
+    f = lr_func_create(m, "nonmutating", m->type_i32, NULL, 0, false);
+    if (!f)
+        return NULL;
+    f->next_vreg = 9;
+    b = lr_block_create(f, arena, "entry");
+    if (!b)
+        return NULL;
+
+    lr_block_append(b, lr_inst_create(arena, LR_OP_ALLOCA, m->type_i32,
+                                      1, NULL, 0));
+    ops[0] = lr_op_imm_i64(7, m->type_i32);
+    ops[1] = lr_op_vreg(1, m->type_ptr);
+    lr_block_append(b, lr_inst_create(arena, LR_OP_STORE, m->type_void,
+                                      0, ops, 2));
+    lr_block_append(b, lr_inst_create(arena, LR_OP_ALLOCA, m->type_ptr,
+                                      2, NULL, 0));
+    ops[0] = lr_op_vreg(1, m->type_ptr);
+    ops[1] = lr_op_vreg(2, m->type_ptr);
+    lr_block_append(b, lr_inst_create(arena, LR_OP_STORE, m->type_void,
+                                      0, ops, 2));
+    ops[0] = lr_op_vreg(2, m->type_ptr);
+    lr_block_append(b, lr_inst_create(arena, LR_OP_LOAD, m->type_ptr,
+                                      3, ops, 1));
+    ops[0] = lr_op_vreg(3, m->type_ptr);
+    ops[1] = lr_op_imm_i64(0, m->type_i64);
+    lr_block_append(b, lr_inst_create(arena, LR_OP_GEP, m->type_i32,
+                                      4, ops, 2));
+    ops[0] = lr_op_vreg(4, m->type_ptr);
+    lr_block_append(b, lr_inst_create(arena, LR_OP_LOAD, m->type_i32,
+                                      5, ops, 1));
+    ops[0] = lr_op_global(lr_module_intern_symbol(m, "sink_ptr"),
+                          m->type_ptr);
+    ops[1] = lr_op_vreg(1, m->type_ptr);
+    lr_block_append(b, lr_inst_create(arena, LR_OP_CALL, m->type_i32,
+                                      6, ops, 2));
+    ops[0] = lr_op_vreg(5, m->type_i32);
+    lr_block_append(b, lr_inst_create(arena, LR_OP_RET, m->type_i32,
+                                      0, ops, 1));
+    return m;
+}
+
+int test_ir_emission_does_not_mutate_module(void) {
+    lr_arena_t *arena = lr_arena_create(0);
+    lr_module_t *m;
+    char *before = NULL;
+    char *after_dump = NULL;
+    char *after_second = NULL;
+    char *dump1 = NULL;
+    char *dump2 = NULL;
+    int result = 1;
+
+    TEST_ASSERT(arena != NULL, "arena create");
+    m = build_nonmutating_fixture(arena);
+    TEST_ASSERT(m != NULL, "fixture module");
+
+    before = snapshot_module_structure(m);
+    TEST_ASSERT(before != NULL, "pre-emission snapshot");
+
+    dump1 = dump_module_text(m);
+    TEST_ASSERT(dump1 != NULL, "first dump");
+    after_dump = snapshot_module_structure(m);
+    TEST_ASSERT(after_dump != NULL, "post-dump snapshot");
+    if (strcmp(before, after_dump) != 0) {
+        fprintf(stderr, "  FAIL: dump mutated source module\n--- before ---\n%s"
+                "--- after ---\n%s", before, after_dump);
+        goto cleanup;
+    }
+
+    dump2 = dump_module_text(m);
+    TEST_ASSERT(dump2 != NULL, "second dump");
+    if (strcmp(dump1, dump2) != 0) {
+        fprintf(stderr, "  FAIL: repeated dump is not stable\n");
+        goto cleanup;
+    }
+    after_second = snapshot_module_structure(m);
+    TEST_ASSERT(after_second != NULL, "post-second-dump snapshot");
+    if (strcmp(before, after_second) != 0) {
+        fprintf(stderr, "  FAIL: second dump mutated source module\n");
+        goto cleanup;
+    }
+
+    result = 0;
+
+cleanup:
+    free(before);
+    free(after_dump);
+    free(after_second);
+    free(dump1);
+    free(dump2);
+    lr_arena_destroy(arena);
+    return result;
+}
+
+int test_ir_emission_clone_failure_preserves_module(void) {
+    lr_arena_t *arena = lr_arena_create(0);
+    lr_module_t *m;
+    char *before = NULL;
+    char *after = NULL;
+    char *text = NULL;
+    int result = 1;
+
+    TEST_ASSERT(arena != NULL, "arena create");
+    m = build_nonmutating_fixture(arena);
+    TEST_ASSERT(m != NULL, "fixture module");
+
+    before = snapshot_module_structure(m);
+    TEST_ASSERT(before != NULL, "pre-failure snapshot");
+
+    lr_ir_set_emission_clone_failure_for_testing(true);
+    text = dump_module_text(m);
+    lr_ir_set_emission_clone_failure_for_testing(false);
+
+    after = snapshot_module_structure(m);
+    TEST_ASSERT(after != NULL, "post-failure snapshot");
+    if (strcmp(before, after) != 0) {
+        fprintf(stderr, "  FAIL: failed emission mutated source module\n");
+        goto cleanup;
+    }
+#if defined(LIRIC_BACKEND_LLVM_VERSION_MAJOR) && \
+    LIRIC_BACKEND_LLVM_VERSION_MAJOR < 15
+    /* Legacy dialect needs the clone; a clone failure must emit nothing at
+       all rather than a partially legalized module. */
+    if (text != NULL) {
+        fprintf(stderr, "  FAIL: clone failure produced partial output\n");
+        goto cleanup;
+    }
+#else
+    /* Opaque-pointer emission needs no clone and is unaffected. */
+    TEST_ASSERT(text != NULL, "modern dialect still emits without a clone");
+#endif
+
+    result = 0;
+
+cleanup:
+    free(before);
+    free(after);
+    free(text);
+    lr_arena_destroy(arena);
+    return result;
+}


### PR DESCRIPTION
Closes #525.

## Summary

Legacy typed-pointer legalization (`legacy_materialize_pointer_types`) ran directly on the caller's `lr_module_t`, so dumping or emitting an object was a destructive operation: it rewrote function type nodes, instruction and operand types, bumped `next_vreg`, spliced bitcasts into block instruction lists, and invalidated cached linear arrays.

Emission now runs on an owned clone in a private arena. The source module is left unchanged on every path.

- `src/ir.c`: `lr_module_clone_for_emission` deep-copies functions (including the `LR_TYPE_FUNC` node and its params array, `param_types`, `param_vregs`), blocks, instructions, and operand arrays into a fresh arena; immutable shared state (scalar type singletons, interned symbol tables, globals, names) is aliased and never freed through the clone. `lr_module_dump_opts` legalizes and prints the clone, then releases its arena.
- Clone construction is skipped entirely for LLVM 15+, where legalization is a no-op, so the opaque-pointer path takes no extra cost.
- `src/llvm_backend.c` needed no change: it emits through `lr_module_dump`, so it inherits the non-mutating path.
- `src/ir.h`: `lr_ir_set_emission_clone_failure_for_testing` test hook for the allocation-failure path.

## Invariants preserved

- **Non-mutating legacy emission**: structural snapshots of the caller's module are identical before emission, after a dump, after a second dump, and after a failed clone.
- **Repeated-dump stability**: two dumps of the same module are byte-identical; no assertion was weakened.
- **Pointer dialect contract**: LLVM 3.8-14 still prints typed pointers, LLVM 15+ still prints opaque `ptr`. The existing `test_ir_dump_pointer_dialect_for_backend` assertions are untouched.
- **Ownership**: the clone owns exactly its own arena; it never frees state shared with the source.

## Verification

Behavioral oracle written first and recorded failing on unmodified main, under a forced LLVM 14 build. The source module's function type node was rewritten by the dump:

```text
  test_ir_emission_does_not_mutate_module...  FAIL: dump mutated source module
--- before ---
func sink_ptr vregs=1 params=1 k14(k4,k10[<null>]) ret=k4 p0=k10[<null>]
  op=28 dest=0 t=k0 o0:k1:k4 o1:k0:k10[<null>]
--- after ---
func sink_ptr vregs=1 params=1 k14(k4,k10[k4]) ret=k4 p0=k10[k4]
  op=28 dest=0 t=k0 o0:k1:k4 o1:k0:k10[k4]
```

After the fix, forced LLVM 14 (legacy typed-pointer dialect):

```text
$ cmake -S . -B b14 -G Ninja -DCMAKE_C_FLAGS=-DLIRIC_BACKEND_LLVM_VERSION_MAJOR=14
$ cmake --build b14 --target test_liric -j3 && ./b14/test_liric
304 tests: 304 passed, 0 failed
```

Canonical build (opaque-pointer dialect):

```text
$ cmake -S . -B build -G Ninja && cmake --build build -j3
$ ctest --test-dir build --output-on-failure -j3
100% tests passed out of 48
```

## Fixtures added

- `test_ir_emission_does_not_mutate_module`: nested pointers across alloca/load/store/GEP/call/return; structural snapshot unchanged after dump and after a second dump, and repeated dumps identical.
- `test_ir_emission_clone_failure_preserves_module`: forced clone failure leaves the source untouched and emits no partial output in the legacy dialect.