### PR TITLE
[session-02] version and verify the public session ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,7 @@ set(LIRIC_LIB_SOURCES
     src/stencil_data.c
     src/stencil_runtime.c
     src/session.c
+    src/session_abi.c
     src/module_emit.c
     src/llvm_backend.c
     src/objfile.c

--- a/include/liric/liric_ir_shared.h
+++ b/include/liric/liric_ir_shared.h
@@ -7,55 +7,61 @@
 extern "C" {
 #endif
 
+/* Explicit, append-only opcode values. These numbers are frozen public ABI:
+   inserting a value before an existing one requires bumping
+   LIRIC_SESSION_ABI_VERSION. New opcodes are appended before LR_OP_COUNT. */
 typedef enum lr_opcode {
-    LR_OP_RET,
-    LR_OP_RET_VOID,
-    LR_OP_BR,
-    LR_OP_CONDBR,
-    LR_OP_UNREACHABLE,
-    LR_OP_ADD,
-    LR_OP_SUB,
-    LR_OP_MUL,
-    LR_OP_SDIV,
-    LR_OP_SREM,
-    LR_OP_UDIV,
-    LR_OP_UREM,
-    LR_OP_AND,
-    LR_OP_OR,
-    LR_OP_XOR,
-    LR_OP_SHL,
-    LR_OP_LSHR,
-    LR_OP_ASHR,
-    LR_OP_FADD,
-    LR_OP_FSUB,
-    LR_OP_FMUL,
-    LR_OP_FDIV,
-    LR_OP_FREM,
-    LR_OP_FNEG,
-    LR_OP_ICMP,
-    LR_OP_FCMP,
-    LR_OP_ALLOCA,
-    LR_OP_LOAD,
-    LR_OP_STORE,
-    LR_OP_GEP,
-    LR_OP_CALL,
-    LR_OP_PHI,
-    LR_OP_SELECT,
-    LR_OP_SEXT,
-    LR_OP_ZEXT,
-    LR_OP_TRUNC,
-    LR_OP_BITCAST,
-    LR_OP_PTRTOINT,
-    LR_OP_INTTOPTR,
-    LR_OP_SITOFP,
-    LR_OP_UITOFP,
-    LR_OP_FPTOSI,
-    LR_OP_FPTOUI,
-    LR_OP_FPEXT,
-    LR_OP_FPTRUNC,
-    LR_OP_EXTRACTVALUE,
-    LR_OP_INSERTVALUE,
+    LR_OP_RET = 0,
+    LR_OP_RET_VOID = 1,
+    LR_OP_BR = 2,
+    LR_OP_CONDBR = 3,
+    LR_OP_UNREACHABLE = 4,
+    LR_OP_ADD = 5,
+    LR_OP_SUB = 6,
+    LR_OP_MUL = 7,
+    LR_OP_SDIV = 8,
+    LR_OP_SREM = 9,
+    LR_OP_UDIV = 10,
+    LR_OP_UREM = 11,
+    LR_OP_AND = 12,
+    LR_OP_OR = 13,
+    LR_OP_XOR = 14,
+    LR_OP_SHL = 15,
+    LR_OP_LSHR = 16,
+    LR_OP_ASHR = 17,
+    LR_OP_FADD = 18,
+    LR_OP_FSUB = 19,
+    LR_OP_FMUL = 20,
+    LR_OP_FDIV = 21,
+    LR_OP_FREM = 22,
+    LR_OP_FNEG = 23,
+    LR_OP_ICMP = 24,
+    LR_OP_FCMP = 25,
+    LR_OP_ALLOCA = 26,
+    LR_OP_LOAD = 27,
+    LR_OP_STORE = 28,
+    LR_OP_GEP = 29,
+    LR_OP_CALL = 30,
+    LR_OP_PHI = 31,
+    LR_OP_SELECT = 32,
+    LR_OP_SEXT = 33,
+    LR_OP_ZEXT = 34,
+    LR_OP_TRUNC = 35,
+    LR_OP_BITCAST = 36,
+    LR_OP_PTRTOINT = 37,
+    LR_OP_INTTOPTR = 38,
+    LR_OP_SITOFP = 39,
+    LR_OP_UITOFP = 40,
+    LR_OP_FPTOSI = 41,
+    LR_OP_FPTOUI = 42,
+    LR_OP_FPEXT = 43,
+    LR_OP_FPTRUNC = 44,
+    LR_OP_EXTRACTVALUE = 45,
+    LR_OP_INSERTVALUE = 46,
 } lr_opcode_t;
+
+/* Count sentinel, kept outside the enum so exhaustive switches stay clean. */
+enum { LR_OP_COUNT = LR_OP_INSERTVALUE + 1 };
 
 typedef enum lr_fcmp_pred {
     LR_FCMP_FALSE,
@@ -82,6 +88,7 @@ typedef struct lr_phi_copy_desc {
     lr_operand_desc_t src_op;
 } lr_phi_copy_desc_t;
 
+/* Explicit, append-only operand-kind values; same freezing rule as opcodes. */
 enum {
     LR_OP_KIND_VREG    = 0,
     LR_OP_KIND_IMM_I64 = 1,
@@ -91,6 +98,8 @@ enum {
     LR_OP_KIND_NULL    = 5,
     LR_OP_KIND_UNDEF   = 6,
 };
+
+enum { LR_OP_KIND_COUNT = LR_OP_KIND_UNDEF + 1 };
 
 #ifdef __cplusplus
 }

--- a/include/liric/liric_session.h
+++ b/include/liric/liric_session.h
@@ -50,12 +50,12 @@ typedef struct lr_error {
 /* Error codes */
 enum {
     LR_OK = 0,
-    LR_ERR_ARGUMENT,
-    LR_ERR_STATE,
-    LR_ERR_MODE,
-    LR_ERR_NOT_FOUND,
-    LR_ERR_BACKEND,
-    LR_ERR_PARSE,
+    LR_ERR_ARGUMENT = 1,
+    LR_ERR_STATE = 2,
+    LR_ERR_MODE = 3,
+    LR_ERR_NOT_FOUND = 4,
+    LR_ERR_BACKEND = 5,
+    LR_ERR_PARSE = 6,
 };
 
 /* ---- Opcodes ------------------------------------------------------------ */
@@ -79,6 +79,47 @@ typedef struct lr_inst_desc {
     bool call_vararg;
     uint32_t call_fixed_args;
 } lr_inst_desc_t;
+
+/* ---- ABI version and layout ------------------------------------------- */
+
+/* Bumped whenever an existing public session layout or enumerator value
+   changes. Appending a field to the end of lr_session_abi_info_t, or an
+   opcode before LR_OP_COUNT, does not require a bump; reordering or inserting
+   does. A foreign-language binding should query lr_session_get_abi_info and
+   refuse to emit instructions when the reported version or layout differs
+   from the one it was generated against. */
+#define LIRIC_SESSION_ABI_VERSION 1u
+
+typedef struct lr_session_abi_info {
+    uint32_t abi_version;
+    size_t struct_size;
+    size_t config_size;
+    size_t error_size;
+    size_t operand_size;
+    size_t inst_size;
+    size_t config_mode_offset;
+    size_t config_target_offset;
+    size_t config_backend_offset;
+    size_t config_opt_level_offset;
+    size_t error_code_offset;
+    size_t error_msg_offset;
+    size_t error_msg_size;
+    size_t operand_kind_offset;
+    size_t operand_type_offset;
+    size_t operand_global_offset_offset;
+    size_t inst_op_offset;
+    size_t inst_type_offset;
+    size_t inst_dest_offset;
+    size_t inst_operands_offset;
+    size_t inst_num_operands_offset;
+    uint32_t opcode_count;
+    uint32_t operand_kind_count;
+} lr_session_abi_info_t;
+
+/* Fills *out with the layout of this build's public session ABI. Returns
+   LR_OK, or LR_ERR_ARGUMENT when out is NULL or out_size is smaller than
+   sizeof(lr_session_abi_info_t). Callable before any session exists. */
+int lr_session_get_abi_info(lr_session_abi_info_t *out, size_t out_size);
 
 /* ---- Lifecycle --------------------------------------------------------- */
 

--- a/src/session.c
+++ b/src/session.c
@@ -2538,6 +2538,7 @@ lr_type_t *lr_type_f128_s(struct lr_session *s) {
 lr_type_t *lr_type_ptr_s(struct lr_session *s) {
     return (s && s->module) ? s->module->type_ptr : NULL;
 }
+
 lr_type_t *lr_type_ptr_to_s(struct lr_session *s, lr_type_t *pointee) {
     if (!s || !s->module || !pointee)
         return NULL;

--- a/src/session_abi.c
+++ b/src/session_abi.c
@@ -1,0 +1,43 @@
+/* Public session ABI layout query (issue #527).
+
+   Kept in its own translation unit: src/session.c deliberately declares the
+   session entry points with internal types and cannot include the public
+   header, but the ABI report must be computed from the public definitions
+   that foreign-language bindings actually see. */
+
+#include <liric/liric_session.h>
+#include <stddef.h>
+#include <string.h>
+
+int lr_session_get_abi_info(lr_session_abi_info_t *out, size_t out_size) {
+    lr_session_abi_info_t info;
+    if (!out || out_size < sizeof(lr_session_abi_info_t))
+        return LR_ERR_ARGUMENT;
+    memset(&info, 0, sizeof(info));
+    info.abi_version = LIRIC_SESSION_ABI_VERSION;
+    info.struct_size = sizeof(lr_session_abi_info_t);
+    info.config_size = sizeof(lr_session_config_t);
+    info.error_size = sizeof(lr_error_t);
+    info.operand_size = sizeof(lr_operand_desc_t);
+    info.inst_size = sizeof(lr_inst_desc_t);
+    info.config_mode_offset = offsetof(lr_session_config_t, mode);
+    info.config_target_offset = offsetof(lr_session_config_t, target);
+    info.config_backend_offset = offsetof(lr_session_config_t, backend);
+    info.config_opt_level_offset = offsetof(lr_session_config_t, opt_level);
+    info.error_code_offset = offsetof(lr_error_t, code);
+    info.error_msg_offset = offsetof(lr_error_t, msg);
+    info.error_msg_size = sizeof(((lr_error_t *)0)->msg);
+    info.operand_kind_offset = offsetof(lr_operand_desc_t, kind);
+    info.operand_type_offset = offsetof(lr_operand_desc_t, type);
+    info.operand_global_offset_offset =
+        offsetof(lr_operand_desc_t, global_offset);
+    info.inst_op_offset = offsetof(lr_inst_desc_t, op);
+    info.inst_type_offset = offsetof(lr_inst_desc_t, type);
+    info.inst_dest_offset = offsetof(lr_inst_desc_t, dest);
+    info.inst_operands_offset = offsetof(lr_inst_desc_t, operands);
+    info.inst_num_operands_offset = offsetof(lr_inst_desc_t, num_operands);
+    info.opcode_count = (uint32_t)LR_OP_COUNT;
+    info.operand_kind_count = (uint32_t)LR_OP_KIND_COUNT;
+    *out = info;
+    return LR_OK;
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -253,6 +253,8 @@ int test_ir_emission_does_not_mutate_module(void);
 int test_ir_emission_clone_failure_preserves_module(void);
 int test_session_scalar_gep_undef_tail_trimmed(void);
 int test_session_typed_pointer_metadata(void);
+int test_session_abi_info_contract(void);
+int test_session_abi_enum_values_frozen(void);
 int test_ir_dump_scalar_gep_undef_tail_trimmed(void);
 int test_ir_dump_declares_undeclared_call_targets(void);
 int test_session_ir_lookup_prefers_module_symbol_over_process_symbol(void);
@@ -603,6 +605,8 @@ int main(void) {
     RUN_TEST(test_ir_emission_clone_failure_preserves_module);
     RUN_TEST(test_session_scalar_gep_undef_tail_trimmed);
     RUN_TEST(test_session_typed_pointer_metadata);
+    RUN_TEST(test_session_abi_info_contract);
+    RUN_TEST(test_session_abi_enum_values_frozen);
     RUN_TEST(test_ir_dump_scalar_gep_undef_tail_trimmed);
     RUN_TEST(test_ir_dump_declares_undeclared_call_targets);
     RUN_TEST(test_session_ir_lookup_prefers_module_symbol_over_process_symbol);

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -3253,3 +3253,163 @@ cleanup:
     lr_session_destroy(s);
     return result;
 }
+
+/* --- Issue #527: version and verify the public session ABI --------------- */
+
+int test_session_abi_info_contract(void) {
+    lr_session_abi_info_t info;
+    lr_session_abi_info_t small;
+    int rc;
+
+    memset(&info, 0xAB, sizeof(info));
+    rc = lr_session_get_abi_info(&info, sizeof(info));
+    TEST_ASSERT_EQ(rc, LR_OK, "abi info query");
+
+    TEST_ASSERT_EQ(info.abi_version, LIRIC_SESSION_ABI_VERSION,
+                   "reported ABI version matches the published macro");
+    TEST_ASSERT_EQ(info.struct_size, sizeof(lr_session_abi_info_t),
+                   "reported struct size");
+
+    TEST_ASSERT_EQ(info.config_size, sizeof(lr_session_config_t),
+                   "config size");
+    TEST_ASSERT_EQ(info.error_size, sizeof(lr_error_t), "error size");
+    TEST_ASSERT_EQ(info.operand_size, sizeof(lr_operand_desc_t),
+                   "operand size");
+    TEST_ASSERT_EQ(info.inst_size, sizeof(lr_inst_desc_t), "inst size");
+
+    TEST_ASSERT_EQ(info.config_mode_offset,
+                   offsetof(lr_session_config_t, mode), "config.mode offset");
+    TEST_ASSERT_EQ(info.config_target_offset,
+                   offsetof(lr_session_config_t, target),
+                   "config.target offset");
+    TEST_ASSERT_EQ(info.config_backend_offset,
+                   offsetof(lr_session_config_t, backend),
+                   "config.backend offset");
+    TEST_ASSERT_EQ(info.config_opt_level_offset,
+                   offsetof(lr_session_config_t, opt_level),
+                   "config.opt_level offset");
+
+    TEST_ASSERT_EQ(info.error_code_offset, offsetof(lr_error_t, code),
+                   "error.code offset");
+    TEST_ASSERT_EQ(info.error_msg_offset, offsetof(lr_error_t, msg),
+                   "error.msg offset");
+    TEST_ASSERT_EQ(info.error_msg_size, sizeof(((lr_error_t *)0)->msg),
+                   "error.msg size");
+
+    TEST_ASSERT_EQ(info.operand_kind_offset,
+                   offsetof(lr_operand_desc_t, kind), "operand.kind offset");
+    TEST_ASSERT_EQ(info.operand_type_offset,
+                   offsetof(lr_operand_desc_t, type), "operand.type offset");
+    TEST_ASSERT_EQ(info.operand_global_offset_offset,
+                   offsetof(lr_operand_desc_t, global_offset),
+                   "operand.global_offset offset");
+
+    TEST_ASSERT_EQ(info.inst_op_offset, offsetof(lr_inst_desc_t, op),
+                   "inst.op offset");
+    TEST_ASSERT_EQ(info.inst_type_offset, offsetof(lr_inst_desc_t, type),
+                   "inst.type offset");
+    TEST_ASSERT_EQ(info.inst_dest_offset, offsetof(lr_inst_desc_t, dest),
+                   "inst.dest offset");
+    TEST_ASSERT_EQ(info.inst_operands_offset,
+                   offsetof(lr_inst_desc_t, operands),
+                   "inst.operands offset");
+    TEST_ASSERT_EQ(info.inst_num_operands_offset,
+                   offsetof(lr_inst_desc_t, num_operands),
+                   "inst.num_operands offset");
+
+    TEST_ASSERT_EQ(info.opcode_count, LR_OP_COUNT, "opcode count");
+    TEST_ASSERT_EQ(info.operand_kind_count, LR_OP_KIND_COUNT,
+                   "operand kind count");
+
+    /* Negative: null and undersized outputs are rejected. */
+    TEST_ASSERT_EQ(lr_session_get_abi_info(NULL, sizeof(info)),
+                   LR_ERR_ARGUMENT, "null output rejected");
+    TEST_ASSERT_EQ(lr_session_get_abi_info(&small, sizeof(info) - 1u),
+                   LR_ERR_ARGUMENT, "undersized output rejected");
+    TEST_ASSERT_EQ(lr_session_get_abi_info(&small, 0), LR_ERR_ARGUMENT,
+                   "zero-sized output rejected");
+
+    return 0;
+}
+
+/* Freezes the pre-change opcode and operand-kind numbering. Inserting a value
+   before an existing one changes these constants and must therefore come with
+   an ABI version bump; appending at the end does not. */
+int test_session_abi_enum_values_frozen(void) {
+    TEST_ASSERT_EQ(LIRIC_SESSION_ABI_VERSION, 1u, "published ABI version");
+
+    TEST_ASSERT_EQ(LR_OP_RET, 0, "LR_OP_RET");
+    TEST_ASSERT_EQ(LR_OP_RET_VOID, 1, "LR_OP_RET_VOID");
+    TEST_ASSERT_EQ(LR_OP_BR, 2, "LR_OP_BR");
+    TEST_ASSERT_EQ(LR_OP_CONDBR, 3, "LR_OP_CONDBR");
+    TEST_ASSERT_EQ(LR_OP_UNREACHABLE, 4, "LR_OP_UNREACHABLE");
+    TEST_ASSERT_EQ(LR_OP_ADD, 5, "LR_OP_ADD");
+    TEST_ASSERT_EQ(LR_OP_SUB, 6, "LR_OP_SUB");
+    TEST_ASSERT_EQ(LR_OP_MUL, 7, "LR_OP_MUL");
+    TEST_ASSERT_EQ(LR_OP_SDIV, 8, "LR_OP_SDIV");
+    TEST_ASSERT_EQ(LR_OP_SREM, 9, "LR_OP_SREM");
+    TEST_ASSERT_EQ(LR_OP_UDIV, 10, "LR_OP_UDIV");
+    TEST_ASSERT_EQ(LR_OP_UREM, 11, "LR_OP_UREM");
+    TEST_ASSERT_EQ(LR_OP_AND, 12, "LR_OP_AND");
+    TEST_ASSERT_EQ(LR_OP_OR, 13, "LR_OP_OR");
+    TEST_ASSERT_EQ(LR_OP_XOR, 14, "LR_OP_XOR");
+    TEST_ASSERT_EQ(LR_OP_SHL, 15, "LR_OP_SHL");
+    TEST_ASSERT_EQ(LR_OP_LSHR, 16, "LR_OP_LSHR");
+    TEST_ASSERT_EQ(LR_OP_ASHR, 17, "LR_OP_ASHR");
+    TEST_ASSERT_EQ(LR_OP_FADD, 18, "LR_OP_FADD");
+    TEST_ASSERT_EQ(LR_OP_FSUB, 19, "LR_OP_FSUB");
+    TEST_ASSERT_EQ(LR_OP_FMUL, 20, "LR_OP_FMUL");
+    TEST_ASSERT_EQ(LR_OP_FDIV, 21, "LR_OP_FDIV");
+    TEST_ASSERT_EQ(LR_OP_FREM, 22, "LR_OP_FREM");
+    TEST_ASSERT_EQ(LR_OP_FNEG, 23, "LR_OP_FNEG");
+    TEST_ASSERT_EQ(LR_OP_ICMP, 24, "LR_OP_ICMP");
+    TEST_ASSERT_EQ(LR_OP_FCMP, 25, "LR_OP_FCMP");
+    TEST_ASSERT_EQ(LR_OP_ALLOCA, 26, "LR_OP_ALLOCA");
+    TEST_ASSERT_EQ(LR_OP_LOAD, 27, "LR_OP_LOAD");
+    TEST_ASSERT_EQ(LR_OP_STORE, 28, "LR_OP_STORE");
+    TEST_ASSERT_EQ(LR_OP_GEP, 29, "LR_OP_GEP");
+    TEST_ASSERT_EQ(LR_OP_CALL, 30, "LR_OP_CALL");
+    TEST_ASSERT_EQ(LR_OP_PHI, 31, "LR_OP_PHI");
+    TEST_ASSERT_EQ(LR_OP_SELECT, 32, "LR_OP_SELECT");
+    TEST_ASSERT_EQ(LR_OP_SEXT, 33, "LR_OP_SEXT");
+    TEST_ASSERT_EQ(LR_OP_ZEXT, 34, "LR_OP_ZEXT");
+    TEST_ASSERT_EQ(LR_OP_TRUNC, 35, "LR_OP_TRUNC");
+    TEST_ASSERT_EQ(LR_OP_BITCAST, 36, "LR_OP_BITCAST");
+    TEST_ASSERT_EQ(LR_OP_PTRTOINT, 37, "LR_OP_PTRTOINT");
+    TEST_ASSERT_EQ(LR_OP_INTTOPTR, 38, "LR_OP_INTTOPTR");
+    TEST_ASSERT_EQ(LR_OP_SITOFP, 39, "LR_OP_SITOFP");
+    TEST_ASSERT_EQ(LR_OP_UITOFP, 40, "LR_OP_UITOFP");
+    TEST_ASSERT_EQ(LR_OP_FPTOSI, 41, "LR_OP_FPTOSI");
+    TEST_ASSERT_EQ(LR_OP_FPTOUI, 42, "LR_OP_FPTOUI");
+    TEST_ASSERT_EQ(LR_OP_FPEXT, 43, "LR_OP_FPEXT");
+    TEST_ASSERT_EQ(LR_OP_FPTRUNC, 44, "LR_OP_FPTRUNC");
+    TEST_ASSERT_EQ(LR_OP_EXTRACTVALUE, 45, "LR_OP_EXTRACTVALUE");
+    TEST_ASSERT_EQ(LR_OP_INSERTVALUE, 46, "LR_OP_INSERTVALUE");
+    TEST_ASSERT_EQ(LR_OP_COUNT, 47, "opcode count sentinel");
+
+    TEST_ASSERT_EQ(LR_OP_KIND_VREG, 0, "LR_OP_KIND_VREG");
+    TEST_ASSERT_EQ(LR_OP_KIND_IMM_I64, 1, "LR_OP_KIND_IMM_I64");
+    TEST_ASSERT_EQ(LR_OP_KIND_IMM_F64, 2, "LR_OP_KIND_IMM_F64");
+    TEST_ASSERT_EQ(LR_OP_KIND_BLOCK, 3, "LR_OP_KIND_BLOCK");
+    TEST_ASSERT_EQ(LR_OP_KIND_GLOBAL, 4, "LR_OP_KIND_GLOBAL");
+    TEST_ASSERT_EQ(LR_OP_KIND_NULL, 5, "LR_OP_KIND_NULL");
+    TEST_ASSERT_EQ(LR_OP_KIND_UNDEF, 6, "LR_OP_KIND_UNDEF");
+    TEST_ASSERT_EQ(LR_OP_KIND_COUNT, 7, "operand kind count sentinel");
+
+    TEST_ASSERT_EQ(LR_OK, 0, "LR_OK");
+    TEST_ASSERT_EQ(LR_ERR_ARGUMENT, 1, "LR_ERR_ARGUMENT");
+    TEST_ASSERT_EQ(LR_ERR_STATE, 2, "LR_ERR_STATE");
+    TEST_ASSERT_EQ(LR_ERR_MODE, 3, "LR_ERR_MODE");
+    TEST_ASSERT_EQ(LR_ERR_NOT_FOUND, 4, "LR_ERR_NOT_FOUND");
+    TEST_ASSERT_EQ(LR_ERR_BACKEND, 5, "LR_ERR_BACKEND");
+    TEST_ASSERT_EQ(LR_ERR_PARSE, 6, "LR_ERR_PARSE");
+
+    TEST_ASSERT_EQ(LR_MODE_DIRECT, 0, "LR_MODE_DIRECT");
+    TEST_ASSERT_EQ(LR_MODE_IR, 1, "LR_MODE_IR");
+    TEST_ASSERT_EQ(LR_SESSION_BACKEND_DEFAULT, 0, "backend default");
+    TEST_ASSERT_EQ(LR_SESSION_BACKEND_ISEL, 1, "backend isel");
+    TEST_ASSERT_EQ(LR_SESSION_BACKEND_COPY_PATCH, 2, "backend copy-patch");
+    TEST_ASSERT_EQ(LR_SESSION_BACKEND_LLVM, 3, "backend llvm");
+
+    return 0;
+}


### PR DESCRIPTION
Closes #527. Depends on #526 (merged).

## Summary

Foreign-language bindings can now detect an incompatible session layout before emitting any instruction, and the previously implicit opcode numbering is explicit and append-only.

- `include/liric/liric_session.h`: publishes `LIRIC_SESSION_ABI_VERSION` (1), `lr_session_abi_info_t`, and `lr_session_get_abi_info`. Error codes are given explicit values.
- `include/liric/liric_ir_shared.h`: every `lr_opcode_t` and operand-kind value is now written out explicitly, with `LR_OP_COUNT` and `LR_OP_KIND_COUNT` sentinels kept outside their enums so exhaustive switches stay clean.
- `src/session_abi.c` (new TU): computes the report from the public definitions. It is deliberately separate because `src/session.c` declares the session entry points with internal types and cannot include the public header - so the reported layout is the one bindings actually see, not an internal approximation.

## Invariants preserved

- **Versioned public interface**: `LIRIC_SESSION_ABI_VERSION` is published and asserted to equal the value the query reports. The documented rule is recorded in the header: appending a field or an opcode before the count sentinel is compatible; reordering or inserting requires a bump.
- **Verified ABI declarations**: the test compares every reported size and field offset against `sizeof`/`offsetof` of the public structs, so a silent layout drift fails the build rather than corrupting a binding.
- **No opcode renumbering**: all 47 opcode values are frozen against the pre-change implicit numbering (`LR_OP_RET` = 0 through `LR_OP_INSERTVALUE` = 46), and all 7 operand kinds, error codes, modes, and backend values are frozen too. Making the values explicit is a no-op for every existing consumer.
- Private IR structures are not covered, and no Fortran bindings are generated here.

## Verification

Oracle written first and recorded failing on unmodified main - the interface does not exist:

```text
tests/test_session.c:3260:5: error: unknown type name 'lr_session_abi_info_t'
tests/test_session.c:3265:10: error: implicit declaration of function 'lr_session_get_abi_info'
```

After the change:

```text
$ cmake -S . -B build -G Ninja && cmake --build build -j3
$ ./build/test_liric
307 tests: 307 passed, 0 failed
$ ctest --test-dir build --output-on-failure -j3
100% tests passed out of 48
```

Forced LLVM 14 build (legacy typed-pointer dialect), confirming the explicit enum values did not disturb legacy emission:

```text
$ ./d14/test_liric
307 tests: 307 passed, 0 failed
```

## Fixtures added

- `test_session_abi_info_contract`: reported version, struct size, all four descriptor sizes, and fifteen field offsets equal their `sizeof`/`offsetof` values; null, undersized, and zero-sized outputs each return `LR_ERR_ARGUMENT`.
- `test_session_abi_enum_values_frozen`: freezes every opcode, operand kind, error code, session mode, and backend value, plus both count sentinels and the published ABI version.