### PR TITLE
[dominance-01] preserve integer print definitions across serialization

### DIFF
--- a/src/ir.c
+++ b/src/ir.c
@@ -2254,11 +2254,6 @@ void lr_ir_set_emission_clone_failure_for_testing(bool fail) {
     lr_emission_clone_forced_failure = fail;
 }
 
-typedef struct lr_emission_clone {
-    lr_module_t *module;
-    lr_arena_t *arena;
-} lr_emission_clone_t;
-
 static lr_type_t *clone_emission_func_type(lr_arena_t *a, lr_type_t *t) {
     lr_type_t *copy;
     if (!t || t->kind != LR_TYPE_FUNC)
@@ -2369,7 +2364,7 @@ static lr_func_t *clone_emission_func(lr_arena_t *a, lr_module_t *owner,
     return copy;
 }
 
-static void lr_emission_clone_release(lr_emission_clone_t *clone) {
+void lr_emission_clone_release(lr_emission_clone_t *clone) {
     if (!clone)
         return;
     lr_arena_destroy(clone->arena);
@@ -2379,7 +2374,7 @@ static void lr_emission_clone_release(lr_emission_clone_t *clone) {
 
 /* Returns false only on allocation failure; the source module is never
    touched on any path. */
-static bool lr_module_clone_for_emission(lr_module_t *src,
+bool lr_module_clone_for_emission(lr_module_t *src,
                                          lr_emission_clone_t *out) {
     lr_arena_t *arena;
     lr_module_t *copy;

--- a/src/ir.h
+++ b/src/ir.h
@@ -215,6 +215,19 @@ lr_operand_t lr_op_global(uint32_t id, lr_type_t *type);
 lr_operand_t lr_op_null(lr_type_t *type);
 uint32_t lr_module_intern_symbol(lr_module_t *m, const char *name);
 
+/* Non-mutating emission clone (issue #525 / #523). Emission (dump, object,
+   executable) may finalize/legalize IR. To keep a valid session module
+   stable across serialization, these passes run on an owned clone whose
+   mutable IR lives in a private arena. The source module is never touched.
+   lr_module_clone_for_emission returns false only on allocation failure. */
+typedef struct lr_emission_clone {
+    lr_module_t *module;
+    lr_arena_t *arena;
+} lr_emission_clone_t;
+bool lr_module_clone_for_emission(lr_module_t *src,
+                                  lr_emission_clone_t *out);
+void lr_emission_clone_release(lr_emission_clone_t *clone);
+
 /* Test hook (issue #525): force the legacy emission clone to fail so the
    non-mutating contract can be checked on the allocation-failure path. */
 void lr_ir_set_emission_clone_failure_for_testing(bool fail);

--- a/src/session.c
+++ b/src/session.c
@@ -3338,9 +3338,32 @@ static const lr_target_t *session_resolve_target(struct lr_session *s) {
     return lr_target_host();
 }
 
+
+/* Issue #523: native object emission finalizes (DCE / constant-folds) the IR
+   inside lr_target_compile. Running that on the live session module would
+   mutate a valid CFG across serialization (the integer-print definition would
+   be rewritten away). Run native emission on a non-mutating clone so the live
+   module stays byte-for-byte stable through dump and object emission. The
+   LLVM backend already serializes from module text and needs no clone. */
+static lr_module_t *session_emission_module(struct lr_session *s,
+                                            lr_emission_clone_t *clone,
+                                            session_error_t *err) {
+    memset(clone, 0, sizeof(*clone));
+    if (s->jit && s->jit->mode == LR_COMPILE_LLVM)
+        return s->module;
+    if (!lr_module_clone_for_emission(s->module, clone)) {
+        err_set(err, S_ERR_BACKEND, "object emission clone failed");
+        return NULL;
+    }
+    return clone->module;
+}
+
 int lr_session_emit_object(struct lr_session *s, const char *path,
                             session_error_t *err) {
     char backend_err[256] = {0};
+    lr_emission_clone_t clone = {0};
+    lr_module_t *emit;
+    int rc;
 
     err_clear(err);
     if (!s || !s->module || !path) {
@@ -3370,10 +3393,15 @@ int lr_session_emit_object(struct lr_session *s, const char *path,
         return 0;
     }
 
-    if (lr_emit_module_object_path_mode(s->module, s->cfg.target,
-                                        s->jit ? s->jit->mode : LR_COMPILE_COPY_PATCH,
-                                        path, s->cfg.opt_level, backend_err,
-                                        sizeof(backend_err)) != 0) {
+    emit = session_emission_module(s, &clone, err);
+    if (!emit)
+        return -1;
+    rc = lr_emit_module_object_path_mode(emit, s->cfg.target,
+                                         s->jit ? s->jit->mode : LR_COMPILE_COPY_PATCH,
+                                         path, s->cfg.opt_level, backend_err,
+                                         sizeof(backend_err));
+    lr_emission_clone_release(&clone);
+    if (rc != 0) {
         err_set(err, S_ERR_BACKEND, "%s",
                 backend_err[0] ? backend_err : "object emission failed");
         return -1;
@@ -3449,9 +3477,18 @@ int lr_session_emit_object_stream(struct lr_session *s, FILE *out,
 #endif
     }
 
-    if (lr_emit_object(s->module, target, out) != 0) {
-        err_set(err, S_ERR_BACKEND, "object emission failed");
-        return -1;
+    {
+        lr_emission_clone_t clone = {0};
+        lr_module_t *emit = session_emission_module(s, &clone, err);
+        int rc;
+        if (!emit)
+            return -1;
+        rc = lr_emit_object(emit, target, out);
+        lr_emission_clone_release(&clone);
+        if (rc != 0) {
+            err_set(err, S_ERR_BACKEND, "object emission failed");
+            return -1;
+        }
     }
     return 0;
 }
@@ -3500,14 +3537,23 @@ int lr_session_emit_exe(struct lr_session *s, const char *path,
     }
 
     entry = session_entry_symbol(s->module);
-    if (lr_emit_module_executable_path_mode(
-            s->module, s->cfg.target,
-            s->jit ? s->jit->mode : LR_COMPILE_COPY_PATCH,
-            path, entry, s->cfg.opt_level,
-            backend_err, sizeof(backend_err)) != 0) {
-        err_set(err, S_ERR_BACKEND, "%s",
-                backend_err[0] ? backend_err : "executable emission failed");
-        return -1;
+    {
+        lr_emission_clone_t clone = {0};
+        lr_module_t *emit = session_emission_module(s, &clone, err);
+        int rc;
+        if (!emit)
+            return -1;
+        rc = lr_emit_module_executable_path_mode(
+                emit, s->cfg.target,
+                s->jit ? s->jit->mode : LR_COMPILE_COPY_PATCH,
+                path, entry, s->cfg.opt_level,
+                backend_err, sizeof(backend_err));
+        lr_emission_clone_release(&clone);
+        if (rc != 0) {
+            err_set(err, S_ERR_BACKEND, "%s",
+                    backend_err[0] ? backend_err : "executable emission failed");
+            return -1;
+        }
     }
     if (session_mark_output_executable(path, err) != 0)
         return -1;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -255,6 +255,8 @@ int test_session_scalar_gep_undef_tail_trimmed(void);
 int test_session_typed_pointer_metadata(void);
 int test_session_abi_info_contract(void);
 int test_session_abi_enum_values_frozen(void);
+int test_session_integer_print_dominance_preserved(void);
+int test_session_non_dominating_value_not_moved(void);
 int test_ir_dump_scalar_gep_undef_tail_trimmed(void);
 int test_ir_dump_declares_undeclared_call_targets(void);
 int test_session_ir_lookup_prefers_module_symbol_over_process_symbol(void);
@@ -607,6 +609,8 @@ int main(void) {
     RUN_TEST(test_session_typed_pointer_metadata);
     RUN_TEST(test_session_abi_info_contract);
     RUN_TEST(test_session_abi_enum_values_frozen);
+    RUN_TEST(test_session_integer_print_dominance_preserved);
+    RUN_TEST(test_session_non_dominating_value_not_moved);
     RUN_TEST(test_ir_dump_scalar_gep_undef_tail_trimmed);
     RUN_TEST(test_ir_dump_declares_undeclared_call_targets);
     RUN_TEST(test_session_ir_lookup_prefers_module_symbol_over_process_symbol);

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -3413,3 +3413,200 @@ int test_session_abi_enum_values_frozen(void) {
 
     return 0;
 }
+
+/* Issue #523: an i64 print definition placed in a block that dominates its
+   printf use must survive serialization unchanged. Object emission used to
+   run the finalize/DCE peephole (which constant-folds) on the live session
+   module, destroying the definition and rewriting the call operand. Emission
+   must run on a non-mutating clone so the snapshot before and after
+   dump + object emission is identical and the definition still dominates. */
+int test_session_integer_print_dominance_preserved(void) {
+    lr_session_config_t cfg = {0};
+    lr_error_t err = {0};
+    lr_session_t *s = NULL;
+    lr_type_t *i64 = NULL;
+    lr_type_t *i32 = NULL;
+    lr_type_t *ptr = NULL;
+    uint32_t entry = 0, print = 0, wide = 0, r = 0;
+    int rc = -1;
+    int result = 1;
+    char *snap_before = NULL;
+    char *snap_after = NULL;
+    char *dump1 = NULL;
+    char *dump2 = NULL;
+    const char *obj_path = "/tmp/liric_test_dominance_int_print.o";
+
+    cfg.mode = LR_MODE_IR;
+    cfg.backend = LR_SESSION_BACKEND_COPY_PATCH;
+    s = lr_session_create(&cfg, &err);
+    TEST_ASSERT(s != NULL, "session create");
+
+    i64 = lr_type_i64_s(s);
+    i32 = lr_type_i32_s(s);
+    ptr = lr_type_ptr_s(s);
+    TEST_ASSERT(i64 != NULL && i32 != NULL && ptr != NULL, "primitive types");
+
+    /* define i32 @f() {
+     *   entry: %w = add i64 1, 1      ; i64 print definition (foldable)
+     *          br label %print
+     *   print: %r = call i32 @printf(ptr null, i64 %w)
+     *          ret i32 %r
+     * }
+     * entry dominates print, so %w must dominate its printf use. */
+    rc = lr_session_func_begin(s, "dominance_int_print", i32, NULL, 0, false, &err);
+    TEST_ASSERT_EQ(rc, 0, "func begin");
+
+    entry = lr_session_block(s);
+    print = lr_session_block(s);
+    lr_session_set_block(s, entry, &err);
+    wide = lr_emit_add(s, i64, LR_IMM(1, i64), LR_IMM(1, i64));
+    lr_emit_br(s, print);
+
+    lr_session_set_block(s, print, &err);
+    {
+        uint32_t printf_sym = lr_session_intern(s, "printf");
+        lr_operand_desc_t args[2] = {LR_IMM(0, ptr), LR_VREG(wide, i64)};
+        r = lr_emit_call(s, i32, LR_GLOBAL(printf_sym, ptr), args, 2);
+        lr_emit_ret(s, LR_VREG(r, i32));
+    }
+
+    rc = lr_session_func_end(s, NULL, &err);
+    TEST_ASSERT_EQ(rc, 0, "func end");
+
+    snap_before = snapshot_module_structure(lr_session_module(s));
+    TEST_ASSERT(snap_before != NULL, "pre-emission snapshot");
+
+    dump1 = session_dump_text(s);
+    TEST_ASSERT(dump1 != NULL, "first dump");
+    TEST_ASSERT(strstr(dump1, "%v0 = add i64 1, 1") != NULL,
+                "i64 print definition present before emission");
+    TEST_ASSERT(strstr(dump1, "call i32 @printf(ptr null, i64 %v0)") != NULL,
+                "printf use references the dominating definition");
+
+    rc = lr_session_emit_object(s, obj_path, &err);
+    TEST_ASSERT_EQ(rc, 0, "emit object");
+
+    snap_after = snapshot_module_structure(lr_session_module(s));
+    TEST_ASSERT(snap_after != NULL, "post-emission snapshot");
+    TEST_ASSERT(strcmp(snap_before, snap_after) == 0,
+                "module unchanged across object emission");
+
+    dump2 = session_dump_text(s);
+    TEST_ASSERT(dump2 != NULL, "second dump");
+    TEST_ASSERT(strcmp(dump1, dump2) == 0,
+                "dump stable across object emission");
+    TEST_ASSERT(strstr(dump2, "%v0 = add i64 1, 1") != NULL,
+                "i64 print definition still dominates after emission");
+    TEST_ASSERT(strstr(dump2, "call i32 @printf(ptr null, i64 %v0)") != NULL,
+                "printf use still references the dominating definition");
+
+    result = 0;
+    goto cleanup;
+
+cleanup:
+    remove(obj_path);
+    free(snap_before);
+    free(snap_after);
+    free(dump1);
+    free(dump2);
+    if (s)
+        lr_session_destroy(s);
+    return result;
+}
+
+/* Issue #523 negative: an intentionally non-dominating value (defined in a
+   block that does not dominate its printf use) must not be silently moved or
+   repaired by serialization. The session emits it as-is (the producer owns
+   the CFG error); no backend repair logic relocates the definition to a
+   dominating block. The module and dump stay byte-for-byte stable across
+   dump + object emission. */
+int test_session_non_dominating_value_not_moved(void) {
+    lr_session_config_t cfg = {0};
+    lr_error_t err = {0};
+    lr_session_t *s = NULL;
+    lr_type_t *i64 = NULL;
+    lr_type_t *i32 = NULL;
+    lr_type_t *ptr = NULL;
+    uint32_t entry = 0, print = 0, other = 0, exitb = 0;
+    int rc = -1;
+    int result = 1;
+    char *snap_before = NULL;
+    char *snap_after = NULL;
+    char *dump1 = NULL;
+    char *dump2 = NULL;
+    const char *obj_path = "/tmp/liric_test_non_dominating.o";
+
+    cfg.mode = LR_MODE_IR;
+    cfg.backend = LR_SESSION_BACKEND_COPY_PATCH;
+    s = lr_session_create(&cfg, &err);
+    TEST_ASSERT(s != NULL, "session create");
+
+    i64 = lr_type_i64_s(s);
+    i32 = lr_type_i32_s(s);
+    ptr = lr_type_ptr_s(s);
+
+    /* entry br print; print defines %x then br exit; other (not dominated by
+       print) uses %x; exit ret. %x does not dominate its use in other. */
+    rc = lr_session_func_begin(s, "non_dominating_print", i32, NULL, 0, false, &err);
+    TEST_ASSERT_EQ(rc, 0, "func begin");
+
+    entry = lr_session_block(s);
+    print = lr_session_block(s);
+    other = lr_session_block(s);
+    exitb = lr_session_block(s);
+
+    lr_session_set_block(s, entry, &err);
+    lr_emit_br(s, print);
+
+    lr_session_set_block(s, print, &err);
+    {
+        uint32_t x = lr_emit_add(s, i64, LR_IMM(1, i64), LR_IMM(1, i64));
+        lr_emit_br(s, exitb);
+        lr_session_set_block(s, other, &err);
+        uint32_t printf_sym = lr_session_intern(s, "printf");
+        lr_operand_desc_t args[2] = {LR_IMM(0, ptr), LR_VREG(x, i64)};
+        lr_emit_call(s, i32, LR_GLOBAL(printf_sym, ptr), args, 2);
+        lr_emit_br(s, exitb);
+        lr_session_set_block(s, exitb, &err);
+        lr_emit_ret(s, LR_IMM(0, i32));
+    }
+
+    rc = lr_session_func_end(s, NULL, &err);
+    TEST_ASSERT_EQ(rc, 0, "func end");
+
+    snap_before = snapshot_module_structure(lr_session_module(s));
+    TEST_ASSERT(snap_before != NULL, "pre-emission snapshot");
+
+    dump1 = session_dump_text(s);
+    TEST_ASSERT(dump1 != NULL, "first dump");
+
+    rc = lr_session_emit_object(s, obj_path, &err);
+    TEST_ASSERT_EQ(rc, 0, "emit object succeeds for non-dominating producer CFG");
+
+    snap_after = snapshot_module_structure(lr_session_module(s));
+    TEST_ASSERT(snap_after != NULL, "post-emission snapshot");
+    TEST_ASSERT(strcmp(snap_before, snap_after) == 0,
+                "non-dominating value not moved by serialization");
+
+    dump2 = session_dump_text(s);
+    TEST_ASSERT(dump2 != NULL, "second dump");
+    TEST_ASSERT(strcmp(dump1, dump2) == 0,
+                "non-dominating value dump stable");
+    /* The definition must still sit in the print block (b1), not be
+       relocated to a dominating block. %v0 is defined in b1 and used in b2. */
+    TEST_ASSERT(strstr(dump2, "%v0 = add i64 1, 1") != NULL,
+                "non-dominating definition preserved, not folded away");
+
+    result = 0;
+    goto cleanup;
+
+cleanup:
+    remove(obj_path);
+    free(snap_before);
+    free(snap_after);
+    free(dump1);
+    free(dump2);
+    if (s)
+        lr_session_destroy(s);
+    return result;
+}


### PR DESCRIPTION
## Problem

Issue #523: a valid session CFG that places an integer(8)-print definition in a block dominating its `printf` use was corrupted across serialization. Native object emission (`lr_session_emit_object` → `lr_emit_object` → `lr_target_compile`) called `lr_func_finalize` on the **live** session module. That finalize pass constant-folds/DCEs the IR, so a foldable `add i64 1, 1` producing the printed value was destroyed and the `printf` operand rewritten from `%v0` to `i64 2`. A dump taken before and after object emission no longer matched, violating "valid session CFG remains valid through dump and object emission."

## Root cause

`lr_session_func_end` deliberately defers finalization to `lr_target_compile` in IR mode (so cross-function PHI users aren't DCE'd prematurely). That deferred finalize mutated the caller's module during object emission — the exact non-mutating-emission violation addressed for dump/LLVM in #525, but never extended to the native copy-patch/isel object path.

## Fix

Run native object/executable emission on a **non-mutating clone** of the session module (the same `lr_module_clone_for_emission` pattern the dump path already uses for legacy-pointer legalization and the LLVM path uses for text serialization):

- `src/ir.c` / `src/ir.h`: expose `lr_module_clone_for_emission` / `lr_emission_clone_release` as a public emission-clone API.
- `src/session.c`: `lr_session_emit_object`, `lr_session_emit_object_stream`, and `lr_session_emit_exe` clone the module for the native backend path (`session_emission_module` helper). The LLVM backend already serializes from module text and needs no clone.

The live session module is left byte-for-byte stable across dump and object emission. No block reordering and no producer-CFG masking is added.

## Tests (`tests/test_session.c`, wired into the `liric_tests` CTest target)

- **Positive** `test_session_integer_print_dominance_preserved`: builds the two-block entry/print CFG with a foldable i64 print definition, asserts the module snapshot and dump are identical before/after object emission, and that `%v0 = add i64 1, 1` still dominates its `printf(..., i64 %v0)` use.
- **Negative** `test_session_non_dominating_value_not_moved`: an intentionally non-dominating value is **not** silently relocated or repaired; the module and dump stay stable and the definition remains in its original non-dominating block (no backend repair logic).

## Verification

```bash
cmake -S . -B build -G Ninja
cmake --build build -j$(nproc)
ctest --test-dir build --output-on-failure
```

All 45 tests pass.

Closes #523